### PR TITLE
Remove `filterEventsListing` toggle and related code

### DIFF
--- a/common/types/periods.ts
+++ b/common/types/periods.ts
@@ -1,4 +1,3 @@
-// Remove when filterEventsListing is removed from the toggles
 const Periods = [
   'today',
   'this-weekend',

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -6,9 +6,6 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import { getServerData } from '@weco/common/server-data';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { PaginatedResults } from '@weco/common/services/prismic/types';
-import { Period } from '@weco/common/types/periods';
-import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
 import { font } from '@weco/common/utils/classnames';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { pluralize } from '@weco/common/utils/grammar';
@@ -20,7 +17,6 @@ import {
 } from '@weco/common/utils/search';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb';
-import Divider from '@weco/common/views/components/Divider';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import {
   ContaineredLayout,
@@ -29,14 +25,11 @@ import {
 } from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader';
 import PageLayout from '@weco/common/views/components/PageLayout';
-import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PaginationWrapper from '@weco/common/views/components/styled/PaginationWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import { themeValues } from '@weco/common/views/themes/config';
-import CardGrid from '@weco/content/components/CardGrid';
 import EventsSearchResults from '@weco/content/components/EventsSearchResults';
-import MoreLink from '@weco/content/components/MoreLink';
 import NoEvents from '@weco/content/components/NoEvents';
 import Pagination from '@weco/content/components/Pagination';
 import SearchFilters from '@weco/content/components/SearchFilters';
@@ -45,38 +38,19 @@ import {
   fromQuery,
 } from '@weco/content/components/SearchPagesLink/Events';
 import Tabs from '@weco/content/components/Tabs';
-import { orderEventsByNextAvailableDate } from '@weco/content/services/prismic/events';
-import { createClient } from '@weco/content/services/prismic/fetch';
-import { fetchEvents } from '@weco/content/services/prismic/fetch/events';
-import {
-  transformEvent,
-  transformEventBasic,
-} from '@weco/content/services/prismic/transformers/events';
-import {
-  eventLd,
-  eventLdContentApi,
-} from '@weco/content/services/prismic/transformers/json-ld';
-import { transformQuery } from '@weco/content/services/prismic/transformers/paginated-results';
+import { eventLdContentApi } from '@weco/content/services/prismic/transformers/json-ld';
 import { eventsFilters } from '@weco/content/services/wellcome/common/filters';
 import { getEvents } from '@weco/content/services/wellcome/content/events';
 import {
   ContentResultsList,
   EventDocument,
 } from '@weco/content/services/wellcome/content/types/api';
-import { EventBasic } from '@weco/content/types/events';
 import { Query } from '@weco/content/types/search';
 import { getPage } from '@weco/content/utils/query-params';
 import { getActiveFiltersLabel, hasFilters } from '@weco/content/utils/search';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 
 export type Props = {
-  title: string;
-  events: PaginatedResults<EventBasic>;
-  period?: Period;
-  jsonLd: JsonLdObj[];
-};
-
-export type NewProps = {
   events: ContentResultsList<EventDocument>;
   eventsRouteProps: EventsProps;
   query: Query;
@@ -87,7 +61,7 @@ export type NewProps = {
 const EVENTS_LISTING_FORM_ID = 'events-listing-form';
 
 export const getServerSideProps: GetServerSideProps<
-  (NewProps | Props) | AppErrorProps
+  Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res, cacheTTL.events);
   const page = getPage(context.query);
@@ -97,97 +71,51 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   const serverData = await getServerData(context);
-  const isUsingContentAPI = !!serverData.toggles.filterEventsListing.value;
 
-  if (isUsingContentAPI) {
-    const { page, ...restOfQuery } = context.query;
-    const pageNumber = getQueryPropertyValue(page);
-    const params = fromQuery(restOfQuery);
-    const timespan = 'future';
+  const { page: pageQuery, ...restOfQuery } = context.query;
+  const params = fromQuery(restOfQuery);
+  const timespan = 'future';
 
-    const allPossibleParams = { ...params, timespan };
-    const queriedParams = { ...restOfQuery, timespan };
+  const allPossibleParams = { ...params, timespan };
+  const queriedParams = { ...restOfQuery, timespan };
 
-    const eventResponseList = await getEvents({
-      params: {
-        ...queriedParams,
-        sort: 'times.startDateTime',
-        sortOrder: 'asc',
-        ...(pageNumber && { page: Number(pageNumber) }),
-        aggregations: [
-          'format',
-          'audience',
-          'interpretation',
-          'location',
-        ].filter(isNotUndefined),
-      },
-      pageSize: 25,
-      toggles: serverData.toggles,
-    });
+  const eventResponseList = await getEvents({
+    params: {
+      ...queriedParams,
+      sort: 'times.startDateTime',
+      sortOrder: 'asc',
+      ...(page && { page: Number(page) }),
+      aggregations: ['format', 'audience', 'interpretation', 'location'].filter(
+        isNotUndefined
+      ),
+    },
+    pageSize: 25,
+    toggles: serverData.toggles,
+  });
 
-    if (eventResponseList?.type === 'Error') {
-      return appError(
-        context,
-        eventResponseList.httpStatus,
-        'Content API error'
-      );
-    }
-
-    if (eventResponseList) {
-      const jsonLd = eventResponseList.results.flatMap(eventLdContentApi);
-
-      return {
-        props: serialiseProps({
-          events: eventResponseList,
-          query: context.query,
-          eventsRouteProps: allPossibleParams,
-          period: timespan,
-          jsonLd,
-          serverData,
-        }),
-      };
-    }
-
-    return { notFound: true };
-  } else {
-    const { isOnline, availableOnline } = context.query;
-
-    const client = createClient(context);
-
-    const eventsQueryPromise = await fetchEvents(client, {
-      page,
-      period: 'current-and-coming-up',
-      pageSize: 100,
-      isOnline: isOnline === 'true',
-      availableOnline: availableOnline === 'true',
-    });
-
-    const events = transformQuery(eventsQueryPromise, transformEvent);
-    const basicEvents = transformQuery(eventsQueryPromise, transformEventBasic);
-
-    if (events) {
-      const title = 'Events';
-      const jsonLd = events.results.flatMap(eventLd);
-
-      return {
-        props: serialiseProps({
-          events: {
-            ...events,
-            results: basicEvents.results,
-          },
-          title,
-          period: 'current-and-coming-up',
-          jsonLd,
-          serverData,
-        }),
-      };
-    } else {
-      return { notFound: true };
-    }
+  if (eventResponseList?.type === 'Error') {
+    return appError(context, eventResponseList.httpStatus, 'Content API error');
   }
+
+  if (eventResponseList) {
+    const jsonLd = eventResponseList.results.flatMap(eventLdContentApi);
+
+    return {
+      props: serialiseProps({
+        events: eventResponseList,
+        query: context.query,
+        eventsRouteProps: allPossibleParams,
+        period: timespan,
+        jsonLd,
+        serverData,
+      }),
+    };
+  }
+
+  return { notFound: true };
 };
 
-const EventsPage: FunctionComponent<Props | NewProps> = props => {
+const EventsPage: FunctionComponent<Props> = props => {
   const { period, jsonLd } = props;
   const router = useRouter();
 
@@ -220,279 +148,176 @@ const EventsPage: FunctionComponent<Props | NewProps> = props => {
     return router.push(link.href, link.as);
   };
 
-  // Only the old page returns a title
-  if (!('title' in props)) {
-    const { events, query } = props;
-    const firstEvent = events.results[0];
+  const { events, query } = props;
+  const firstEvent = events.results[0];
 
-    const filters = eventsFilters({
-      events,
-      props: props.eventsRouteProps,
-    }).filter(
-      f =>
-        f.id !== 'timespan' &&
-        (isInPastListing ? true : f.id !== 'isAvailableOnline')
-    );
+  const filters = eventsFilters({
+    events,
+    props: props.eventsRouteProps,
+  }).filter(
+    f =>
+      f.id !== 'timespan' &&
+      (isInPastListing ? true : f.id !== 'isAvailableOnline')
+  );
 
-    const hasNoResults = events.totalResults === 0;
-    const hasActiveFilters = hasFilters({
-      filters: filters.map(f => f.id),
-      queryParams: query,
-    });
-    const activeFiltersLabels = getActiveFiltersLabel({ filters });
+  const hasNoResults = events.totalResults === 0;
+  const hasActiveFilters = hasFilters({
+    filters: filters.map(f => f.id),
+    queryParams: query,
+  });
+  const activeFiltersLabels = getActiveFiltersLabel({ filters });
 
-    return (
-      <PageLayout
-        title="Events"
-        description={pageDescriptions.events}
-        url={{ pathname: `/events${period ? `/${period}` : ''}` }}
-        jsonLd={jsonLd}
-        openGraphType="website"
-        siteSection="whats-on"
-        image={firstEvent && transformImage(firstEvent.image)}
-      >
-        <SpacingSection>
-          <PageHeader
-            breadcrumbs={getBreadcrumbItems('whats-on')}
-            title="Events"
-            isSlim={true}
-          />
+  return (
+    <PageLayout
+      title="Events"
+      description={pageDescriptions.events}
+      url={{ pathname: `/events${period ? `/${period}` : ''}` }}
+      jsonLd={jsonLd}
+      openGraphType="website"
+      siteSection="whats-on"
+      image={firstEvent && transformImage(firstEvent.image)}
+    >
+      <SpacingSection>
+        <PageHeader
+          breadcrumbs={getBreadcrumbItems('whats-on')}
+          title="Events"
+          isSlim={true}
+        />
 
-          {pageDescriptions.events && (
-            <ContaineredLayout gridSizes={gridSize8(false)}>
-              <div className={`body-text spaced-text ${font('intr', 4)}`}>
-                <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                  <p>{pageDescriptions.events}</p>
-                </Space>
-              </div>
-            </ContaineredLayout>
-          )}
-
-          <ContaineredLayout gridSizes={gridSize12()}>
-            <div
-              style={{
-                borderBottom: `1px solid ${themeValues.color('neutral.300')}`,
-              }}
-            >
-              <Tabs
-                tabBehaviour="navigate"
-                currentSection={
-                  period === 'future' || !period ? 'future' : 'past'
-                }
-                label="Time-based event filter"
-                items={[
-                  {
-                    id: 'future',
-                    url: `/events`,
-                    text: 'Upcoming events',
-                  },
-                  {
-                    id: 'past',
-                    url: `/events/past`,
-                    text: 'Past events',
-                  },
-                ]}
-                hideBorder
-              />
+        {pageDescriptions.events && (
+          <ContaineredLayout gridSizes={gridSize8(false)}>
+            <div className={`body-text spaced-text ${font('intr', 4)}`}>
+              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+                <p>{pageDescriptions.events}</p>
+              </Space>
             </div>
           </ContaineredLayout>
+        )}
 
-          {(!hasNoResults || (hasNoResults && hasActiveFilters)) && (
-            <ContaineredLayout gridSizes={gridSize12()}>
-              <Space
-                $v={{
-                  size: 'l',
-                  properties: ['padding-top', 'padding-bottom'],
+        <ContaineredLayout gridSizes={gridSize12()}>
+          <div
+            style={{
+              borderBottom: `1px solid ${themeValues.color('neutral.300')}`,
+            }}
+          >
+            <Tabs
+              tabBehaviour="navigate"
+              currentSection={
+                period === 'future' || !period ? 'future' : 'past'
+              }
+              label="Time-based event filter"
+              items={[
+                {
+                  id: 'future',
+                  url: `/events`,
+                  text: 'Upcoming events',
+                },
+                {
+                  id: 'past',
+                  url: `/events/past`,
+                  text: 'Past events',
+                },
+              ]}
+              hideBorder
+            />
+          </div>
+        </ContaineredLayout>
+
+        {(!hasNoResults || (hasNoResults && hasActiveFilters)) && (
+          <ContaineredLayout gridSizes={gridSize12()}>
+            <Space
+              $v={{
+                size: 'l',
+                properties: ['padding-top', 'padding-bottom'],
+              }}
+            >
+              <form
+                role="search"
+                id={EVENTS_LISTING_FORM_ID}
+                onSubmit={event => {
+                  event.preventDefault();
+
+                  updateUrl(event.currentTarget);
                 }}
               >
-                <form
-                  role="search"
-                  id={EVENTS_LISTING_FORM_ID}
-                  onSubmit={event => {
-                    event.preventDefault();
-
-                    updateUrl(event.currentTarget);
-                  }}
-                >
-                  {/* Normally the search input is here but we don't want one in this case..
+                {/* Normally the search input is here but we don't want one in this case..
                   We need the form for good functioning & No JS behaviour, but we deal with the filters
                   through Javascript and they can't be wrapped in the form as it causes bugs. Because we have
                   the filters twice (modal and desktop), we need to control which filters are assigned to the form
                   instead of including them all. */}
-                </form>
+              </form>
 
-                <SearchFilters
-                  linkResolver={params =>
-                    linkResolver({ params, pathname: router.pathname })
-                  }
-                  searchFormId={EVENTS_LISTING_FORM_ID}
-                  changeHandler={() => {
-                    const form = document.getElementById(
-                      EVENTS_LISTING_FORM_ID
+              <SearchFilters
+                linkResolver={params =>
+                  linkResolver({ params, pathname: router.pathname })
+                }
+                searchFormId={EVENTS_LISTING_FORM_ID}
+                changeHandler={() => {
+                  const form = document.getElementById(EVENTS_LISTING_FORM_ID);
+                  form &&
+                    form.dispatchEvent(
+                      new window.Event('submit', {
+                        cancelable: true,
+                        bubbles: true,
+                      })
                     );
-                    form &&
-                      form.dispatchEvent(
-                        new window.Event('submit', {
-                          cancelable: true,
-                          bubbles: true,
-                        })
-                      );
-                  }}
-                  filters={filters}
-                  hasNoResults={hasNoResults}
-                />
-              </Space>
-            </ContaineredLayout>
-          )}
-          {hasNoResults ? (
-            <ContaineredLayout gridSizes={gridSize12()}>
-              <NoEvents
-                isPastListing={isInPastListing}
-                hasFilters={hasActiveFilters}
+                }}
+                filters={filters}
+                hasNoResults={hasNoResults}
               />
-            </ContaineredLayout>
-          ) : (
-            <>
-              <ContaineredLayout gridSizes={gridSize12()}>
-                <PaginationWrapper $verticalSpacing="l">
-                  <span>
-                    {pluralize(
-                      events.totalResults,
-                      (isInPastListing ? 'past ' : '') + 'event'
-                    )}
-                  </span>
-                  {activeFiltersLabels.length > 0 && (
-                    <span className="visually-hidden">
-                      {' '}
-                      filtered with: {activeFiltersLabels.join(', ')}
-                    </span>
-                  )}
-
-                  <Pagination
-                    totalPages={events.totalPages}
-                    ariaLabel="Events pagination"
-                    isHiddenMobile
-                  />
-                </PaginationWrapper>
-
-                <EventsSearchResults
-                  events={events.results}
-                  isInPastListing={isInPastListing}
-                />
-              </ContaineredLayout>
-
-              <ContaineredLayout gridSizes={gridSize12()}>
-                <PaginationWrapper $verticalSpacing="l" $alignRight>
-                  <Pagination
-                    totalPages={events.totalPages}
-                    ariaLabel="Events pagination"
-                  />
-                </PaginationWrapper>
-              </ContaineredLayout>
-            </>
-          )}
-        </SpacingSection>
-      </PageLayout>
-    );
-  } else {
-    const { events } = props;
-
-    const convertedPaginatedResults = {
-      ...events,
-      results: !isInPastListing
-        ? orderEventsByNextAvailableDate(events.results)
-        : events.results,
-    };
-    const firstEvent = events.results[0];
-
-    return (
-      <PageLayout
-        title={props.title}
-        description={pageDescriptions.events}
-        url={{ pathname: `/events${period ? `/${period}` : ''}` }}
-        jsonLd={jsonLd}
-        openGraphType="website"
-        siteSection="whats-on"
-        image={firstEvent?.promo?.image}
-      >
-        <SpacingSection>
-          <PageHeader
-            breadcrumbs={getBreadcrumbItems('whats-on')}
-            labels={undefined}
-            title={props.title}
-            ContentTypeInfo={
-              pageDescriptions.events && (
-                <PrismicHtmlBlock
-                  html={[
-                    {
-                      type: 'paragraph',
-                      text: pageDescriptions.events,
-                      spans: [],
-                    },
-                  ]}
-                />
-              )
-            }
-            backgroundTexture={headerBackgroundLs}
-            highlightHeading={true}
-          />
-
-          {convertedPaginatedResults.totalPages > 1 && (
+            </Space>
+          </ContaineredLayout>
+        )}
+        {hasNoResults ? (
+          <ContaineredLayout gridSizes={gridSize12()}>
+            <NoEvents
+              isPastListing={isInPastListing}
+              hasFilters={hasActiveFilters}
+            />
+          </ContaineredLayout>
+        ) : (
+          <>
             <ContaineredLayout gridSizes={gridSize12()}>
               <PaginationWrapper $verticalSpacing="l">
                 <span>
-                  {pluralize(convertedPaginatedResults.totalResults, 'result')}
+                  {pluralize(
+                    events.totalResults,
+                    (isInPastListing ? 'past ' : '') + 'event'
+                  )}
                 </span>
+                {activeFiltersLabels.length > 0 && (
+                  <span className="visually-hidden">
+                    {' '}
+                    filtered with: {activeFiltersLabels.join(', ')}
+                  </span>
+                )}
 
                 <Pagination
-                  totalPages={convertedPaginatedResults.totalPages}
-                  ariaLabel="Results pagination"
+                  totalPages={events.totalPages}
+                  ariaLabel="Events pagination"
                   isHiddenMobile
                 />
               </PaginationWrapper>
 
-              <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <Divider />
-              </Space>
-            </ContaineredLayout>
-          )}
-
-          <Space $v={{ size: 'l', properties: ['margin-top'] }}>
-            {convertedPaginatedResults.results.length > 0 ? (
-              <CardGrid
-                items={convertedPaginatedResults.results}
-                itemsPerRow={3}
+              <EventsSearchResults
+                events={events.results}
                 isInPastListing={isInPastListing}
               />
-            ) : (
-              <ContaineredLayout gridSizes={gridSize12()}>
-                <p>There are no results.</p>
-              </ContaineredLayout>
-            )}
-          </Space>
+            </ContaineredLayout>
 
-          {convertedPaginatedResults.totalPages > 1 && (
             <ContaineredLayout gridSizes={gridSize12()}>
               <PaginationWrapper $verticalSpacing="l" $alignRight>
                 <Pagination
-                  totalPages={convertedPaginatedResults.totalPages}
-                  ariaLabel="Results pagination"
+                  totalPages={events.totalPages}
+                  ariaLabel="Events pagination"
                 />
               </PaginationWrapper>
             </ContaineredLayout>
-          )}
-
-          {period === 'current-and-coming-up' && (
-            <ContaineredLayout gridSizes={gridSize12()}>
-              <Space $v={{ size: 'm', properties: ['margin-top'] }}>
-                <MoreLink url="/events/past" name="View past events" />
-              </Space>
-            </ContaineredLayout>
-          )}
-        </SpacingSection>
-      </PageLayout>
-    );
-  }
+          </>
+        )}
+      </SpacingSection>
+    </PageLayout>
+  );
 };
 
 export default EventsPage;

--- a/content/webapp/pages/events/past.tsx
+++ b/content/webapp/pages/events/past.tsx
@@ -4,20 +4,9 @@ import { FunctionComponent } from 'react';
 import { getServerData } from '@weco/common/server-data';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { serialiseProps } from '@weco/common/utils/json';
-import { getQueryPropertyValue } from '@weco/common/utils/search';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { fromQuery } from '@weco/content/components/SearchPagesLink/Events';
-import { createClient } from '@weco/content/services/prismic/fetch';
-import { fetchEvents } from '@weco/content/services/prismic/fetch/events';
-import {
-  transformEvent,
-  transformEventBasic,
-} from '@weco/content/services/prismic/transformers/events';
-import {
-  eventLd,
-  eventLdContentApi,
-} from '@weco/content/services/prismic/transformers/json-ld';
-import { transformQuery } from '@weco/content/services/prismic/transformers/paginated-results';
+import { eventLdContentApi } from '@weco/content/services/prismic/transformers/json-ld';
 import { getEvents } from '@weco/content/services/wellcome/content/events';
 import { getPage } from '@weco/content/utils/query-params';
 import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
@@ -25,7 +14,7 @@ import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
 import * as page from './index';
 
 export const getServerSideProps: GetServerSideProps<
-  (page.NewProps | page.Props) | AppErrorProps
+  page.Props | AppErrorProps
 > = async context => {
   setCacheControl(context.res, cacheTTL.events);
   const page = getPage(context.query);
@@ -35,105 +24,62 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   const serverData = await getServerData(context);
-  const isUsingContentAPI = !!serverData.toggles.filterEventsListing.value;
 
-  if (isUsingContentAPI) {
-    const { availableOnline, page, ...restOfQuery } = context.query;
+  const { availableOnline, page: pageQuery, ...restOfQuery } = context.query;
 
-    if (availableOnline) {
-      return {
-        redirect: {
-          permanent: false,
-          destination: '/events/past?isAvailableOnline=true',
-        },
-      };
-    }
-
-    const pageNumber = getQueryPropertyValue(page);
-    const params = fromQuery(restOfQuery);
-    const timespan = 'past';
-
-    const allPossibleParams = { ...params, timespan };
-    const queriedParams = { ...restOfQuery, timespan };
-
-    const eventResponseList = await getEvents({
-      params: {
-        ...queriedParams,
-        sort: 'times.startDateTime',
-        sortOrder: 'desc',
-        ...(pageNumber && { page: Number(pageNumber) }),
-        aggregations: [
-          'format',
-          'audience',
-          'interpretation',
-          'location',
-          'isAvailableOnline',
-        ].filter(isNotUndefined),
+  if (availableOnline) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/events/past?isAvailableOnline=true',
       },
-      pageSize: 25,
-      toggles: serverData.toggles,
-    });
-
-    if (eventResponseList?.type === 'Error') {
-      return appError(
-        context,
-        eventResponseList.httpStatus,
-        'Content API error'
-      );
-    }
-
-    if (eventResponseList) {
-      const jsonLd = eventResponseList.results.flatMap(eventLdContentApi);
-
-      return {
-        props: serialiseProps({
-          events: eventResponseList,
-          period: timespan,
-          query: context.query,
-          eventsRouteProps: allPossibleParams,
-          jsonLd,
-          serverData,
-        }),
-      };
-    }
-
-    return { notFound: true };
-  } else {
-    const { isOnline, availableOnline } = context.query;
-
-    const client = createClient(context);
-
-    const eventsQueryPromise = await fetchEvents(client, {
-      page,
-      period: 'past',
-      pageSize: 100,
-      isOnline: isOnline === 'true',
-      availableOnline: availableOnline === 'true',
-    });
-
-    const events = transformQuery(eventsQueryPromise, transformEvent);
-    const basicEvents = transformQuery(eventsQueryPromise, transformEventBasic);
-
-    if (events) {
-      const title = 'Past events';
-      const jsonLd = events.results.flatMap(eventLd);
-
-      return {
-        props: serialiseProps({
-          events: {
-            ...events,
-            results: basicEvents.results,
-          },
-          title,
-          period: 'past',
-          jsonLd,
-          serverData,
-        }),
-      };
-    } else {
-      return { notFound: true };
-    }
+    };
   }
+
+  const params = fromQuery(restOfQuery);
+  const timespan = 'past';
+
+  const allPossibleParams = { ...params, timespan };
+  const queriedParams = { ...restOfQuery, timespan };
+
+  const eventResponseList = await getEvents({
+    params: {
+      ...queriedParams,
+      sort: 'times.startDateTime',
+      sortOrder: 'desc',
+      ...(page && { page: Number(page) }),
+      aggregations: [
+        'format',
+        'audience',
+        'interpretation',
+        'location',
+        'isAvailableOnline',
+      ].filter(isNotUndefined),
+    },
+    pageSize: 25,
+    toggles: serverData.toggles,
+  });
+
+  if (eventResponseList?.type === 'Error') {
+    return appError(context, eventResponseList.httpStatus, 'Content API error');
+  }
+
+  if (eventResponseList) {
+    const jsonLd = eventResponseList.results.flatMap(eventLdContentApi);
+
+    return {
+      props: serialiseProps({
+        events: eventResponseList,
+        period: timespan,
+        query: context.query,
+        eventsRouteProps: allPossibleParams,
+        jsonLd,
+        serverData,
+      }),
+    };
+  }
+
+  return { notFound: true };
 };
 
 const EventsPast: FunctionComponent<page.Props> = (props: page.Props) => {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -103,14 +103,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'filterEventsListing',
-      title: 'Changes to the Events listing pages',
-      initialValue: false,
-      description:
-        'Have the Events listing pages use the Content API and be filterable',
-      type: 'experimental',
-    },
-    {
       id: 'audioPlayer',
       title: 'Changes to the AudioPlayer component',
       initialValue: false,


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/11851

Removes all traces of the toggle! Everything should work as it currently does in prod.

## How to test

Affected pages:
1. https://www-dev.wellcomecollection.org/events
2. https://www-dev.wellcomecollection.org/events/past
3. https://www-dev.wellcomecollection.org/search/events

Ensure the filters still work
The pagination still works
The ordering is the same as in production

## How can we measure success?

Less code yay

## Have we considered potential risks?
N/A