### PR TITLE
Add events search to pa11y and Check URL

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -17,6 +17,7 @@
 /search/stories?query=human
 /search/images?query=human
 /search/works?query=human
+/search/events?query=human
 /concepts/cza334ke
 # A works search page where some results contain thumbnails
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1657191146272169

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -60,6 +60,7 @@ const urls = [
   '/search/stories?query=human',
   '/search/images?query=human',
   '/search/works?query=human',
+  '/search/events?query=human',
 ].map(u => `${baseUrl}${u}`);
 
 const promises = urls.map(url =>


### PR DESCRIPTION
## What does this change?

[#11885](https://github.com/wellcomecollection/wellcomecollection.org/issues/11885)

## How to test
From this PR's tests:
https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/16285#0196ca56-05e8-4128-b78a-fc65df9a309e/141-329

https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/5910#0196ca59-3d94-4077-862e-e78edb36f875/146-175

## How can we measure success?

All search pages are checked

## Have we considered potential risks?
N/A