### PR TITLE
Add data-gtm attribute for the related image id

### DIFF
--- a/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
@@ -95,6 +95,7 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
         {similarImages.map(related => (
           <a
             data-gtm-trigger="visually_similar_image"
+            data-gtm-img-id={related.id}
             key={related.id}
             onClick={() => {
               onClickImage(related);


### PR DESCRIPTION
For #11618 

## What does this change?
[We want to know the id of the visually similar image being clicked,](https://github.com/wellcomecollection/wellcomecollection.org/issues/11618#issuecomment-2876051922) but this isn't currently available as an attribute in the DOM. It would probably be possible with some tagmanager acrobatics, but I think the simpler/better solution is to add it as an attribute to the element that we're tracking clicks on.

## How to test
Visit a [page with a modal displaying visually similar images](http://localhost:3000/search?query=test#djjp3ye7) and inspect the `<a>` tags that wrap the images – do they have a `data-gtm-img-id` attribute populated with the image id?

## How can we measure success?
We can track what we need to in GTM

## Have we considered potential risks?
n/a