### PR TITLE
Add original image id data attribute

### DIFF
--- a/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
@@ -95,6 +95,8 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
         {similarImages.map(related => (
           <a
             data-gtm-trigger="visually_similar_image"
+            data-gtm-related-img-id={related.id}
+            data-gtm-original-img-id={originalId}
             key={related.id}
             onClick={() => {
               onClickImage(related);


### PR DESCRIPTION
## What does this change?

After #11912 I thought I'd be able to get the currently-being-viewed image id from the URL in tagmanager, but it is always the previously viewed image (this is also true if I use the gtm built in `newHistoryFragment` or `oldHistoryFragment` variables, so doesn't seem easy to pluck out with gtm alone. So instead I'm adding the original image id as an attribute as well.

## How to test
Can you see a `data-gtm-original-img-id` attribute on the visually similar images on e.g. [this page](http://localhost:3000/search?query=test#d6yspfaz)

## How can we measure success?
Visually similar image journeys can be tracked

## Have we considered potential risks?
n/a