### PR TITLE
Use dataLayer to send 'visually_similar_image_click' event

### DIFF
--- a/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
+++ b/content/webapp/components/VisuallySimilarImagesFromApi/index.tsx
@@ -94,11 +94,16 @@ const VisuallySimilarImagesFromApi: FunctionComponent<Props> = ({
       <Wrapper>
         {similarImages.map(related => (
           <a
-            data-gtm-trigger="visually_similar_image"
-            data-gtm-related-img-id={related.id}
-            data-gtm-original-img-id={originalId}
             key={related.id}
             onClick={() => {
+              // We tried to use data attributes to send these values and pick them up with a GTM clicked links trigger, but The onClickImage function below was updating the originalId before it was sent (making the relatedId and originalId appear the same in GA). By pushing to the dataLayer before onClickImage runs we can get round this.
+              window.dataLayer?.push({
+                event: 'visually_similar_image_click',
+                visuallySimilarImage: {
+                  relatedId: related.id,
+                  originalId,
+                },
+              });
               onClickImage(related);
 
               trackSegmentEvent({


### PR DESCRIPTION
## What does this change?
We previously tried to use data attributes to send these values and pick them up with a GTM clicked links trigger, but The `onClickImage` function was updating the `originalId` before it was sent (making the `relatedId` and `originalId` appear the same in GA). By pushing to the dataLayer before `onClickImage` runs we make sure the correct values are sent.

This bit of site functionality is ripe for a refactor though – there is definitely some confusion with potentially extra history changes and unwanted hash behaviour (#11631)

## How to test
Not sure – if you want to run tag manager locally you should be able to see the `visually_similar_images_click` event happening when you click a similar image with the correct parameters being set

## How can we measure success?
Get the right results in GTM

## Have we considered potential risks?
n/a