### PR TITLE
Revert #11875 which was a partial revert of #11841

### DIFF
--- a/content/webapp/components/WorkDetails/index.tsx
+++ b/content/webapp/components/WorkDetails/index.tsx
@@ -1,5 +1,5 @@
 import { usePathname } from 'next/navigation';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useMemo } from 'react';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
@@ -120,7 +120,10 @@ const WorkDetails: FunctionComponent<Props> = ({
 
   const seriesPartOfs = work.partOf.filter(p => !p.id);
 
-  const physicalItems = getItemsWithPhysicalLocation(work.items ?? []);
+  const physicalItems = useMemo(
+    () => getItemsWithPhysicalLocation(work.items ?? []),
+    [work.items]
+  );
 
   const locationOfWork = work.notes.find(
     note => note.noteType.id === 'location-of-original'


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/platform/issues/5879

Original ticket: #11841
Partially reverted in #11875 as we thought it was the cause of a lot of alerts, but then [Robert found it was probably due to something else](https://wellcome.slack.com/archives/CQ720BG02/p1746708905563989).
As the alerts have now subsided, we are wanting this code back in to address #5879. We'll keep an eye on it to make sure it was unrelated.

## How to test

From original ticket:

- > Visit a requestable work (http://localhost:3000/works/spq4snpy) and refresh lots of times – check that the requesting button consistently appears
- > Visit an archive with requestable items (http://localhost:3000/works/pxr3mfzx) and click to another item in the archive – does the requesting section re-render (it should)?

## How can we measure success?

Bug is addressed 

## Have we considered potential risks?
See what happens with what I've said above.