### PR TITLE
Trial: split out Exhibition component

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.AccessAccordion.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.AccessAccordion.tsx
@@ -1,0 +1,197 @@
+import NextLink from 'next/link';
+
+import {
+  ExhibitionHighlightToursDocument,
+  ExhibitionTextsDocument,
+} from '@weco/common/prismicio-types';
+import linkResolver from '@weco/common/services/prismic/link-resolver';
+import Accordion from '@weco/content/components/Accordion';
+import { Link } from '@weco/content/types/link';
+
+const ExhibitionAccessAccordion = ({
+  exhibitionTexts,
+  exhibitionHighlightTours,
+  visualStoryLink,
+}: {
+  exhibitionTexts: ExhibitionTextsDocument[];
+  exhibitionHighlightTours: ExhibitionHighlightToursDocument[];
+  visualStoryLink?: Link & { type: string };
+}) => {
+  const hasExhibitionTexts = exhibitionTexts.length > 0;
+  const hasExhibitionHighlightTours = exhibitionHighlightTours.length > 0;
+
+  // Theoretically, there could be multiple ExhibitionTexts and ExhibitionHighlightTours
+  // attached to an exhibition, but in reality there is only one, so we just take the first
+  // and create links to them.
+  const exhibitionTextLink =
+    hasExhibitionTexts && linkResolver(exhibitionTexts[0]);
+
+  const bslTourLink =
+    hasExhibitionHighlightTours &&
+    linkResolver({
+      ...exhibitionHighlightTours[0],
+      highlightTourType: 'bsl',
+    });
+
+  const audioTourLink =
+    hasExhibitionHighlightTours &&
+    linkResolver({
+      ...exhibitionHighlightTours[0],
+      highlightTourType: 'audio',
+    });
+
+  // This contains all the possible content for the access section accordion
+  // We then filter out content that isn't relevant, i.e. if there isn't a highlight tour attached to the exhibition
+  const possibleExhibitionAccessContent = [
+    {
+      gtmHook: 'digital_highlights_tour',
+      summary: 'Digital highlights tour',
+      content: (
+        <ul>
+          <li>
+            Find out more about the exhibition with our digital highlights tour,
+            available in short audio clips with audio description and
+            transcripts, or as BSL videos. It can be accessed on your own
+            device, via handheld devices with tactile buttons, or on an iPad
+            which you can borrow
+          </li>
+          {bslTourLink && (
+            <li>
+              <NextLink href={bslTourLink}>Watch BSL video tour</NextLink>
+            </li>
+          )}
+          {audioTourLink && (
+            <li>
+              <NextLink href={audioTourLink}>
+                Listen to audio tour with audio description
+              </NextLink>
+            </li>
+          )}
+        </ul>
+      ),
+    },
+    {
+      gtmHook: 'bsl_transcripts_and_induction_loops',
+      summary: 'BSL, transcripts and induction loops',
+      content: (
+        <ul>
+          <li>BSL content is available in the gallery</li>
+          {bslTourLink && (
+            <li>
+              <NextLink href={bslTourLink}>
+                Watch BSL videos of the digital highlights tour on your own
+                device
+              </NextLink>
+            </li>
+          )}
+
+          <li>
+            <span id="transcript-link-text">
+              Transcripts of all audiovisual content are available
+            </span>{' '}
+            in the gallery
+            {exhibitionTextLink && (
+              <>
+                {` and `}
+                <NextLink
+                  id="transcript-link"
+                  aria-labelledby="transcript-link-text transcript-link"
+                  href={exhibitionTextLink}
+                >
+                  online
+                </NextLink>
+              </>
+            )}
+          </li>
+
+          <li>All videos are subtitled</li>
+          <li>
+            There are fixed induction loops in the building and portable
+            induction loops available to borrow
+          </li>
+        </ul>
+      ),
+    },
+    {
+      gtmHook: 'audio_description_and_visual_access',
+      summary: 'Audio description and visual access',
+      content: (
+        <ul>
+          {audioTourLink && (
+            <li>
+              <NextLink href={audioTourLink}>
+                The digital highlights tour is available with audio description
+              </NextLink>
+            </li>
+          )}
+          {exhibitionTextLink && (
+            <li>
+              <NextLink href={exhibitionTextLink}>
+                Access all the text from the exhibition on your own device
+              </NextLink>
+            </li>
+          )}
+          <li>
+            A large-print guide and magnifiers are available in the gallery
+          </li>
+          <li>There is a tactile line on the gallery floor</li>
+        </ul>
+      ),
+    },
+    {
+      gtmHook: 'wheelchair_and_physical_access',
+      summary: 'Wheelchair and physical access',
+      content: (
+        <ul>
+          <li>Step-free access is available to all floors of the building</li>
+          <li>
+            We have a Changing Places toilet on level 0 and accessible toilets
+            on all floors
+          </li>
+        </ul>
+      ),
+    },
+    {
+      gtmHook: 'sensory_access',
+      summary: 'Sensory access',
+      content: (
+        <ul>
+          <li>
+            {visualStoryLink ? (
+              <>
+                <NextLink href={visualStoryLink?.url}>
+                  A visual story with a sensory map is available online
+                </NextLink>{' '}
+                and
+              </>
+            ) : (
+              'A visual story with a sensory map is available '
+            )}{' '}
+            in the building at the start of the exhibition
+          </li>
+          <li>
+            You can borrow tinted glasses, tinted visors, ear defenders and
+            weighted lap pads. Please speak to a member of staff in the building
+          </li>
+          <li>
+            Weekday mornings and Thursday evenings are usually the quietest
+            times to visit
+          </li>
+        </ul>
+      ),
+    },
+  ];
+
+  // If there is no digital highlights tour attached to the exhibition, we want to remove
+  // the section about the digital highlights tour
+  const accordionContent = possibleExhibitionAccessContent.filter(section => {
+    return !(
+      section.summary === 'Digital highlights tour' &&
+      !hasExhibitionHighlightTours
+    );
+  });
+
+  return <Accordion id="access-resources" items={accordionContent} />;
+};
+
+export default ExhibitionAccessAccordion;

--- a/content/webapp/components/Exhibition/Exhibition.BeingHuman.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.BeingHuman.tsx
@@ -1,0 +1,180 @@
+// We should aim to delete this as soon as possible
+// https://github.com/wellcomecollection/wellcomecollection.org/issues/11732
+
+import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
+import { arrow, download } from '@weco/common/icons';
+import { font } from '@weco/common/utils/classnames';
+import { isPast } from '@weco/common/utils/dates';
+import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
+import Icon from '@weco/common/views/components/Icon';
+import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
+import Space from '@weco/common/views/components/styled/Space';
+import { PaletteColor } from '@weco/common/views/themes/config';
+import Contributors from '@weco/content/components/Contributors';
+import { defaultSerializer } from '@weco/content/components/HTMLSerializers';
+import InfoBox from '@weco/content/components/InfoBox';
+import SearchResults from '@weco/content/components/SearchResults';
+import {
+  ResourceLink,
+  ResourceLinkIconWrapper,
+  ResourcesItem,
+  ResourcesList,
+} from '@weco/content/components/styled/AccessResources';
+
+import { getInfoItems } from './Exhibition.helpers';
+
+function getBorderColor({
+  type,
+  i,
+}: {
+  type?: string;
+  i: number;
+}): PaletteColor {
+  if (type === 'visual-story') {
+    return 'accent.turquoise';
+  } else if (type === 'exhibition-guide') {
+    return 'accent.salmon';
+  } else if (i % 2 === 0) {
+    return 'accent.blue';
+  } else {
+    return 'accent.purple';
+  }
+}
+
+const ExhibitionBeingHuman = ({
+  exhibition,
+  accessResourceLinks,
+  exhibitionAbouts,
+  exhibitionFormat,
+  exhibitionOfs,
+  pages,
+}) => {
+  const hasResources = Boolean(
+    exhibition.accessResourcesText ||
+      exhibition.accessResourcesPdfs.length > 0 ||
+      accessResourceLinks.length > 0
+  );
+
+  return (
+    <>
+      {hasResources && (
+        <>
+          <Space
+            as="h2"
+            $v={{ size: 'm', properties: ['margin-bottom'] }}
+            className={font('wb', 3)}
+          >{`${exhibitionFormat} access content`}</Space>
+          {(accessResourceLinks.length > 0 ||
+            exhibition.accessResourcesPdfs.length > 0) && (
+            <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
+              <ResourcesList>
+                {accessResourceLinks.map((link, i) => {
+                  const borderColor = getBorderColor({
+                    type: link.type,
+                    i,
+                  });
+                  return (
+                    <ResourcesItem key={link.url}>
+                      <ResourceLink
+                        key={i}
+                        href={link.url}
+                        $borderColor={borderColor}
+                      >
+                        {link.type === 'exhibition-guide' && (
+                          <h3 className={font('intb', 4)}>
+                            Digital exhibition guide
+                          </h3>
+                        )}
+                        {link.type === 'visual-story' && (
+                          <h3 className={font('intb', 4)}>Visual story</h3>
+                        )}
+                        <span className={font('intr', 6)}>{link.text}</span>
+                        <ResourceLinkIconWrapper>
+                          <Icon icon={arrow} />
+                        </ResourceLinkIconWrapper>
+                      </ResourceLink>
+                    </ResourcesItem>
+                  );
+                })}
+                {exhibition.accessResourcesPdfs.map((pdf, i) => {
+                  const borderColor = getBorderColor({
+                    type: undefined,
+                    i,
+                  });
+                  return (
+                    <ResourcesItem key={pdf.url}>
+                      <ResourceLink
+                        key={i}
+                        href={pdf.url}
+                        $borderColor={borderColor}
+                        $underlineText={true}
+                      >
+                        <span className={font('intr', 5)}>
+                          {`${pdf.text} PDF`} {`(${pdf.size}kb)`}
+                        </span>
+                        <ResourceLinkIconWrapper>
+                          <Icon icon={download} />
+                        </ResourceLinkIconWrapper>
+                      </ResourceLink>
+                    </ResourcesItem>
+                  );
+                })}
+              </ResourcesList>
+            </Space>
+          )}
+          {exhibition.accessResourcesText && (
+            <PrismicHtmlBlock
+              html={exhibition.accessResourcesText}
+              htmlSerializer={defaultSerializer}
+            />
+          )}
+        </>
+      )}
+
+      {exhibition.contributors.length > 0 && (
+        <Contributors contributors={exhibition.contributors} />
+      )}
+
+      {(exhibitionOfs.length > 0 || pages.length > 0) && (
+        <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+          <SearchResults
+            id="events-list"
+            items={[...exhibitionOfs, ...pages]}
+            title={`${exhibitionFormat} events`}
+          />
+        </Space>
+      )}
+
+      {exhibition.end && !isPast(exhibition.end) && (
+        <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+          <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
+            <p className={font('intr', 5)} style={{ margin: 0 }}>
+              For more information, please visit our{' '}
+              <a href={`/visit-us/${prismicPageIds.access}`}>Accessibility</a>{' '}
+              page. If you have any queries about accessibility, please email us
+              at{' '}
+              <a href="mailto:access@wellcomecollection.org">
+                access@wellcomecollection.org
+              </a>{' '}
+              or call{' '}
+              {/*
+                  This is to ensure phone numbers are read in a sensible way by
+                  screen readers.
+                */}
+              <span className="visually-hidden">
+                {createScreenreaderLabel('020 7611 2222')}
+              </span>
+              <span aria-hidden="true">020&nbsp;7611&nbsp;2222.</span>
+            </p>
+          </InfoBox>
+        </Space>
+      )}
+
+      {exhibitionAbouts.length > 0 && (
+        <SearchResults items={exhibitionAbouts} title="Related stories" />
+      )}
+    </>
+  );
+};
+
+export default ExhibitionBeingHuman;

--- a/content/webapp/components/Exhibition/Exhibition.helpers.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.helpers.tsx
@@ -1,0 +1,162 @@
+import * as prismic from '@prismicio/client';
+
+import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
+import { a11y } from '@weco/common/data/microcopy';
+import {
+  a11YVisual,
+  accessibility,
+  accessible,
+  bslSquare,
+  calendar,
+  clock,
+  IconSvg,
+  location,
+  ticket,
+} from '@weco/common/icons';
+import { isFuture } from '@weco/common/utils/dates';
+import { formatDate } from '@weco/common/utils/format-date';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
+import { LabelField } from '@weco/content/model/label-field';
+import { Exhibition as ExhibitionType } from '@weco/content/types/exhibitions';
+
+type ExhibitionItem = LabelField & {
+  icon?: IconSvg;
+};
+
+function getUpcomingExhibitionObject(
+  exhibition: ExhibitionType
+): ExhibitionItem | undefined {
+  return isFuture(exhibition.start)
+    ? {
+        description: [
+          {
+            type: 'paragraph',
+            text: `Opening on ${formatDate(exhibition.start)}`,
+            spans: [],
+          },
+        ],
+        icon: calendar,
+      }
+    : undefined;
+}
+
+function getAdmissionObject(): ExhibitionItem {
+  return {
+    description: [
+      {
+        type: 'paragraph',
+        text: 'Free admission',
+        spans: [],
+      },
+    ],
+    icon: ticket,
+  };
+}
+
+function getTodaysHoursObject(): ExhibitionItem {
+  const todaysHoursText = 'Galleries open Tuesday–Sunday, Opening times';
+
+  const link: prismic.RTLinkNode = {
+    type: 'hyperlink',
+    start: todaysHoursText.length - 'Opening times'.length,
+    end: todaysHoursText.length,
+    data: {
+      link_type: 'Web',
+      url: `/visit-us/${prismicPageIds.openingTimes}`,
+    },
+  };
+
+  return {
+    description: [
+      {
+        type: 'paragraph',
+        text: todaysHoursText,
+        spans: [link],
+      },
+    ],
+    icon: clock,
+  };
+}
+
+function getPlaceObject(
+  exhibition: ExhibitionType
+): ExhibitionItem | undefined {
+  return (
+    exhibition.place && {
+      description: [
+        {
+          type: 'paragraph',
+          text: `${exhibition.place.title}, level ${exhibition.place.level}`,
+          spans: [],
+        },
+      ],
+      icon: location,
+    }
+  );
+}
+
+function getAccessibilityItems(): ExhibitionItem[] {
+  const accessibilityItems: {
+    description: prismic.RichTextField;
+    icon: IconSvg;
+  }[] = [
+    {
+      description: [
+        {
+          type: 'paragraph',
+          text: a11y.stepFreeAccess,
+          spans: [],
+        },
+      ],
+      icon: accessible,
+    },
+    {
+      description: [
+        {
+          type: 'paragraph',
+          text: a11y.largePrintGuides,
+          spans: [],
+        },
+      ],
+      icon: a11YVisual,
+    },
+    {
+      description: [
+        {
+          type: 'paragraph',
+          text: a11y.bsl,
+          spans: [],
+        },
+      ],
+      icon: bslSquare,
+    },
+    {
+      description: [
+        {
+          type: 'paragraph',
+          text: a11y.accessResources,
+          spans: [],
+        },
+      ],
+      icon: accessibility,
+    },
+  ];
+
+  return accessibilityItems.filter(item => {
+    if (item.description[0] && 'text' in item.description[0]) {
+      return item.description[0]?.text !== a11y.largePrintGuides;
+    } else {
+      return true;
+    }
+  });
+}
+
+export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
+  return [
+    getUpcomingExhibitionObject(exhibition),
+    getAdmissionObject(),
+    getTodaysHoursObject(),
+    getPlaceObject(exhibition),
+    ...getAccessibilityItems(),
+  ].filter(isNotUndefined);
+}

--- a/content/webapp/components/Exhibition/index.tsx
+++ b/content/webapp/components/Exhibition/index.tsx
@@ -1,59 +1,28 @@
-import * as prismic from '@prismicio/client';
 import NextLink from 'next/link';
 import { FunctionComponent, useEffect, useState } from 'react';
-import styled from 'styled-components';
 
-import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import { a11y } from '@weco/common/data/microcopy';
-import {
-  a11YVisual,
-  accessibility,
-  accessible,
-  arrow,
-  bslSquare,
-  calendar,
-  clock,
-  download,
-  IconSvg,
-  location,
-  ticket,
-} from '@weco/common/icons';
 import {
   ExhibitionHighlightToursDocument,
   ExhibitionTextsDocument,
 } from '@weco/common/prismicio-types';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { font } from '@weco/common/utils/classnames';
-import { isFuture, isPast } from '@weco/common/utils/dates';
-import { formatDate } from '@weco/common/utils/format-date';
-import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
+import { isPast } from '@weco/common/utils/dates';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb';
 import { HTMLDate } from '@weco/common/views/components/HTMLDateAndTime';
-import Icon from '@weco/common/views/components/Icon';
 import PageHeader from '@weco/common/views/components/PageHeader';
-import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
-import { PaletteColor } from '@weco/common/views/themes/config';
-import Accordion from '@weco/content/components/Accordion';
 import Body from '@weco/content/components/Body';
 import BslLeafletVideo from '@weco/content/components/BslLeafletVideo';
 import Contact from '@weco/content/components/Contact';
 import ContentPage from '@weco/content/components/ContentPage';
 import Contributors from '@weco/content/components/Contributors';
 import DateRange from '@weco/content/components/DateRange';
-import { defaultSerializer } from '@weco/content/components/HTMLSerializers';
 import InfoBox from '@weco/content/components/InfoBox';
 import SearchResults from '@weco/content/components/SearchResults';
 import StatusIndicator from '@weco/content/components/StatusIndicator';
-import {
-  ResourceLink,
-  ResourceLinkIconWrapper,
-  ResourcesItem,
-  ResourcesList,
-} from '@weco/content/components/styled/AccessResources';
-import { LabelField } from '@weco/content/model/label-field';
 import { fetchExhibitionRelatedContentClientSide } from '@weco/content/services/prismic/fetch/exhibitions';
 import { EventBasic } from '@weco/content/types/events';
 import {
@@ -67,170 +36,9 @@ import {
   getHeroPicture,
 } from '@weco/content/utils/page-header';
 
-function getBorderColor({
-  type,
-  i,
-}: {
-  type?: string;
-  i: number;
-}): PaletteColor {
-  if (type === 'visual-story') {
-    return 'accent.turquoise';
-  } else if (type === 'exhibition-guide') {
-    return 'accent.salmon';
-  } else if (i % 2 === 0) {
-    return 'accent.blue';
-  } else {
-    return 'accent.purple';
-  }
-}
-
-type ExhibitionItem = LabelField & {
-  icon?: IconSvg;
-};
-
-function getUpcomingExhibitionObject(
-  exhibition: ExhibitionType
-): ExhibitionItem | undefined {
-  return isFuture(exhibition.start)
-    ? {
-        description: [
-          {
-            type: 'paragraph',
-            text: `Opening on ${formatDate(exhibition.start)}`,
-            spans: [],
-          },
-        ],
-        icon: calendar,
-      }
-    : undefined;
-}
-
-function getadmissionObject(): ExhibitionItem {
-  return {
-    description: [
-      {
-        type: 'paragraph',
-        text: 'Free admission',
-        spans: [],
-      },
-    ],
-    icon: ticket,
-  };
-}
-
-function getTodaysHoursObject(): ExhibitionItem {
-  const todaysHoursText = 'Galleries open Tuesday–Sunday, Opening times';
-
-  const link: prismic.RTLinkNode = {
-    type: 'hyperlink',
-    start: todaysHoursText.length - 'Opening times'.length,
-    end: todaysHoursText.length,
-    data: {
-      link_type: 'Web',
-      url: `/visit-us/${prismicPageIds.openingTimes}`,
-    },
-  };
-
-  return {
-    description: [
-      {
-        type: 'paragraph',
-        text: todaysHoursText,
-        spans: [link],
-      },
-    ],
-    icon: clock,
-  };
-}
-
-function getPlaceObject(
-  exhibition: ExhibitionType
-): ExhibitionItem | undefined {
-  return (
-    exhibition.place && {
-      description: [
-        {
-          type: 'paragraph',
-          text: `${exhibition.place.title}, level ${exhibition.place.level}`,
-          spans: [],
-        },
-      ],
-      icon: location,
-    }
-  );
-}
-function getAccessibilityItems(): ExhibitionItem[] {
-  const accessibilityItems: {
-    description: prismic.RichTextField;
-    icon: IconSvg;
-  }[] = [
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.stepFreeAccess,
-          spans: [],
-        },
-      ],
-      icon: accessible,
-    },
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.largePrintGuides,
-          spans: [],
-        },
-      ],
-      icon: a11YVisual,
-    },
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.bsl,
-          spans: [],
-        },
-      ],
-      icon: bslSquare,
-    },
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.accessResources,
-          spans: [],
-        },
-      ],
-      icon: accessibility,
-    },
-  ];
-
-  return accessibilityItems.filter(item => {
-    if (item.description[0] && 'text' in item.description[0]) {
-      return item.description[0]?.text !== a11y.largePrintGuides;
-    } else {
-      return true;
-    }
-  });
-}
-
-export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
-  return [
-    getUpcomingExhibitionObject(exhibition),
-    getadmissionObject(),
-    getTodaysHoursObject(),
-    getPlaceObject(exhibition),
-    ...getAccessibilityItems(),
-  ].filter(isNotUndefined);
-}
-
-export const AccessibilityServices = styled.p.attrs({
-  className: font('intr', 5),
-})`
-  margin: 0;
-`;
+import ExhibitionAccessAccordion from './Exhibition.AccessAccordion';
+import ExhibitionBeingHuman from './Exhibition.BeingHuman';
+import { getInfoItems } from './Exhibition.helpers';
 
 type Props = {
   exhibition: ExhibitionType;
@@ -240,6 +48,8 @@ type Props = {
   exhibitionHighlightTours: ExhibitionHighlightToursDocument[];
 };
 
+type ExhibitionOf = (ExhibitionType | EventBasic)[];
+
 const Exhibition: FunctionComponent<Props> = ({
   exhibition,
   pages,
@@ -247,8 +57,6 @@ const Exhibition: FunctionComponent<Props> = ({
   exhibitionTexts,
   exhibitionHighlightTours,
 }) => {
-  type ExhibitionOf = (ExhibitionType | EventBasic)[];
-
   const [exhibitionOfs, setExhibitionOfs] = useState<ExhibitionOf>([]);
   const [exhibitionAbouts, setExhibitionAbouts] = useState<ExhibitionAbout[]>(
     []
@@ -258,178 +66,6 @@ const Exhibition: FunctionComponent<Props> = ({
   const visualStoryLink = accessResourceLinks.find(
     link => link.type === 'visual-story'
   );
-
-  const hasExhibitionTexts = exhibitionTexts.length > 0;
-  const hasExhibitionHighlightTours = exhibitionHighlightTours.length > 0;
-
-  // Theoretically, there could be multiple ExhibitionTexts and ExhibitionHighlightTours
-  // attached to an exhibition, but in reality there is only one, so we just take the first
-  // and create links to them.
-  const exhibitionTextLink =
-    hasExhibitionTexts && linkResolver(exhibitionTexts[0]);
-  const bslTourLink =
-    hasExhibitionHighlightTours &&
-    linkResolver({
-      ...exhibitionHighlightTours[0],
-      highlightTourType: 'bsl',
-    });
-  const audioTourLink =
-    hasExhibitionHighlightTours &&
-    linkResolver({
-      ...exhibitionHighlightTours[0],
-      highlightTourType: 'audio',
-    });
-
-  // This contains all the possible content for the access section accordion
-  // We then filter out content that isn't relevant, i.e. if there isn't a highlight tour attached to the exhibition
-  const possibleExhibitionAccessContent = [
-    {
-      gtmHook: 'digital_highlights_tour',
-      summary: 'Digital highlights tour',
-      content: (
-        <ul>
-          <li>
-            Find out more about the exhibition with our digital highlights tour,
-            available in short audio clips with audio description and
-            transcripts, or as BSL videos. It can be accessed on your own
-            device, via handheld devices with tactile buttons, or on an iPad
-            which you can borrow
-          </li>
-          {bslTourLink && (
-            <li>
-              <NextLink href={bslTourLink}>Watch BSL video tour</NextLink>
-            </li>
-          )}
-          {audioTourLink && (
-            <li>
-              <NextLink href={audioTourLink}>
-                Listen to audio tour with audio description
-              </NextLink>
-            </li>
-          )}
-        </ul>
-      ),
-    },
-    {
-      gtmHook: 'bsl_transcripts_and_induction_loops',
-      summary: 'BSL, transcripts and induction loops',
-      content: (
-        <ul>
-          <li>BSL content is available in the gallery</li>
-          {bslTourLink && (
-            <li>
-              <NextLink href={bslTourLink}>
-                Watch BSL videos of the digital highlights tour on your own
-                device
-              </NextLink>
-            </li>
-          )}
-
-          <li>
-            <span id="transcript-link-text">
-              Transcripts of all audiovisual content are available
-            </span>{' '}
-            in the gallery
-            {exhibitionTextLink && (
-              <>
-                {` and `}
-                <NextLink
-                  id="transcript-link"
-                  aria-labelledby="transcript-link-text transcript-link"
-                  href={exhibitionTextLink}
-                >
-                  online
-                </NextLink>
-              </>
-            )}
-          </li>
-
-          <li>All videos are subtitled</li>
-          <li>
-            There are fixed induction loops in the building and portable
-            induction loops available to borrow
-          </li>
-        </ul>
-      ),
-    },
-    {
-      gtmHook: 'audio_description_and_visual_access',
-      summary: 'Audio description and visual access',
-      content: (
-        <ul>
-          {audioTourLink && (
-            <li>
-              <NextLink href={audioTourLink}>
-                The digital highlights tour is available with audio description
-              </NextLink>
-            </li>
-          )}
-          {exhibitionTextLink && (
-            <li>
-              <NextLink href={exhibitionTextLink}>
-                Access all the text from the exhibition on your own device
-              </NextLink>
-            </li>
-          )}
-          <li>
-            A large-print guide and magnifiers are available in the gallery
-          </li>
-          <li>There is a tactile line on the gallery floor</li>
-        </ul>
-      ),
-    },
-    {
-      gtmHook: 'wheelchair_and_physical_access',
-      summary: 'Wheelchair and physical access',
-      content: (
-        <ul>
-          <li>Step-free access is available to all floors of the building</li>
-          <li>
-            We have a Changing Places toilet on level 0 and accessible toilets
-            on all floors
-          </li>
-        </ul>
-      ),
-    },
-    {
-      gtmHook: 'sensory_access',
-      summary: 'Sensory access',
-      content: (
-        <ul>
-          <li>
-            {visualStoryLink ? (
-              <>
-                <NextLink href={visualStoryLink?.url}>
-                  A visual story with a sensory map is available online
-                </NextLink>{' '}
-                and
-              </>
-            ) : (
-              'A visual story with a sensory map is available '
-            )}{' '}
-            in the building at the start of the exhibition
-          </li>
-          <li>
-            You can borrow tinted glasses, tinted visors, ear defenders and
-            weighted lap pads. Please speak to a member of staff in the building
-          </li>
-          <li>
-            Weekday mornings and Thursday evenings are usually the quietest
-            times to visit
-          </li>
-        </ul>
-      ),
-    },
-  ];
-
-  const accordionContent = possibleExhibitionAccessContent.filter(section => {
-    // If there is no digital highlights tour attached to the exhibition, we want to remove
-    // the section about the digital highlights tour
-    return !(
-      section.summary === 'Digital highlights tour' &&
-      !hasExhibitionHighlightTours
-    );
-  });
 
   useEffect(() => {
     const ids = exhibition.relatedIds;
@@ -466,11 +102,10 @@ const Exhibition: FunctionComponent<Props> = ({
     ? getFeaturedMedia(exhibition)
     : undefined;
 
-  const hasResources = Boolean(
-    exhibition.accessResourcesText ||
-      exhibition.accessResourcesPdfs.length > 0 ||
-      accessResourceLinks.length > 0
-  );
+  const exhibitionFormat =
+    !exhibition.format || exhibition.format?.title === 'Permanent exhibition'
+      ? 'Exhibition'
+      : exhibition.format.title;
 
   const Header = (
     <>
@@ -505,6 +140,7 @@ const Exhibition: FunctionComponent<Props> = ({
         isContentTypeInfoBeforeMedia={true}
         includeAccessibilityProvision={true}
       />
+
       {exhibition.bslLeafletVideo && (
         <BslLeafletVideo
           video={exhibition.bslLeafletVideo}
@@ -514,11 +150,6 @@ const Exhibition: FunctionComponent<Props> = ({
       )}
     </>
   );
-
-  const exhibitionFormat =
-    !exhibition.format || exhibition.format?.title === 'Permanent exhibition'
-      ? 'Exhibition'
-      : exhibition.format.title;
 
   return (
     <ContentPage
@@ -531,10 +162,18 @@ const Exhibition: FunctionComponent<Props> = ({
         />
       }
       seasons={exhibition.seasons}
-      // We hide contributors as we show them further up the page
-      hideContributors={true}
+      hideContributors={true} // We hide contributors as we show them further up the page
     >
-      {exhibition.uid !== 'being-human' ? (
+      {exhibition.uid === 'being-human' ? (
+        <ExhibitionBeingHuman
+          exhibition={exhibition}
+          accessResourceLinks={accessResourceLinks}
+          exhibitionFormat={exhibitionFormat}
+          exhibitionOfs={exhibitionOfs}
+          exhibitionAbouts={exhibitionAbouts}
+          pages={pages}
+        />
+      ) : (
         <>
           {exhibition.end && !isPast(exhibition.end) && (
             <InfoBox title="Visit us" items={getInfoItems(exhibition)} />
@@ -587,9 +226,15 @@ const Exhibition: FunctionComponent<Props> = ({
                 Resources designed to support your visit are available online
                 and in the gallery.
               </p>
+
               <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-                <Accordion id="access-resources" items={accordionContent} />
+                <ExhibitionAccessAccordion
+                  exhibitionTexts={exhibitionTexts}
+                  exhibitionHighlightTours={exhibitionHighlightTours}
+                  visualStoryLink={visualStoryLink}
+                />
               </Space>
+
               <Space
                 as="h3"
                 className={font('intb', 4)}
@@ -618,127 +263,6 @@ const Exhibition: FunctionComponent<Props> = ({
 
           {exhibition.contributors.length > 0 && (
             <Contributors contributors={exhibition.contributors} />
-          )}
-        </>
-      ) : (
-        <>
-          {hasResources && (
-            <>
-              <Space
-                as="h2"
-                $v={{ size: 'm', properties: ['margin-bottom'] }}
-                className={font('wb', 3)}
-              >{`${exhibitionFormat} access content`}</Space>
-              {(accessResourceLinks.length > 0 ||
-                exhibition.accessResourcesPdfs.length > 0) && (
-                <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
-                  <ResourcesList>
-                    {accessResourceLinks.map((link, i) => {
-                      const borderColor = getBorderColor({
-                        type: link.type,
-                        i,
-                      });
-                      return (
-                        <ResourcesItem key={link.url}>
-                          <ResourceLink
-                            key={i}
-                            href={link.url}
-                            $borderColor={borderColor}
-                          >
-                            {link.type === 'exhibition-guide' && (
-                              <h3 className={font('intb', 4)}>
-                                Digital exhibition guide
-                              </h3>
-                            )}
-                            {link.type === 'visual-story' && (
-                              <h3 className={font('intb', 4)}>Visual story</h3>
-                            )}
-                            <span className={font('intr', 6)}>{link.text}</span>
-                            <ResourceLinkIconWrapper>
-                              <Icon icon={arrow} />
-                            </ResourceLinkIconWrapper>
-                          </ResourceLink>
-                        </ResourcesItem>
-                      );
-                    })}
-                    {exhibition.accessResourcesPdfs.map((pdf, i) => {
-                      const borderColor = getBorderColor({
-                        type: undefined,
-                        i,
-                      });
-                      return (
-                        <ResourcesItem key={pdf.url}>
-                          <ResourceLink
-                            key={i}
-                            href={pdf.url}
-                            $borderColor={borderColor}
-                            $underlineText={true}
-                          >
-                            <span className={font('intr', 5)}>
-                              {`${pdf.text} PDF`} {`(${pdf.size}kb)`}
-                            </span>
-                            <ResourceLinkIconWrapper>
-                              <Icon icon={download} />
-                            </ResourceLinkIconWrapper>
-                          </ResourceLink>
-                        </ResourcesItem>
-                      );
-                    })}
-                  </ResourcesList>
-                </Space>
-              )}
-              {exhibition.accessResourcesText && (
-                <PrismicHtmlBlock
-                  html={exhibition.accessResourcesText}
-                  htmlSerializer={defaultSerializer}
-                />
-              )}
-            </>
-          )}
-
-          {exhibition.contributors.length > 0 && (
-            <Contributors contributors={exhibition.contributors} />
-          )}
-
-          {(exhibitionOfs.length > 0 || pages.length > 0) && (
-            <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-              <SearchResults
-                id="events-list"
-                items={[...exhibitionOfs, ...pages]}
-                title={`${exhibitionFormat} events`}
-              />
-            </Space>
-          )}
-
-          {exhibition.end && !isPast(exhibition.end) && (
-            <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-              <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
-                <AccessibilityServices>
-                  For more information, please visit our{' '}
-                  <a href={`/visit-us/${prismicPageIds.access}`}>
-                    Accessibility
-                  </a>{' '}
-                  page. If you have any queries about accessibility, please
-                  email us at{' '}
-                  <a href="mailto:access@wellcomecollection.org">
-                    access@wellcomecollection.org
-                  </a>{' '}
-                  or call{' '}
-                  {/*
-                  This is to ensure phone numbers are read in a sensible way by
-                  screen readers.
-                */}
-                  <span className="visually-hidden">
-                    {createScreenreaderLabel('020 7611 2222')}
-                  </span>
-                  <span aria-hidden="true">020&nbsp;7611&nbsp;2222.</span>
-                </AccessibilityServices>
-              </InfoBox>
-            </Space>
-          )}
-
-          {exhibitionAbouts.length > 0 && (
-            <SearchResults items={exhibitionAbouts} title="Related stories" />
           )}
         </>
       )}

--- a/content/webapp/components/Installation/index.tsx
+++ b/content/webapp/components/Installation/index.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
+import { font } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -11,10 +12,7 @@ import PageHeader from '@weco/common/views/components/PageHeader';
 import Body from '@weco/content/components/Body';
 import ContentPage from '@weco/content/components/ContentPage';
 import DateAndStatusIndicator from '@weco/content/components/DateAndStatusIndicator';
-import {
-  AccessibilityServices,
-  getInfoItems,
-} from '@weco/content/components/Exhibition';
+import { getInfoItems } from '@weco/content/components/Exhibition/Exhibition.helpers';
 import InfoBox from '@weco/content/components/InfoBox';
 import StatusIndicator from '@weco/content/components/StatusIndicator';
 import { fetchExhibitExhibition } from '@weco/content/services/prismic/fetch/exhibitions';
@@ -82,6 +80,7 @@ const Installation: FunctionComponent<Props> = ({ installation }) => {
       isContentTypeInfoBeforeMedia={true}
     />
   );
+
   return (
     <ContentPage
       id={installation.id}
@@ -97,7 +96,7 @@ const Installation: FunctionComponent<Props> = ({ installation }) => {
     >
       {installation.end && !isPast(installation.end) && (
         <InfoBox title="Visit us" items={getInfoItems(installation)}>
-          <AccessibilityServices>
+          <p className={font('intr', 5)} style={{ margin: 0 }}>
             For more information, please visit our{' '}
             <a href={`/visit-us/${prismicPageIds.access}`}>Accessibility</a>{' '}
             page. If you have any queries about accessibility, please email us
@@ -107,14 +106,14 @@ const Installation: FunctionComponent<Props> = ({ installation }) => {
             </a>{' '}
             or call{' '}
             {/*
-        This is to ensure phone numbers are read in a sensible way by
-        screen readers.
-      */}
+              This is to ensure phone numbers are read in a sensible way by
+              screen readers.
+            */}
             <span className="visually-hidden">
               {createScreenreaderLabel('020 7611 2222')}
             </span>
             <span aria-hidden="true">020&nbsp;7611&nbsp;2222.</span>
-          </AccessibilityServices>
+          </p>
         </InfoBox>
       )}
     </ContentPage>


### PR DESCRIPTION
## What does this change?

The way the Exhibition page works/is structured is close to a way I've worked in the past that I've quite enjoyed, so I decided to look at it as part of #11541 (ish) and run it past everyone.

So the `pages/exhibitions/[exhibitionId]/index.tsx` page's main purpose is to get everything that's required through the `getServerSideProps` fetches and logic, and then a bit of typing and Layout-ing.
Then it imports the `Exhibition` component, which handles the front-end logic of the page. So data and front-end are a bit more split, and that, to me, makes the files much easier to read and the concerns are split. 

So I went a step further and split out the `Exhibition` component, which held a lot of logic for the AccessAccordion, as well as the special "Being Human" case - I wanted to tidy it up further, furthering readability and separation of concern.

I thought `Installation` might have been worth considering as well but decided not to for now!

If we like this way of splitting stuff up, it could be considered done across, as I said, I've worked like it in the past and tend to prefer smaller files with separate logic, but I'm very open to not head that way. Discuss!