### PR TITLE
Works audio to be the new audio player

### DIFF
--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -309,7 +309,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           canvas={canvas}
           isRestricted={isRestricted}
         >
-          {audioPlayer && extendedViewer ? (
+          {extendedViewer ? (
             isInViewer ? (
               <AudioPlayerNew
                 isDark
@@ -326,10 +326,19 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
               />
             )
           ) : (
-            <AudioPlayer
-              audioFile={item.id}
-              title={getAudioVideoLabel(canvas.label, titleOverride) || ''}
-            />
+            <>
+              {audioPlayer ? (
+                <AudioPlayerNew
+                  audioFile={item.id}
+                  title={getAudioVideoLabel(canvas.label, titleOverride) || ''}
+                />
+              ) : (
+                <AudioPlayer
+                  audioFile={item.id}
+                  title={getAudioVideoLabel(canvas.label, titleOverride) || ''}
+                />
+              )}
+            </>
           )}
         </IIIFItemWrapper>
       );


### PR DESCRIPTION
## What does this change?

Forgot this case when I did https://github.com/wellcomecollection/wellcomecollection.org/pull/11921 for https://github.com/wellcomecollection/wellcomecollection.org/issues/11899

## How to test

https://www-dev.wellcomecollection.org/works/k9k5vv2q
without the Extended viewer canvas should now display the new viewer instead of the old one (and only one at a time now woo)

## How can we measure success?
I believe that's NOW the new player everywhere

## Have we considered potential risks?
N/A