### PR TITLE
Add a link to A/B tests steps in cache README

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -25,7 +25,7 @@ Create a PR with this change, and once merged and built, run `terraform plan` an
 Test your redirection in staging after a few minutes. Cache might need to be cleared.
 
 If that works, next step is to apply the changes to prod.
-For that, you'll need to change the edge lambda versions in our [locals file](./locals.tf). 
+For that, you'll need to change the edge lambda versions in our [locals file](./locals.tf).
 You can find that version number in the Lambda AWS app.
 
 Once that has been merged and built, you'll need to reapply Terraform.
@@ -35,6 +35,8 @@ Once that has been merged and built, you'll need to reapply Terraform.
 Randomly assign people into A/B buckets against a `key` that is then available to our webapps.
 
 We do this by setting a `toggle_{key}=true|false` that is then read via the standard toggles method.
+
+The steps to create an A/B test are available in [GitBook](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/DPDDj27NI2F2kPukWrC1/readme/front-end/a-b-testing).
 
 ```mermaid
 sequenceDiagram

--- a/cache/README.md
+++ b/cache/README.md
@@ -36,8 +36,6 @@ Randomly assign people into A/B buckets against a `key` that is then available t
 
 We do this by setting a `toggle_{key}=true|false` that is then read via the standard toggles method.
 
-The steps to create an A/B test are available in [GitBook](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/DPDDj27NI2F2kPukWrC1/readme/front-end/a-b-testing).
-
 ```mermaid
 sequenceDiagram
 participant End_user
@@ -60,3 +58,31 @@ end
 ```
 
 `toggler` runs @ the `origin-request` and `origin-response` of [the lambda@edgfe lifecycle](https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html).
+
+### Steps to create an A/B test
+1. Add a test object to [`toggler.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/edge_lambdas/src/toggler.ts) and add an equivalent test object with the same id to [`toggles.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/toggles/webapp/toggles.ts)  – this second object is important because it allows us to determine [what should be sent to GA](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/services/app/analytics-scripts/google-analytics.tsx)
+```json
+{
+  id: 'someToggleId',
+  title: 'New subject tags on works pages',
+  range: [0, SOME_PERCENTAGE],
+  when: request => {
+    return !!request.uri.match(/SOME_REGEX/);
+  },
+}
+```
+2. Update and upload the lambda deployment package:
+```
+docker compose build edge_lambdas
+AWS_PROFILE=experience-developer docker compose run edge_lambdas yarn deploy
+```
+3. deploy the lambda:
+```
+terraform plan -out=terraform.plan
+terraform apply terraform.plan
+```
+4. Make a note of the edge_lambda_request_version and edge_lambda_response_version numbers in the terminal resulting from the terraform command
+5. Check www-stage and verify the test cookie (`toggle_someToggleId`) is set
+6. Check the data is being sent to GA (either `someToggleId` or `!someToggleId`). You should initially be able to see the toggles dataLayer variable being set (`DLV - Toggles`) in GTM, then this data should get sent to GA as a custom dimension (note you might not be able to see this until the next day)
+7. Update [`locals.tf`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/locals.tf) with values from previous terraform and re-run the terraform steps above to get the changes in to production
+8. Use the toggle to conditionally serve different UI in the same way as you would for feature flags

--- a/cache/README.md
+++ b/cache/README.md
@@ -61,7 +61,7 @@ end
 
 ### Steps to create an A/B test
 1. Add a test object to [`toggler.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/edge_lambdas/src/toggler.ts) and add an equivalent test object with the same id to [`toggles.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/toggles/webapp/toggles.ts)  – this second object is important because it allows us to determine [what should be sent to GA](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/services/app/analytics-scripts/google-analytics.tsx)
-```json
+```
 {
   id: 'someToggleId',
   title: 'New subject tags on works pages',


### PR DESCRIPTION
## What does this change?
Adds a link to the newly created A/B test steps in GitBook

## How to test
Read it?

## How can we measure success?
We can make A/B tests easier

## Have we considered potential risks?
n/a
