### PR TITLE
Ab tags

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -71,18 +71,22 @@ end
   },
 }
 ```
-2. Update and upload the lambda deployment package:
+2. Update and upload the lambda deployment package. From the root of the repo, run:
 ```
 docker compose build edge_lambdas
 AWS_PROFILE=experience-developer docker compose run edge_lambdas yarn deploy
 ```
-3. deploy the lambda:
+3. Deploy the toggle to the toggles dashboard. From the `toggles/webapp` directory, run:
+```
+yarn deploy
+```
+4. Deploy the lambda. From inside the `cache` directory, run:
 ```
 terraform plan -out=terraform.plan
 terraform apply terraform.plan
 ```
-4. Make a note of the edge_lambda_request_version and edge_lambda_response_version numbers in the terminal resulting from the terraform command
-5. Check www-stage and verify the test cookie (`toggle_someToggleId`) is set
-6. Check the data is being sent to GA (either `someToggleId` or `!someToggleId`). You should initially be able to see the toggles dataLayer variable being set (`DLV - Toggles`) in GTM, then this data should get sent to GA as a custom dimension (note you might not be able to see this until the next day)
-7. Update [`locals.tf`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/locals.tf) with values from previous terraform and re-run the terraform steps above to get the changes in to production
-8. Use the toggle to conditionally serve different UI in the same way as you would for feature flags
+5. Make a note of the `edge_lambda_request_version` and `edge_lambda_response_version` numbers in the terminal resulting from the terraform command
+6. Check www-stage and verify the test cookie (`toggle_someToggleId`) is set
+7. Check the data is being sent to GA (either `someToggleId` or `!someToggleId`). You should initially be able to see the toggles dataLayer variable being set (`DLV - Toggles`) in GTM, then this data should get sent to GA as a custom dimension (note you might not be able to see this until the next day)
+8. Update [`locals.tf`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/locals.tf) with values from previous terraform and re-run the terraform steps above to get the changes in to production
+9. Use the toggle to conditionally serve different UI in the same way as you would for feature flags

--- a/cache/README.md
+++ b/cache/README.md
@@ -60,15 +60,25 @@ end
 `toggler` runs @ the `origin-request` and `origin-response` of [the lambda@edgfe lifecycle](https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html).
 
 ### Steps to create an A/B test
-1. Add a test object to [`toggler.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/edge_lambdas/src/toggler.ts) and add an equivalent test object with the same id to [`toggles.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/toggles/webapp/toggles.ts)  – this second object is important because it allows us to determine [what should be sent to GA](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/services/app/analytics-scripts/google-analytics.tsx)
+1. Add a test object to [`toggler.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/edge_lambdas/src/toggler.ts) and add an equivalent test object with the same id (without the `when` key) to [`toggles.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/toggles/webapp/toggles.ts)  – this second object is important because it allows us to determine [what should be sent to GA](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/services/app/analytics-scripts/google-analytics.tsx)
+
+**toggler.ts**
 ```
 {
   id: 'someToggleId',
-  title: 'New subject tags on works pages',
+  title: 'Some descriptive title',
   range: [0, SOME_PERCENTAGE],
   when: request => {
     return !!request.uri.match(/SOME_REGEX/);
   },
+}
+```
+**toggles.ts**
+```
+{
+  id: 'someToggleId',
+  title: 'Some descriptive title',
+  range: [0, SOME_PERCENTAGE],
 }
 ```
 2. Update and upload the lambda deployment package. From the root of the repo, run:

--- a/cache/edge_lambdas/src/toggler.ts
+++ b/cache/edge_lambdas/src/toggler.ts
@@ -30,6 +30,14 @@ export let tests: Test[] = [
       return !!request.uri.match(/\/works\/.*$/);
     },
   },
+  {
+    id: 'newTags',
+    title: 'A/B test for new tags',
+    range: [0, 100],
+    when: request => {
+      return !!request.uri.match(/^\/works\/[^/]+$/); // /works/someid but not /works/someid/otherpath
+    },
+  },
 ]; // Any test toggles included here also have to be included in the toggles dir because they are deployed separately and consequently can't share a source of truth
 
 export const setTests = function (newTests: Test[]): void {

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -3,8 +3,8 @@ data "aws_secretsmanager_secret_version" "slack_webhook" {
 }
 
 locals {
-  edge_lambda_request_version  = 151
-  edge_lambda_response_version = 149
+  edge_lambda_request_version  = 152
+  edge_lambda_response_version = 150
 
   wellcome_cdn_cert_arn = "arn:aws:acm:us-east-1:130871440101:certificate/bb840c52-56bb-4bf8-86f8-59e7deaf9c98"
 

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -1,5 +1,3 @@
-import { CloudFrontRequest } from 'aws-lambda';
-
 export type ToggleTypes = 'permanent' | 'experimental' | 'test' | 'stage';
 
 type ToggleBase = {
@@ -21,8 +19,6 @@ export type PublishedToggle = ToggleBase & {
 export type ABTest = {
   id: string;
   title: string;
-  range: [number, number];
-  when: (request: CloudFrontRequest) => boolean;
   type: 'test';
 };
 

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -20,6 +20,7 @@ export type ABTest = {
   id: string;
   title: string;
   type: 'test';
+  range: [number, number];
 };
 
 const toggles = {
@@ -118,11 +119,13 @@ const toggles = {
       id: 'abTestTestTest',
       title: 'Testing the A/B test toggler',
       type: 'test',
+      range: [0, 100],
     },
     {
       id: 'newTags',
       title: 'A/B test for new tags',
       type: 'test',
+      range: [0, 100],
     },
   ] as ABTest[], // We have to include a reference to any test toggles here as well as in the cache dir because they are deployed separately and consequently can't share a source of truth
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -117,10 +117,11 @@ const toggles = {
     {
       id: 'abTestTestTest',
       title: 'Testing the A/B test toggler',
-      range: [0, 100],
-      when: request => {
-        return !!request.uri.match(/\/works\/.*$/);
-      },
+      type: 'test',
+    },
+    {
+      id: 'newTags',
+      title: 'A/B test for new tags',
       type: 'test',
     },
   ] as ABTest[], // We have to include a reference to any test toggles here as well as in the cache dir because they are deployed separately and consequently can't share a source of truth


### PR DESCRIPTION
## What does this change?
- Adds the code for the (already deployed from the command line) `newTags` toggle which we'll use for A/B testing.
- Improves the README steps

## How to test
n/a

## How can we measure success?
We can A/B test new tags

## Have we considered potential risks?
Can't think of any