### PR TITLE
New tags for AB test

### DIFF
--- a/cardigan/stories/components/Tags/Tags.stories.tsx
+++ b/cardigan/stories/components/Tags/Tags.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
-import Readme from '@weco/content/components/Tags/README.mdx';
 import Tags from '@weco/content/components/Tags';
+import Readme from '@weco/content/components/Tags/README.mdx';
 
 const nextLink = {
   href: {
@@ -26,6 +26,8 @@ const meta: Meta<typeof Tags> = {
   component: Tags,
   args: {
     isFirstPartBold: false,
+    isABTestWorkTag: false,
+    separator: '-',
     tags: [
       {
         textParts: ['Medical illustration'],
@@ -40,6 +42,13 @@ const meta: Meta<typeof Tags> = {
         linkAttributes: nextLink,
       },
     ],
+  },
+  argTypes: {
+    tags: {
+      table: {
+        disable: true,
+      },
+    },
   },
 };
 

--- a/cardigan/stories/components/TagsGroup/TagsGroup.stories.tsx
+++ b/cardigan/stories/components/TagsGroup/TagsGroup.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
-import Readme from '@weco/content/components/TagsGroup/README.mdx';
 import TagsGroup from '@weco/content/components/TagsGroup';
+import Readme from '@weco/content/components/TagsGroup/README.mdx';
 
 const meta: Meta<typeof TagsGroup> = {
   title: 'Components/TagsGroup',
@@ -46,6 +46,13 @@ const meta: Meta<typeof TagsGroup> = {
         },
       },
     ],
+  },
+  argTypes: {
+    tags: {
+      table: {
+        disable: true,
+      },
+    },
   },
 };
 

--- a/content/webapp/components/Tags/README.md
+++ b/content/webapp/components/Tags/README.md
@@ -1,5 +1,0 @@
-## Purpose
-To display a horizontal list of associated links.
-
-
-[Edit this Readme on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/Tags/README.md)

--- a/content/webapp/components/Tags/Tags.New.tsx
+++ b/content/webapp/components/Tags/Tags.New.tsx
@@ -4,24 +4,13 @@ import styled from 'styled-components';
 
 import { LinkProps } from '@weco/common/model/link-props';
 import { font } from '@weco/common/utils/classnames';
-import { StyledButton } from '@weco/common/views/components/Buttons';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
-import { themeValues } from '@weco/common/views/themes/config';
-
-import TagsNew from './Tags.New';
 
 export type TagType = {
   textParts: string[];
   linkAttributes: LinkProps;
 };
-
-const TagInner = styled.span`
-  white-space: normal;
-  display: inline-block;
-  text-align: left;
-  line-height: 1.2;
-`;
 
 type PartWithSeparatorProps = {
   $separator: string;
@@ -41,10 +30,10 @@ const PartWithSeparator = styled.span.attrs({
   }
 `;
 
-const LinkWrapper = styled(Space).attrs({
+const LinkWrapper = styled(Space).attrs<{ $isLast: boolean }>(props => ({
   $v: { size: 's', properties: ['margin-bottom'] },
-  $h: { size: 's', properties: ['margin-right'] },
-})`
+  ...(!props.$isLast && { $h: { size: 'l', properties: ['margin-right'] } }),
+}))`
   display: inline-block;
 `;
 
@@ -52,56 +41,40 @@ export type Props = {
   tags: TagType[];
   isFirstPartBold?: boolean;
   separator?: string;
-  isABTestWorkTag?: boolean;
 };
 
-const Tags: FunctionComponent<Props> = ({
+const TagsNew: FunctionComponent<Props> = ({
   tags,
   isFirstPartBold = true,
   separator = '–',
-  isABTestWorkTag,
 }) => {
-  if (isABTestWorkTag)
-    return (
-      <TagsNew
-        tags={tags}
-        isFirstPartBold={isFirstPartBold}
-        separator={separator}
-      />
-    );
-
   return (
     <Space $v={{ size: 's', negative: true, properties: ['margin-bottom'] }}>
       <PlainList>
         {/* Have to use index for key because some LCSH and MSH are the same and therefore textParts aren't unique */}
         {tags.map(({ textParts, linkAttributes }, i) => {
           return (
-            <LinkWrapper as="li" key={i}>
+            <LinkWrapper as="li" key={i} $isLast={i === tags.length - 1}>
               <NextLink {...linkAttributes} passHref legacyBehavior>
-                <StyledButton
-                  $size="small"
-                  $colors={themeValues.buttonColors.pumiceTransparentCharcoal}
-                >
-                  <TagInner>
-                    {textParts.map((part, i, arr) => (
-                      <PartWithSeparator
-                        key={part}
-                        $separator={i === 0 ? '|' : separator}
-                        $isLast={i === arr.length - 1}
+                <a style={{ textUnderlineOffset: '6px' }}>
+                  {textParts.map((part, i, arr) => (
+                    <PartWithSeparator
+                      key={part}
+                      $separator={i === 0 ? '|' : separator}
+                      $isLast={i === arr.length - 1}
+                    >
+                      <span
+                        className={
+                          i === 0 && isFirstPartBold
+                            ? font('intb', 5)
+                            : font('intr', 5)
+                        }
                       >
-                        <span
-                          className={
-                            i === 0 && isFirstPartBold
-                              ? font('intb', 5)
-                              : font('intr', 5)
-                          }
-                        >
-                          {part}
-                        </span>
-                      </PartWithSeparator>
-                    ))}
-                  </TagInner>
-                </StyledButton>
+                        {part}
+                      </span>
+                    </PartWithSeparator>
+                  ))}
+                </a>
               </NextLink>
             </LinkWrapper>
           );
@@ -111,4 +84,4 @@ const Tags: FunctionComponent<Props> = ({
   );
 };
 
-export default Tags;
+export default TagsNew;

--- a/content/webapp/components/TagsGroup/README.md
+++ b/content/webapp/components/TagsGroup/README.md
@@ -1,5 +1,0 @@
-## Purpose
-To display a list of associated links horizontally under a heading
-
-
-[Edit this Readme on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/TagsGroup/README.md)

--- a/content/webapp/components/WorkDetails/WorkDetails.Tags.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.Tags.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'react';
 
+import { useToggles } from '@weco/common/server-data/Context';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import Tags, { Props as TagsProps } from '@weco/content/components/Tags';
@@ -12,6 +13,8 @@ const WorkDetailsTags: FunctionComponent<Props> = ({
   title,
   ...tagsProps
 }: Props) => {
+  const { newTags } = useToggles();
+
   return (
     <WorkDetailsProperty title={title}>
       <ConditionalWrapper
@@ -28,7 +31,7 @@ const WorkDetailsTags: FunctionComponent<Props> = ({
           </Space>
         )}
       >
-        <Tags {...tagsProps} />
+        <Tags {...tagsProps} isABTestWorkTag={newTags} />
       </ConditionalWrapper>
     </WorkDetailsProperty>
   );


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/11755

- Creates a variant of `Tags` that gets displayed if it comes from `WorkDetails.Tags` and the user is part of the B group on the AB test.
- `Tags` is also used in `TagsGroup` which is the component used in the `TagsList` slice ([example here](https://wellcomecollection.org/stories/YtlayxEAACgA_JmE)). Should we move forward with this change, we should ask whether or not the slice should also move to it.

## How to test

Locally, toggle the "A/B test for new tags" AB test and check that [a works page](https://www-dev.wellcomecollection.org/works/a2239muq) shows you the expected tags.

## How can we measure success?

We can go ahead with our first AB test in 2+ years!

## Have we considered potential risks?
N/A