### PR TITLE
Related content works

### DIFF
--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -1,5 +1,7 @@
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useContext, useEffect, useState } from 'react';
 
+import { ServerDataContext } from '@weco/common/server-data/Context';
+import { catalogueQuery } from '@weco/content/services/wellcome/catalogue';
 import { Work } from '@weco/content/services/wellcome/catalogue/types';
 
 type Props = {
@@ -9,6 +11,25 @@ type Props = {
 const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
   const [relatedContent, setRelatedContent] = useState([]);
   const subjects = work.subjects.map(subject => subject.label);
+  const data = useContext(ServerDataContext);
+
+  useEffect(() => {
+    const fetchRelatedContent = async () => {
+      const response = await catalogueQuery('works', {
+        toggles: data.toggles,
+        pageSize: 3,
+        params: {
+          'subjects.label': subjects,
+        },
+      });
+      if (response.type === 'ResultList') {
+        setRelatedContent(response.results);
+      }
+    };
+    if (subjects.length > 0) {
+      fetchRelatedContent();
+    }
+  }, [work]);
   return <h2>Related Works</h2>;
 };
 

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -2,14 +2,18 @@ import { FunctionComponent, useContext, useEffect, useState } from 'react';
 
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import { catalogueQuery } from '@weco/content/services/wellcome/catalogue';
-import { Work } from '@weco/content/services/wellcome/catalogue/types';
+import {
+  toWorkBasic,
+  Work,
+  WorkBasic,
+} from '@weco/content/services/wellcome/catalogue/types';
 
 type Props = {
   work: Work;
 };
 
 const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
-  const [relatedContent, setRelatedContent] = useState([]);
+  const [relatedContent, setRelatedContent] = useState<WorkBasic[]>([]);
   const subjects = work.subjects.map(subject => subject.label);
   const data = useContext(ServerDataContext);
 
@@ -27,6 +31,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
           response.results
             .filter(content => content.id !== work.id) // Exclude the current work
             .slice(0, 3) // Only show 3 results
+            .map(toWorkBasic)
         );
       }
     };

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -1,0 +1,13 @@
+import { FunctionComponent } from 'react';
+
+import { Work } from '@weco/content/services/wellcome/catalogue/types';
+
+type Props = {
+  work: Work;
+};
+
+const RelatedWorks: FunctionComponent<Props> = () => {
+  return <h2>Related Works</h2>;
+};
+
+export default RelatedWorks;

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent, useContext, useEffect, useState } from 'react';
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
+import WorksSearchResult from '@weco/content/components/WorksSearchResult'; // temporary
 import { catalogueQuery } from '@weco/content/services/wellcome/catalogue';
 import {
   toWorkBasic,
@@ -47,6 +48,13 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
       <Container>
         <Space $v={{ size: 'l', properties: ['padding-top'] }}>
           <h2>Related Works</h2>
+          {relatedContent.map((result, i) => (
+            <WorksSearchResult
+              work={result}
+              resultPosition={i}
+              key={result.id}
+            />
+          ))}
         </Space>
       </Container>
     )) ||

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -6,7 +6,8 @@ type Props = {
   work: Work;
 };
 
-const RelatedWorks: FunctionComponent<Props> = () => {
+const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
+  const subjects = work.subjects.map(subject => subject.label);
   return <h2>Related Works</h2>;
 };
 

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
 
 import { Work } from '@weco/content/services/wellcome/catalogue/types';
 
@@ -7,6 +7,7 @@ type Props = {
 };
 
 const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
+  const [relatedContent, setRelatedContent] = useState([]);
   const subjects = work.subjects.map(subject => subject.label);
   return <h2>Related Works</h2>;
 };

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -17,7 +17,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
     const fetchRelatedContent = async () => {
       const response = await catalogueQuery('works', {
         toggles: data.toggles,
-        pageSize: 3,
+        pageSize: 4, // In case we get the current work back, we will still have 3 to show
         params: {
           'subjects.label': subjects,
         },

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -24,7 +24,9 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
       });
       if (response.type === 'ResultList') {
         setRelatedContent(
-          response.results.filter(content => content.id !== work.id) // Exclude the current work
+          response.results
+            .filter(content => content.id !== work.id) // Exclude the current work
+            .slice(0, 3) // Only show 3 results
         );
       }
     };

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -24,6 +24,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
         pageSize: 4, // In case we get the current work back, we will still have 3 to show
         params: {
           'subjects.label': subjects,
+          include: ['production', 'contributors'],
         },
       });
       if (response.type === 'ResultList') {

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -1,6 +1,8 @@
 import { FunctionComponent, useContext, useEffect, useState } from 'react';
 
 import { ServerDataContext } from '@weco/common/server-data/Context';
+import { Container } from '@weco/common/views/components/styled/Container';
+import Space from '@weco/common/views/components/styled/Space';
 import { catalogueQuery } from '@weco/content/services/wellcome/catalogue';
 import {
   toWorkBasic,
@@ -40,7 +42,16 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
       fetchRelatedContent();
     }
   }, [work]);
-  return (relatedContent.length > 0 && <h2>Related Works</h2>) || null;
+  return (
+    (relatedContent.length > 0 && (
+      <Container>
+        <Space $v={{ size: 'l', properties: ['padding-top'] }}>
+          <h2>Related Works</h2>
+        </Space>
+      </Container>
+    )) ||
+    null
+  );
 };
 
 export default RelatedWorks;

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -23,7 +23,9 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
         },
       });
       if (response.type === 'ResultList') {
-        setRelatedContent(response.results);
+        setRelatedContent(
+          response.results.filter(content => content.id !== work.id) // Exclude the current work
+        );
       }
     };
     if (subjects.length > 0) {

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -40,7 +40,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
       fetchRelatedContent();
     }
   }, [work]);
-  return <h2>Related Works</h2>;
+  return (relatedContent.length > 0 && <h2>Related Works</h2>) || null;
 };
 
 export default RelatedWorks;

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -17,6 +17,7 @@ import ArchiveBreadcrumb from '@weco/content/components/ArchiveBreadcrumb';
 import ArchiveTree from '@weco/content/components/ArchiveTree';
 import BackToResults from '@weco/content/components/BackToResults';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout';
+import RelatedWorks from '@weco/content/components/RelatedWorks';
 import WorkDetails from '@weco/content/components/WorkDetails';
 import WorkHeader from '@weco/content/components/WorkHeader';
 import IsArchiveContext from '@weco/content/contexts/IsArchiveContext';
@@ -203,6 +204,7 @@ export const WorkPage: NextPage<Props> = ({
             />
           </>
         )}
+        {relatedContentOnWorks && <RelatedWorks work={work} />}
       </CataloguePageLayout>
     </IsArchiveContext.Provider>
   );

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { getServerData } from '@weco/common/server-data';
+import { useToggles } from '@weco/common/server-data/Context';
 import { appError, AppErrorProps } from '@weco/common/services/app';
 import { Pageview } from '@weco/common/services/conversion/track';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
@@ -67,6 +68,7 @@ export const WorkPage: NextPage<Props> = ({
   transformedManifest,
 }) => {
   useHotjar(true);
+  const { relatedContentOnWorks } = useToggles();
   const { userIsStaffWithRestricted } = useUserContext();
   const isArchive = !!(
     work.parts.length ||


### PR DESCRIPTION
## What does this change?

For #11767 

- grabs the subject labels from a work
- makes a client side request to the catalogue API for works with those subject labels
- displays the first 3 results (not including the current work) at the bottom of the works page

This is very much a work in progress. Currently using the WorksSearchResult component to display the results vertically (it displays the same data we want to display).

## How to test

- with the relatedContentOnWorks toggle off [works pages](http://www-dev.wellcomecollection.org/works/a4ngd332) should appear no differently
- with the relatedContentOnWorks toggle on, [works with subject labels](http://www-dev.wellcomecollection.org/works/a4ngd332) should display related content at the bottom of the page
- with the relatedContentOnWorks toggle on, [works without subject labels](http://www-dev.wellcomecollection.org/works/mx73pk2b) should not display related content at the bottom of the page

## How can we measure success?

n/a

## Have we considered potential risks?

Behind a toggle so should be good

