### PR TITLE
Find invalid links in Prismic (prismic linter check)

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -73,12 +73,16 @@ function detectNonHTTPWWWLinks(doc: any): string[] {
           urlIndex + 7,
           urlIndex + 8
         );
+        const next4Characters = JSON.stringify(doc.data).slice(
+          urlIndex + 7,
+          urlIndex + 11
+        );
 
         if (
           nextCharacter !== '/' && // internal, hopefully
-          nextCharacter !== 'h' && // http, hopefully
-          nextCharacter !== 'm' && // mailto, hopefully
-          nextCharacter !== 't' // tel, hopefully
+          next4Characters !== 'http' && // http, hopefully
+          next4Characters !== 'mail' && // mailto, hopefully
+          next4Characters !== 'tel:' // tel, hopefully
         ) {
           allErrors.push(
             'Please review the links in this document as they may not be valid. The URL should start with http[s]:// (if external) or / (if internal).'

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -59,6 +59,37 @@ function detectEur01Safelinks(doc: any): string[] {
   return [];
 }
 
+function detectNonHTTPWWWLinks(doc: any): string[] {
+  const allUrlIndexes = [...JSON.stringify(doc.data).matchAll(/"url":"/gi)].map(
+    a => a.index
+  );
+
+  const allErrors: string[] = [];
+
+  if (allUrlIndexes.length > 0) {
+    allUrlIndexes.forEach(urlIndex => {
+      if (JSON.stringify(doc.data).indexOf('"url":"') > 0) {
+        const nextCharacter = JSON.stringify(doc.data).slice(
+          urlIndex + 7,
+          urlIndex + 8
+        );
+
+        if (
+          nextCharacter !== '/' && // internal, hopefully
+          nextCharacter !== 'h' && // http, hopefully
+          nextCharacter !== 'm' && // mailto, hopefully
+          nextCharacter !== 't' // tel, hopefully
+        ) {
+          allErrors.push(
+            'Please review the links in this document as they may not be valid. The URL should start with http[s]:// (if external) or / (if internal).'
+          );
+        }
+      }
+    });
+  }
+  return allErrors;
+}
+
 // Look for preview.wellcomecollection.org links.
 //
 // This is a very crude check; we could recurse further down into
@@ -263,6 +294,7 @@ async function run() {
   for (const doc of getPrismicDocuments(snapshotFile)) {
     const errors = [
       ...detectEur01Safelinks(doc),
+      ...detectNonHTTPWWWLinks(doc),
       ...detectPreviewLinks(doc),
       ...detectBrokenInterpretationTypeLinks(doc),
       ...detectNonHttpContributorLinks(doc),


### PR DESCRIPTION
## What does this change?
We were flagged a broken link recently, it started with `www.` and was counted as a relative link, so after chatting with Vanesha, I thought I'd try and figure out a way to spot outliers...

## How to test

Run `yarn lintPrismicData` locally, could try to break a link for it 🤷‍♀️  - There is a broken one already which looks like a link from an iPhone that isn't a link, I'm keeping it there to give the example to Editorial!

## How can we measure success?

Less chances of borked links? The logic is far from perfect, let's be honest, but would reduce chances.

## Have we considered potential risks?
🤷‍♀️ 