### PR TITLE
Related content tabs

### DIFF
--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -145,7 +145,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
     }
   }, [selectedWorksTab, work.id]);
 
-  return (
+  return Object.keys(relatedTabConfig).length === 0 ? null : (
     <Container>
       <Space $v={{ size: 'l', properties: ['padding-top'] }}>
         <h2>Related Works</h2>

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -79,12 +79,13 @@ function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
   } = {};
 
   subjectLabels.forEach(label => {
-    config[`subject-${label}`] = {
+    const id = label.replace(/[^a-zA-Z0-9]/g, '-');
+    config[`subject-${id}`] = {
       text: label,
       params: { 'subjects.label': [label] },
-      related: relatedWorks[`subject-${label}`],
+      related: relatedWorks[`subject-${id}`],
       setRelated: (results: WorkBasic[]) =>
-        setRelatedWorks(prev => ({ ...prev, [`subject-${label}`]: results })),
+        setRelatedWorks(prev => ({ ...prev, [`subject-${id}`]: results })),
     };
   });
 

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -93,10 +93,6 @@ function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
     config['date-range'] = {
       text: dateRange.tabLabel,
       params: {
-        // TODO do we want to filter by subject labels here too or just dates?
-        // ...(subjectLabels.length > 0
-        //   ? { 'subjects.label': subjectLabels }
-        //   : {}),
         'production.dates.from': dateRange.from,
         'production.dates.to': dateRange.to,
       },

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -103,6 +103,11 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
     relatedWorks,
     setRelatedWorks,
   });
+
+  // Set initial tab to first subject or date-range if no subjects
+  const tabKeys = Object.keys(relatedTabConfig);
+  const [selectedWorksTab, setSelectedWorksTab] = useState(tabKeys[0] || '');
+
   const data = useContext(ServerDataContext);
 
   useEffect(() => {

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -126,13 +126,20 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
   const serverData = useContext(ServerDataContext);
 
   useEffect(() => {
-    fetchRelated({
-      work,
-      serverData,
-      params: relatedTabConfig[selectedWorksTab].params,
-      setRelated: relatedTabConfig[selectedWorksTab].setRelated,
-    });
-  }, [selectedWorksTab]);
+    // Only fetch if we haven't already fetched results for hte current tab
+    // or if the results for the current tab now include the current work
+    const related =
+      relatedTabConfig[selectedWorksTab] &&
+      relatedTabConfig[selectedWorksTab].related;
+    if (!related || related.some(result => result.id === work.id)) {
+      fetchRelated({
+        work,
+        serverData,
+        params: relatedTabConfig[selectedWorksTab].params,
+        setRelated: relatedTabConfig[selectedWorksTab].setRelated,
+      });
+    }
+  }, [selectedWorksTab, work.id]);
 
   return (
     <Container>

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -18,19 +18,19 @@ type Props = {
   work: Work;
 };
 
-// TODO may change to century range
-const getDecadeRange = (
+// Returns the century range for a string containing exactly four digits
+const getCenturyRange = (
   str: string
 ): { tabLabel: string; from: string; to: string } | null => {
   const match = str.match(/^(\d{4})$/);
   if (match) {
     const year = parseInt(match[0], 10);
-    const decadeStart = Math.floor(year / 10) * 10;
-    const decadeEnd = decadeStart + 10;
+    const centuryStart = Math.floor(year / 100) * 100;
+    const centuryEnd = centuryStart + 99;
     return {
-      tabLabel: `From ${decadeStart}`,
-      from: `${decadeStart}-01-01`,
-      to: `${decadeEnd}-12-31`,
+      tabLabel: `From ${centuryStart}`,
+      from: `${centuryStart}-01-01`,
+      to: `${centuryEnd}-12-31`,
     };
   }
   return null;
@@ -68,7 +68,7 @@ const fetchRelated = async ({
 // Returns a config object for tabs: one per subject label, plus date-range if present
 function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
   const subjectLabels = work.subjects.map(subject => subject.label).slice(0, 3);
-  const dateRange = getDecadeRange(work.production[0].dates[0].label);
+  const dateRange = getCenturyRange(work.production[0].dates[0].label);
   const config: {
     [key: string]: {
       text: string;

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -92,23 +92,27 @@ function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
 
   return config;
 }
+
 const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
   const [relatedWorks, setRelatedWorks] = useState<{
     [key: string]: WorkBasic[] | undefined;
   }>({});
 
+  const relatedTabConfig = getRelatedTabConfig({
+    work,
+    relatedWorks,
+    setRelatedWorks,
+  });
   const data = useContext(ServerDataContext);
 
   useEffect(() => {
-    if (subjects.length > 0) {
-      fetchRelated({
-        work,
-        data,
-        params: bySubjectParams,
-        setRelated: setRelatedBySubject,
-      });
-    }
-  }, [work]);
+    fetchRelated({
+      work,
+      data,
+      params: relatedTabConfig[selectedWorksTab].params,
+      setRelated: relatedTabConfig[selectedWorksTab].setRelated,
+    });
+  }, [selectedWorksTab]);
 
   return (
     (relatedBySubject.length > 0 && (

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -1,9 +1,11 @@
 import { FunctionComponent, useContext, useEffect, useState } from 'react';
 
 import { ServerDataContext } from '@weco/common/server-data/Context';
+import { classNames } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
-import WorksSearchResult from '@weco/content/components/WorksSearchResult'; // temporary
+import Tabs from '@weco/content/components/Tabs';
+import WorksSearchResult from '@weco/content/components/WorksSearchResult'; // TODO temporary
 import { catalogueQuery } from '@weco/content/services/wellcome/catalogue';
 import {
   toWorkBasic,
@@ -120,21 +122,39 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
   }, [selectedWorksTab]);
 
   return (
-    (relatedBySubject.length > 0 && (
-      <Container>
-        <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-          <h2>Related Works</h2>
-          {relatedBySubject.map((result, i) => (
-            <WorksSearchResult
-              work={result}
-              resultPosition={i}
-              key={result.id}
-            />
-          ))}
-        </Space>
-      </Container>
-    )) ||
-    null
+    <Container>
+      <Space $v={{ size: 'l', properties: ['padding-top'] }}>
+        <h2>Related Works</h2>
+        <Tabs
+          tabBehaviour="switch"
+          label="Related works control"
+          selectedTab={selectedWorksTab}
+          items={Object.entries(relatedTabConfig).map(([id, config]) => ({
+            id,
+            url: `#${id}`,
+            text: config.text,
+          }))}
+          setSelectedTab={setSelectedWorksTab}
+          // trackWithSegment
+        />
+        {Object.keys(relatedTabConfig).map(tabKey => (
+          <div
+            key={tabKey}
+            className={classNames({
+              'is-hidden': selectedWorksTab !== tabKey,
+            })}
+          >
+            {relatedWorks[tabKey]?.map((result, i) => (
+              <WorksSearchResult
+                work={result}
+                resultPosition={i}
+                key={result.id}
+              />
+            ))}
+          </div>
+        ))}
+      </Space>
+    </Container>
   );
 };
 

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -159,7 +159,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
             text: config.text,
           }))}
           setSelectedTab={setSelectedWorksTab}
-          // trackWithSegment
+          // TODO trackWithSegment?
         />
         {Object.keys(relatedTabConfig).map(tabKey => (
           <div
@@ -168,6 +168,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
               'is-hidden': selectedWorksTab !== tabKey,
             })}
           >
+            {/* TODO loading icon */}
             {relatedWorks[tabKey]?.map((result, i) => (
               <WorksSearchResult
                 work={result}

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -28,7 +28,7 @@ const getCenturyRange = (
     const centuryStart = Math.floor(year / 100) * 100;
     const centuryEnd = centuryStart + 99;
     return {
-      tabLabel: `From ${centuryStart}`,
+      tabLabel: `From ${centuryStart}s`,
       from: `${centuryStart}-01-01`,
       to: `${centuryEnd}-12-31`,
     };

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -15,6 +15,7 @@ type Props = {
   work: Work;
 };
 
+// TODO may change to century range
 const getDecadeRange = (str: string) => {
   const match = str.match(/^(\d{4})$/);
   if (match) {

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -15,6 +15,21 @@ type Props = {
   work: Work;
 };
 
+const getDecadeRange = (str: string) => {
+  const match = str.match(/^(\d{4})$/);
+  if (match) {
+    const year = parseInt(match[0], 10);
+    const decadeStart = Math.floor(year / 10) * 10;
+    const decadeEnd = decadeStart + 10;
+    return {
+      tabLabel: `From ${decadeStart}`,
+      from: `${decadeStart}-01-01`,
+      to: `${decadeEnd}-12-31`,
+    };
+  }
+  return null;
+};
+
 const fetchRelated = async ({ data, params, setRelated, work }) => {
   const response = await catalogueQuery('works', {
     toggles: data.toggles,

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -43,7 +43,7 @@ const fetchRelated = async ({ data, params, setRelated, work }) => {
   if (response.type === 'ResultList') {
     setRelated(
       response.results
-        .filter(content => content.id !== work.id) // Exclude the current work
+        .filter(result => result.id !== work.id) // Exclude the current work
         .slice(0, 3) // Only show 3 results
         .map(toWorkBasic)
     );

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -132,7 +132,10 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
     const related =
       relatedTabConfig[selectedWorksTab] &&
       relatedTabConfig[selectedWorksTab].related;
-    if (!related || related.some(result => result.id === work.id)) {
+    if (
+      relatedTabConfig[selectedWorksTab] &&
+      (!related || related.some(result => result.id === work.id))
+    ) {
       fetchRelated({
         work,
         serverData,

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, useContext, useEffect, useState } from 'react';
 
 import { ServerDataContext } from '@weco/common/server-data/Context';
+import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { classNames } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
@@ -18,7 +19,9 @@ type Props = {
 };
 
 // TODO may change to century range
-const getDecadeRange = (str: string) => {
+const getDecadeRange = (
+  str: string
+): { tabLabel: string; from: string; to: string } | null => {
   const match = str.match(/^(\d{4})$/);
   if (match) {
     const year = parseInt(match[0], 10);
@@ -33,9 +36,19 @@ const getDecadeRange = (str: string) => {
   return null;
 };
 
-const fetchRelated = async ({ data, params, setRelated, work }) => {
+const fetchRelated = async ({
+  serverData,
+  params,
+  setRelated,
+  work,
+}: {
+  serverData: SimplifiedServerData;
+  params: { [key: string]: string | string[] };
+  setRelated: (results: WorkBasic[]) => void;
+  work: Work;
+}): Promise<void> => {
   const response = await catalogueQuery('works', {
-    toggles: data.toggles,
+    toggles: serverData.toggles,
     pageSize: 4, // In case we get the current work back, we will still have 3 to show
     params: {
       ...params,
@@ -59,7 +72,7 @@ function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
   const config: {
     [key: string]: {
       text: string;
-      params: unknown; // TODO type
+      params: { [key: string]: string | string[] };
       related: WorkBasic[] | undefined;
       setRelated: (results: WorkBasic[]) => void;
     };
@@ -110,12 +123,12 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
   const tabKeys = Object.keys(relatedTabConfig);
   const [selectedWorksTab, setSelectedWorksTab] = useState(tabKeys[0] || '');
 
-  const data = useContext(ServerDataContext);
+  const serverData = useContext(ServerDataContext);
 
   useEffect(() => {
     fetchRelated({
       work,
-      data,
+      serverData,
       params: relatedTabConfig[selectedWorksTab].params,
       setRelated: relatedTabConfig[selectedWorksTab].setRelated,
     });

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -58,8 +58,8 @@ const fetchRelated = async ({
   if (response.type === 'ResultList') {
     setRelated(
       response.results
-        .filter(result => result.id !== work.id) // Exclude the current work
-        .slice(0, 3) // Only show 3 results
+        .filter(result => result.id !== work.id)
+        .slice(0, 3)
         .map(toWorkBasic)
     );
   }
@@ -67,7 +67,7 @@ const fetchRelated = async ({
 
 // Returns a config object for tabs: one per subject label, plus date-range if present
 function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
-  const subjectLabels = work.subjects.map(subject => subject.label);
+  const subjectLabels = work.subjects.map(subject => subject.label).slice(0, 3);
   const dateRange = getDecadeRange(work.production[0].dates[0].label);
   const config: {
     [key: string]: {

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -93,11 +93,9 @@ function getRelatedTabConfig({ work, relatedWorks, setRelatedWorks }) {
   return config;
 }
 const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
-  const [relatedBySubject, setRelatedBySubject] = useState<WorkBasic[]>([]);
-  const subjects = work.subjects.map(subject => subject.label);
-  const bySubjectParams = {
-    'subjects.label': subjects,
-  };
+  const [relatedWorks, setRelatedWorks] = useState<{
+    [key: string]: WorkBasic[] | undefined;
+  }>({});
 
   const data = useContext(ServerDataContext);
 


### PR DESCRIPTION
## What does this change?

For #11767 

- displays related content in tabs
- will show up to 3 subject tabs
- will show a date tab if the date of the work is a 4 digit string, in which case we assume it is a year 
- the date tab will show with results from the same century
- we should only fetch results for a tab if they have not been previously fetched, or if we switch to work in the results list (because we don't want it to be included)

Still a work in progress, so there are a few TODOs floating about. More tabs to add and styling still to be done.
<img width="1095" alt="Screenshot 2025-05-22 at 14 47 01" src="https://github.com/user-attachments/assets/7da0060b-37aa-4dcc-9098-34ad0b08c778" />

## How to test

- with the relatedContentOnWorks toggle off [works pages](http://www-dev.wellcomecollection.org/works/a4ngd332) should appear no differently
- with the relatedContentOnWorks toggle on, [works with subject labels](http://www-dev.wellcomecollection.org/works/a4ngd332) should display related content at the bottom of the page
- with the relatedContentOnWorks toggle on, [works without subject labels or identifiable dates](http://www-dev.wellcomecollection.org/works/gnfmdk33) should not display related content at the bottom of the page

## How can we measure success?

n/a

## Have we considered potential risks?

Behind a toggle so should be good


