### PR TITLE
Related content type/technique

### DIFF
--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -185,12 +185,16 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
     // We pick the first genre label that is we consider to be visual if there is one,
     // otherwise we pick the first genre label.
     if (genresLabels.length > 0) {
-      const id = genresLabels[0].replace(/[^a-zA-Z0-9]/g, '-');
+      const visualGenre = genresLabels.find(label =>
+        visualGenres.includes(label)
+      );
+      const chosenGenre = visualGenre || genresLabels[0];
+      const id = chosenGenre.replace(/[^a-zA-Z0-9]/g, '-');
       setRelatedTabConfig({
         ...relatedTabConfig,
         [`genres-${id}`]: {
-          text: genresLabels[0],
-          params: { 'genres.label': [genresLabels[0]] },
+          text: chosenGenre,
+          params: { 'genres.label': [chosenGenre] },
           aggregations: [],
           related: relatedWorks[`genres-${id}`],
           setRelated: (results: WorkBasic[]) =>

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -36,6 +36,11 @@ const getCenturyRange = (
   return null;
 };
 
+function getGenreLabels(aggregations: unknown): string[] {
+  const buckets = aggregations?.['genres.label']?.buckets ?? [];
+  return buckets.map((bucket: unknown) => bucket?.data?.label); // TODO
+}
+
 const fetchRelated = async ({
   serverData,
   params,

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -18,6 +18,15 @@ type Props = {
   work: Work;
 };
 
+// genres labels we consider visual
+const visualGenres = [
+  'Engravings',
+  'Etchings',
+  'Portrait prints',
+  'Photographs',
+  'Paintings',
+];
+
 // Returns the century range for a string containing exactly four digits
 const getCenturyRange = (
   str: string

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -181,10 +181,9 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
 
   useEffect(() => {
     // Once we have the genres labels from the first api request,
-    // we can update the related tab config to include the first one we consider visual
-    // else just the first one
-    // TODO should we add then together until we have at least 3 results
-
+    // we can update the related tab config to include a genre label tab.
+    // We pick the first genre label that is we consider to be visual if there is one,
+    // otherwise we pick the first genre label.
     if (genresLabels.length > 0) {
       const id = genresLabels[0].replace(/[^a-zA-Z0-9]/g, '-');
       setRelatedTabConfig({

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -19,7 +19,9 @@ type Props = {
 };
 
 // genres labels we consider visual
+// TODO what should be in this list?
 const visualGenres = [
+  'Caricatures',
   'Engravings',
   'Etchings',
   'Portrait prints',

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -196,9 +196,12 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
           text: chosenGenre,
           params: {
             'genres.label': [chosenGenre],
+            // the genres we chose is based on the query using the first subject label as a filter
+            // this is to avoid having to do a another api call filtered by all the subject labels together
+            // so we also filter here by the first subject label as well as the genre label
             'subjects.label': work.subjects
               .map(subject => subject.label)
-              .slice(0, 1), // TODO we only know what the genres are for the first subject unless we make a second api call
+              .slice(0, 1),
           },
           aggregations: [],
           related: relatedWorks[`genres-${id}`],

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -145,7 +145,7 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
   const serverData = useContext(ServerDataContext);
 
   useEffect(() => {
-    // Only fetch if we haven't already fetched results for hte current tab
+    // Only fetch if we haven't already fetched results for the current tab
     // or if the results for the current tab now include the current work
     const related =
       relatedTabConfig[selectedWorksTab] &&

--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -194,7 +194,12 @@ const RelatedWorks: FunctionComponent<Props> = ({ work }) => {
         ...relatedTabConfig,
         [`genres-${id}`]: {
           text: chosenGenre,
-          params: { 'genres.label': [chosenGenre] },
+          params: {
+            'genres.label': [chosenGenre],
+            'subjects.label': work.subjects
+              .map(subject => subject.label)
+              .slice(0, 1), // TODO we only know what the genres are for the first subject unless we make a second api call
+          },
           aggregations: [],
           related: relatedWorks[`genres-${id}`],
           setRelated: (results: WorkBasic[]) =>


### PR DESCRIPTION
## What does this change?

For #11767 

- add a type/technique tab (genres in the API) to the related content tabs 
- we fetch the genres.label aggregations with the api request for the first tab, so we know what genres are available
- we then pick the first genres we consider to be visual if there is one, otherwise we just use the first genres
- when we make a request filtered by the genres we also filter by the first subject label

- Still a work in progress, so there are a few TODOs floating about. Styling still to be done (and possibly the available online tab)
- Needs discussion/agreement about how the type/technique tab is using the first subject label as a filter (not all the subject labels) 
- Need to agree which genres we consider to be visual

<img width="1110" alt="Screenshot 2025-05-22 at 16 55 35" src="https://github.com/user-attachments/assets/6da80d7b-7dc5-4f05-9ad0-015c79759cce" />

## How to test

- with the relatedContentOnWorks toggle off [works pages](http://www-dev.wellcomecollection.org/works/a4ngd332) should appear no differently
- with the relatedContentOnWorks toggle on, [works with subject labels](http://www-dev.wellcomecollection.org/works/a4ngd332) should display related content at the bottom of the page including a type/technique tab - in this case 'Caricatures'
- with the relatedContentOnWorks toggle on, [works without subject labels or identifiable dates](http://www-dev.wellcomecollection.org/works/gnfmdk33) should not display related content at the bottom of the page

## How can we measure success?

n/a

## Have we considered potential risks?

Behind a toggle so should be good



