### PR TITLE
Remove link field in Teams content type

### DIFF
--- a/cardigan/stories/components/Contact/Contact.stories.tsx
+++ b/cardigan/stories/components/Contact/Contact.stories.tsx
@@ -12,10 +12,6 @@ const meta: Meta<typeof Contact> = {
     subtitle: 'Head of Examples',
     phone: '+44 (0)20 7444 4444',
     email: 'j.bloggs@wellcome.ac.uk',
-    link: {
-      text: `Joe's page`,
-      url: '/visit-us',
-    },
   },
 };
 

--- a/cardigan/stories/components/Contact/Contact.stories.tsx
+++ b/cardigan/stories/components/Contact/Contact.stories.tsx
@@ -12,6 +12,10 @@ const meta: Meta<typeof Contact> = {
     subtitle: 'Head of Examples',
     phone: '+44 (0)20 7444 4444',
     email: 'j.bloggs@wellcome.ac.uk',
+    link: {
+      text: `Joe's page`,
+      url: '/visit-us',
+    },
   },
 };
 

--- a/common/customtypes/teams/index.json
+++ b/common/customtypes/teams/index.json
@@ -3,6 +3,7 @@
   "label": "Team",
   "repeatable": true,
   "status": true,
+  "format": "custom",
   "json": {
     "Team": {
       "title": {
@@ -30,14 +31,7 @@
         "config": {
           "label": "Phone"
         }
-      },
-      "url": {
-        "type": "Text",
-        "config": {
-          "label": "URL"
-        }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -5228,17 +5228,6 @@ interface TeamsDocumentData {
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
   phone: prismic.KeyTextField;
-
-  /**
-   * URL field in *Team*
-   *
-   * - **Field Type**: Text
-   * - **Placeholder**: *None*
-   * - **API ID Path**: teams.url
-   * - **Tab**: Team
-   * - **Documentation**: https://prismic.io/docs/field#key-text
-   */
-  url: prismic.KeyTextField;
 }
 
 /**

--- a/content/webapp/components/Contact/index.tsx
+++ b/content/webapp/components/Contact/index.tsx
@@ -1,7 +1,12 @@
+import NextLink from 'next/link';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { email as emailIcon, phone as phoneIcon } from '@weco/common/icons';
+import {
+  email as emailIcon,
+  link as linkIcon,
+  phone as phoneIcon,
+} from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import Icon from '@weco/common/views/components/Icon';
@@ -60,6 +65,11 @@ export type Props = {
   subtitle?: string;
   phone: string;
   email: string;
+  // The link is added manually in code at times, but isn't part of the content model.
+  link?: {
+    text: string;
+    url: string;
+  };
 };
 
 const Contact: FunctionComponent<Props> = ({
@@ -67,6 +77,7 @@ const Contact: FunctionComponent<Props> = ({
   subtitle,
   phone,
   email,
+  link,
 }: Props): ReactElement => {
   return (
     <Wrapper>
@@ -86,6 +97,24 @@ const Contact: FunctionComponent<Props> = ({
             </span>
             <PhoneNumber aria-hidden="true">{phone}</PhoneNumber>
           </div>
+        </WithIconWrapper>
+      )}
+
+      {link && (
+        <WithIconWrapper>
+          <Icon icon={linkIcon} />
+          <NextLink
+            href={{
+              pathname: link.url,
+            }}
+            as={{ pathname: link.url }}
+            passHref
+            legacyBehavior
+          >
+            <a style={{ display: 'block' }} className={font('intr', 4)}>
+              {link.text}
+            </a>
+          </NextLink>
         </WithIconWrapper>
       )}
 

--- a/content/webapp/components/Contact/index.tsx
+++ b/content/webapp/components/Contact/index.tsx
@@ -88,18 +88,6 @@ const Contact: FunctionComponent<Props> = ({
         </TitleWrapper>
       )}
 
-      {phone && (
-        <WithIconWrapper>
-          <Icon icon={phoneIcon} />
-          <div>
-            <span className="visually-hidden">
-              {createScreenreaderLabel(phone)}
-            </span>
-            <PhoneNumber aria-hidden="true">{phone}</PhoneNumber>
-          </div>
-        </WithIconWrapper>
-      )}
-
       {link && (
         <WithIconWrapper>
           <Icon icon={linkIcon} />
@@ -115,6 +103,18 @@ const Contact: FunctionComponent<Props> = ({
               {link.text}
             </a>
           </NextLink>
+        </WithIconWrapper>
+      )}
+
+      {phone && (
+        <WithIconWrapper>
+          <Icon icon={phoneIcon} />
+          <div>
+            <span className="visually-hidden">
+              {createScreenreaderLabel(phone)}
+            </span>
+            <PhoneNumber aria-hidden="true">{phone}</PhoneNumber>
+          </div>
         </WithIconWrapper>
       )}
 

--- a/content/webapp/components/Contact/index.tsx
+++ b/content/webapp/components/Contact/index.tsx
@@ -1,12 +1,7 @@
-import NextLink from 'next/link';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import {
-  email as emailIcon,
-  link as linkIcon,
-  phone as phoneIcon,
-} from '@weco/common/icons';
+import { email as emailIcon, phone as phoneIcon } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import Icon from '@weco/common/views/components/Icon';
@@ -63,10 +58,6 @@ const WithIconWrapper = styled(Space).attrs({
 export type Props = {
   title?: string;
   subtitle?: string;
-  link?: {
-    text: string;
-    url: string;
-  };
   phone: string;
   email: string;
 };
@@ -74,7 +65,6 @@ export type Props = {
 const Contact: FunctionComponent<Props> = ({
   title,
   subtitle,
-  link,
   phone,
   email,
 }: Props): ReactElement => {
@@ -85,24 +75,6 @@ const Contact: FunctionComponent<Props> = ({
           {title && <Title>{title}</Title>}
           {subtitle && <Subtitle>{subtitle}</Subtitle>}
         </TitleWrapper>
-      )}
-
-      {link && (
-        <WithIconWrapper>
-          <Icon icon={linkIcon} />
-          <NextLink
-            href={{
-              pathname: link.url,
-            }}
-            as={{ pathname: link.url }}
-            passHref
-            legacyBehavior
-          >
-            <a style={{ display: 'block' }} className={font('intr', 4)}>
-              {link.text}
-            </a>
-          </NextLink>
-        </WithIconWrapper>
       )}
 
       {phone && (

--- a/content/webapp/services/prismic/transformers/events.ts
+++ b/content/webapp/services/prismic/transformers/events.ts
@@ -121,7 +121,6 @@ function transformBookingEnquiryTeam(
         title: asText(team.data?.title) || '',
         email: team.data!.email!,
         phone: team.data!.phone!,
-        url: team.data!.url!,
       }
     : undefined;
 }

--- a/content/webapp/services/prismic/types/index.ts
+++ b/content/webapp/services/prismic/types/index.ts
@@ -278,7 +278,6 @@ export const teamFetchLinks: FetchLinks<RawTeamsDocument> = [
   'teams.subtitle',
   'teams.email',
   'teams.phone',
-  'teams.url',
 ];
 
 export type WithExhibitionParents = {
@@ -401,7 +400,6 @@ export const teamsFetchLinks: FetchLinks<RawTeamsDocument> = [
   'teams.subtitle',
   'teams.email',
   'teams.phone',
-  'teams.url',
 ];
 
 export const pageFormatsFetchLinks: FetchLinks<RawPageFormatsDocument> = [

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -47,7 +47,7 @@ export type Team = {
   title: string;
   email: string;
   phone: string;
-  url: string;
+  url?: string;
 };
 
 export type Audience = {


### PR DESCRIPTION
## What does this change?

I think this had been broken for a _while_. The FE expects a hyperlink field and the content type field was a text field? It didn't work. And anyway only one or two Teams document had something in that field, which hadn't rendered them out (it's not in the transformer either!) in I don't know how long.

It seems we do add pass a link to the Contact component, but manually, directly from the codebase [in one instance](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/Exhibition/index.tsx#L600-L604). It might not be a debatable use since it's only once but 🤷‍♀️ 

So am removing from the model since it didn't work anyway.


## How to test

Does it seem to break anything?

## How can we measure success?

Less unused fields/confusing code

## Have we considered potential risks?

Editorial are sad about not having the field; we re-add in and properly render it.
