### PR TITLE
filter date results by the same subject labels the current work has

### DIFF
--- a/content/webapp/components/RelatedWorks.tsx
+++ b/content/webapp/components/RelatedWorks.tsx
@@ -153,6 +153,7 @@ async function getRelatedTabConfig({
     config['date-range'] = {
       text: dateRange.tabLabel,
       params: {
+        'subjects.label': subjectLabels.map(label => `"${label}"`),
         'production.dates.from': dateRange.from,
         'production.dates.to': dateRange.to,
       },


### PR DESCRIPTION
## What does this change?

For [#11964](https://github.com/wellcomecollection/wellcomecollection.org/issues/11964)

Uses the current work's subject labels as a filter when fetching the content for the date tab, as specified in the [figma design files](https://www.figma.com/design/6ZvjrD9yhBBZSAXENc8vK4/Related-content-on-Works-pages?node-id=706-11755&m=dev)

## How to test
- turn on the relatedContentOnWorks toggle
- open the network tab in dev tools
- visit [a work with a date tab](http://www-dev.wellcomecollection.org/works/y9t4zfsh)
-  click on the date tab and see that the network request it initiates includes the subject labels as parameters

## How can we measure success?
n/a

## Have we considered potential risks?
None really. This work is behind a toggle and is an MVP to aid further research/discussion/development

