### PR TITLE
Add tags and siteSection to parentPages

### DIFF
--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -72,6 +72,8 @@ type OrderInParent = {
   uid: string;
   title: string;
   order: number;
+  tags?: string[];
+  siteSection?: SiteSection;
   type: 'pages' | 'exhibitions';
 };
 
@@ -181,6 +183,8 @@ export const getServerSideProps: GetServerSideProps<
           title: p.title,
           order: p.order,
           type: p.type,
+          tags: p.tags,
+          siteSection: p.siteSection,
         };
       }) || [];
 

--- a/content/webapp/services/prismic/transformers/pages.ts
+++ b/content/webapp/services/prismic/transformers/pages.ts
@@ -51,6 +51,8 @@ export function transformPage(document: RawPagesDocument): Page {
           ...transformPage(parent as RawPagesDocument),
           order: data.parents[index].order!,
           type: parent.type,
+          tags: parent.tags,
+          siteSection: parent.siteSection,
         };
       })
     : [];

--- a/content/webapp/types/pages.ts
+++ b/content/webapp/types/pages.ts
@@ -11,6 +11,7 @@ import { Season } from './seasons';
 export type ParentPage = Page & {
   order: number;
   type: 'pages' | 'exhibitions';
+  tags?: string[];
 };
 
 export type Page = GenericContentFields & {


### PR DESCRIPTION
## What does this change?
The [linkResolver](https://github.com/wellcomecollection/wellcomecollection.org/blob/0cb4e0aeb1f8a2328de6961ac0aa8d534120f194/common/services/prismic/link-resolver.ts#L85-L93) gets information from a page's `siteSection` and `tags`, but we don't currently store these things on `page.parentPages` so we're not handling certain breadcrumbs correctly (#11982).

## How to test
Check the 'Library and facilities' link in the breadcrumb correctly includes `/collections` in it's URL for these pages
- http://localhost:3000/collections/study-rooms
- http://localhost:3000/collections/computers--printing-and-wifi
- http://localhost:3000/collections/copying-and-photography

## How can we measure success?
Links don't 404

## Have we considered potential risks?
Can't think of any