### PR TITLE
Remove newTags toggle

### DIFF
--- a/cache/edge_lambdas/src/toggler.ts
+++ b/cache/edge_lambdas/src/toggler.ts
@@ -23,16 +23,7 @@ type Test = {
 // This is mutable for testing
 // Any test toggles included here also have to be included in the toggles dir
 // because they are deployed separately and consequently can't share a source of truth
-export let tests: Test[] = [
-  {
-    id: 'newTags',
-    title: 'A/B test for new tags',
-    range: [0, 100],
-    when: request => {
-      return !!request.uri.match(/^\/works\/[^/]+$/); // /works/someid but not /works/someid/otherpath
-    },
-  },
-];
+export let tests: Test[] = [];
 
 export const setTests = function (newTests: Test[]): void {
   tests = newTests;

--- a/content/webapp/components/WorkDetails/WorkDetails.Tags.tsx
+++ b/content/webapp/components/WorkDetails/WorkDetails.Tags.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from 'react';
 
-import { useToggles } from '@weco/common/server-data/Context';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import Tags, { Props as TagsProps } from '@weco/content/components/Tags';
@@ -13,8 +12,6 @@ const WorkDetailsTags: FunctionComponent<Props> = ({
   title,
   ...tagsProps
 }: Props) => {
-  const { newTags } = useToggles();
-
   return (
     <WorkDetailsProperty title={title}>
       <ConditionalWrapper
@@ -31,7 +28,7 @@ const WorkDetailsTags: FunctionComponent<Props> = ({
           </Space>
         )}
       >
-        <Tags {...tagsProps} isABTestWorkTag={newTags} />
+        <Tags {...tagsProps} />
       </ConditionalWrapper>
     </WorkDetailsProperty>
   );

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -116,14 +116,7 @@ const toggles = {
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth
-  tests: [
-    {
-      id: 'newTags',
-      title: 'A/B test for new tags',
-      type: 'test',
-      range: [0, 100],
-    },
-  ] as ABTest[],
+  tests: [] as ABTest[],
 };
 
 export default toggles;


### PR DESCRIPTION
## What does this change?
Removing the toggle and the code that responds to it

## How to test
Visit a page with tags. You should have the old tags regardless of whether you have the `toggle_newTags` cookies set

## How can we measure success?
n/a

## Have we considered potential risks?
n/a