### PR TITLE
Related works

### DIFF
--- a/content/webapp/components/BetaMessage/index.tsx
+++ b/content/webapp/components/BetaMessage/index.tsx
@@ -11,8 +11,6 @@ const StyledBetaMessage = styled.div.attrs({
 })`
   display: flex;
   align-items: center;
-  border-left: ${props => `4px solid ${props.theme.color('accent.purple')}`};
-  padding-left: ${props => props.theme.spacingUnit}px;
 `;
 
 type Props = { message: string | ReactNode };

--- a/content/webapp/components/RelatedWorks/index.tsx
+++ b/content/webapp/components/RelatedWorks/index.tsx
@@ -62,7 +62,7 @@ const RelatedWorks = ({ work }: { work: Work }) => {
     <>
       <Container>
         <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-          <h2>Related Works</h2>
+          <h2>Related works</h2>
         </Space>
 
         {Object.keys(relatedWorksTabs).length > 1 && (

--- a/content/webapp/components/RelatedWorks/index.tsx
+++ b/content/webapp/components/RelatedWorks/index.tsx
@@ -6,6 +6,7 @@ import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
+import BetaMessage from '@weco/content/components/BetaMessage';
 import Tabs from '@weco/content/components/Tabs';
 import {
   Work,
@@ -62,7 +63,7 @@ const RelatedWorks = ({ work }: { work: Work }) => {
     <>
       <Container>
         <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-          <h2>Related works</h2>
+          <h2>More works</h2>
         </Space>
 
         {Object.keys(relatedWorksTabs).length > 1 && (
@@ -98,6 +99,20 @@ const RelatedWorks = ({ work }: { work: Work }) => {
                 </GridCell>
               ))}
             </Grid>
+
+            <Space $v={{ size: 'l', properties: ['margin-top'] }}>
+              <BetaMessage
+                message={
+                  <>
+                    This is a beta feature.{' '}
+                    <a href="mailto:digital@welllcomecollection.org">
+                      Send us your feedback
+                    </a>{' '}
+                    to help us improve
+                  </>
+                }
+              />
+            </Space>
           </Container>
         </FullWidthRow>
       ))}


### PR DESCRIPTION
## What does this change?

- Adds the BetaMessage below the related cards
- Restyles the BetaMessage to remove the left border

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/cf3b58ce-f5b6-4c5d-af59-79b347a03ccf" />

## How to test

Does the message appear, does the email address link to the right place (digital@wellcomecollection.org)? Does the copy need updating cc. @LaurenFBaily 

## How can we measure success?
People know that this is new and being tested and have an opportunity to feedback (maybe)

## Have we considered potential risks?
n/a