### PR TITLE
Update "sticky" in page navigation post-QA

### DIFF
--- a/cardigan/stories/components/OnThisPageAnchors/Sticky.stories.tsx
+++ b/cardigan/stories/components/OnThisPageAnchors/Sticky.stories.tsx
@@ -29,13 +29,11 @@ const BackgroundGrid = styled(Grid).attrs({})<BackgroundGridProps>`
 `;
 
 const OnThisPageAnchorsInColsContext: FunctionComponent<{
-  activeColor: PaletteColor;
   topColor?: PaletteColor;
 }> = args => {
   const fixedArgs = {
     isSticky: true,
     hasBackgroundBlend: true,
-    activeColor: args.activeColor,
     links,
   };
 
@@ -95,15 +93,9 @@ type Story = StoryObj<typeof OnThisPageAnchorsInColsContext>;
 export const SideBar: Story = {
   name: 'Sticky',
   args: {
-    activeColor: 'accent.lightGreen',
     topColor: 'neutral.700',
   },
   argTypes: {
-    activeColor: {
-      control: 'select',
-      options: themeColors.map(c => c.name),
-      description: 'Color used for the active link',
-    },
     topColor: {
       control: 'select',
       options: themeColors.map(c => c.name),

--- a/cardigan/stories/components/OnThisPageAnchors/Sticky.stories.tsx
+++ b/cardigan/stories/components/OnThisPageAnchors/Sticky.stories.tsx
@@ -59,7 +59,14 @@ const OnThisPageAnchorsInColsContext: FunctionComponent<{
                 marginBottom: '16px',
               }}
             >
-              <h2 id={link.url.replace('#', '')}>{link.text}</h2>
+              <h2
+                id={link.url.replace('#', '')}
+                style={{
+                  scrollMarginTop: '1rem',
+                }}
+              >
+                {link.text}
+              </h2>
               <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
                 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -12,7 +12,6 @@ import { Link } from '@weco/content/types/link';
 const ListItem = styled.li<{
   $isActive?: boolean;
   $isSticky?: boolean;
-  $activeColor?: PaletteColor;
 }>`
   ${props =>
     props.$isSticky
@@ -29,7 +28,8 @@ const ListItem = styled.li<{
     top: 0;
     bottom: 0;
     width: ${props.$isActive ? '3px' : '1px'};
-    background: ${props.theme.color((props.$isActive && props.$activeColor) || 'black')};
+    height: 100%;
+    background: ${props.theme.color((props.$isActive && 'white') || 'black')};
   }
 `
       : ''}
@@ -101,7 +101,6 @@ export type Props = {
 const OnThisPageAnchors: FunctionComponent<Props> = ({
   isSticky = false,
   hasBackgroundBlend = false,
-  activeColor,
   links,
 }) => {
   // Extract ids from links (strip leading #)
@@ -155,17 +154,13 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
           const id = link.url.replace('#', '');
           const isActive = activeId === id;
           return (
-            <ListItem
-              key={link.url}
-              $isActive={isActive}
-              $isSticky={isSticky}
-              $activeColor={activeColor}
-            >
+            <ListItem key={link.url} $isActive={isActive} $isSticky={isSticky}>
               {isSticky ? (
                 <NextLink
                   passHref
                   style={{ textDecoration: 'none' }}
                   href={link.url}
+                  data-gtm-trigger="link_click_page_position"
                   onClick={e => {
                     e.preventDefault();
                     setClickedId(id);

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -13,12 +13,7 @@ import { Link } from '@weco/content/types/link';
 // Used to set the left offset for the active indicator line in sticky mode
 const leftOffset = '12px';
 
-const ListItem = styled.li<{
-  $isSticky?: boolean;
-}>`
-  ${props =>
-    props.$isSticky
-      ? `
+const ListItem = styled.li`
   position: relative;
   padding-left: ${leftOffset};
   padding-bottom: 6px;
@@ -32,10 +27,8 @@ const ListItem = styled.li<{
     bottom: 0;
     width: 1px;
     height: 100%;
-    background: ${props.theme.color('black')};
+    background: ${props => props.theme.color('black')};
   }
-`
-      : ''}
 `;
 
 
@@ -73,6 +66,7 @@ const InPageNavAnimatedLink = styled(AnimatedLink)<{
   color: ${props =>
     props.$hasBackgroundBlend ? props.theme.color('white') : 'inherit'};
   position: relative;
+  --background-size: ${props => (props.$isActive ? '0%' : '100%')};
   &::before {
     content: '';
     display: ${props => (props.$isActive ? 'block' : 'none')};
@@ -164,46 +158,49 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
     <Root $isSticky={isSticky} $hasBackgroundBlend={hasBackgroundBlend}>
       <h2 className={fontStyle}>{titleText}</h2>
 
-      <PlainList>
+      
         {links.map((link: Link) => {
           const id = link.url.replace('#', '');
           const isActive = activeId === id;
           return (
-            <ListItem key={link.url} $isSticky={isSticky}>
+            <PlainList>
               {isSticky ? (
-                <NextLink
-                  passHref
-                  style={{ textDecoration: 'none' }}
-                  href={link.url}
-                  data-gtm-trigger="link_click_page_position"
-                  onClick={e => {
-                    e.preventDefault();
-                    setClickedId(id);
-                    const el = document.getElementById(id);
-                    if (el) {
-                      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    }
-                  }}
-                >
-                  <InPageNavAnimatedLink
-                    $isActive={isActive}
-                    $hasBackgroundBlend={hasBackgroundBlend}
+                <ListItem key={link.url}>
+                  <NextLink
+                    passHref
+                    style={{ textDecoration: 'none' }}
+                    href={link.url}
+                    data-gtm-trigger="link_click_page_position"
+                    onClick={e => {
+                      e.preventDefault();
+                      setClickedId(id);
+                      const el = document.getElementById(id);
+                      if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                      }
+                    }}
                   >
-                    <span>{link.text}</span>
-                  </InPageNavAnimatedLink>
-                </NextLink>
+                    <InPageNavAnimatedLink
+                      $isActive={isActive}
+                      $hasBackgroundBlend={hasBackgroundBlend}
+                    >
+                      <span>{link.text}</span>
+                    </InPageNavAnimatedLink>
+                  </NextLink>
+                </ListItem>
               ) : (
-                <Anchor
-                  data-gtm-trigger="link_click_page_position"
-                  href={link.url}
-                >
-                  {link.text}
-                </Anchor>
+                <li>
+                  <Anchor
+                    data-gtm-trigger="link_click_page_position"
+                    href={link.url}
+                  >
+                    {link.text}
+                  </Anchor>
+                </li>
               )}
-            </ListItem>
+            </PlainList>
           );
         })}
-      </PlainList>
     </Root>
   );
 };

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -69,14 +69,15 @@ const InPageNavAnimatedLink = styled(AnimatedLink)<{
   --background-size: ${props => (props.$isActive ? '0%' : '100%')};
   &::before {
     content: '';
-    display: ${props => (props.$isActive ? 'block' : 'none')};
     position: absolute;
     left: -${leftOffset};
-    top: 0;
-    bottom: 0;
-    width: 3px;
+    top: 0px;
     height: 100%;
+    width: 3px;
     background: ${props => props.theme.color('white')};
+    opacity: ${props => (props.$isActive ? 1 : 0)};
+    transform: scaleY(${props => (props.$isActive ? 1 : 0.5)});
+    transition: opacity 0.3s, transform 0.3s;
   }
 `;
 

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -39,9 +39,9 @@ const AnimatedLink = styled.a`
   position: relative;
   & > span {
     background-image: linear-gradient(0deg, var(--line) 0%, var(--line) 100%);
-    background-position: 100% 100%;
+    background-position: 0% 100%;
     background-repeat: no-repeat;
-    background-size: var(--background-size, 100%) 2px;
+    background-size: var(--background-size, 0%) 2px;
     transition: background-size 0.2s linear 300ms;
     font-size: 14px;
     line-height: 20px;
@@ -49,7 +49,7 @@ const AnimatedLink = styled.a`
     padding-bottom: 2px;
   }
   &:hover {
-    --background-size: 0%;
+    --background-size: 100%;
   }
 `;
 
@@ -66,7 +66,7 @@ const InPageNavAnimatedLink = styled(AnimatedLink)<{
   color: ${props =>
     props.$hasBackgroundBlend ? props.theme.color('white') : 'inherit'};
   position: relative;
-  --background-size: ${props => (props.$isActive ? '0%' : '100%')};
+
   &::before {
     content: '';
     position: absolute;

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -68,6 +68,7 @@ const InPageNavAnimatedLink = styled(AnimatedLink)<{
   color: ${props =>
     props.$hasBackgroundBlend ? props.theme.color('white') : 'inherit'};
   font-weight: ${props => (props.$isActive ? 'bold' : 'normal')};
+  ${props => (props.$isActive ? '--background-size: 0%;' : '')}
 `;
 
 const stickyRootAttrs = `

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -157,7 +157,14 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
                 $isActive={isActive}
                 $hasBackgroundBlend={hasBackgroundBlend}
                 $isSticky={isSticky}
-                onClick={() => setClickedId(id)}
+                onClick={e => {
+                  e.preventDefault();
+                  setClickedId(id);
+                  const el = document.getElementById(id);
+                  if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                  }
+                }}
               >
                 {link.text}
               </Anchor>

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -45,7 +45,7 @@ const AnimatedLink = styled.a`
     background-repeat: no-repeat;
     background-size: var(--background-size, 100%) 2px;
     transition: background-size 0.2s linear 300ms;
-    font-size: 16px;
+    font-size: 14px;
     line-height: 20px;
     transform: translateZ(0);
     padding-bottom: 2px;
@@ -67,7 +67,6 @@ const InPageNavAnimatedLink = styled(AnimatedLink)<{
 }>`
   color: ${props =>
     props.$hasBackgroundBlend ? props.theme.color('white') : 'inherit'};
-  font-weight: ${props => (props.$isActive ? 'bold' : 'normal')};
   ${props => (props.$isActive ? '--background-size: 0%;' : '')}
 `;
 
@@ -143,7 +142,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
   }, [activeId]);
 
   const titleText = isSticky ? 'On this page' : 'What’s on this page';
-  const fontStyle = isSticky ? font('intr', 4) : font('wb', 4);
+  const fontStyle = isSticky ? font('intm', 5) : font('wb', 4);
 
   return (
     <Root $isSticky={isSticky} $hasBackgroundBlend={hasBackgroundBlend}>

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -9,32 +9,37 @@ import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import { Link } from '@weco/content/types/link';
 
+
+// Used to set the left offset for the active indicator line in sticky mode
+const leftOffset = '12px';
+
 const ListItem = styled.li<{
-  $isActive?: boolean;
   $isSticky?: boolean;
 }>`
   ${props =>
     props.$isSticky
       ? `
   position: relative;
-  padding-left: 12px;
+  padding-left: ${leftOffset};
   padding-bottom: 6px;
   padding-top: 6px;
   &::before {
     content: '';
     display: block;
     position: absolute;
-    left: ${props.$isActive ? '0px' : '1px'};
+    left: 1px;
     top: 0;
     bottom: 0;
-    width: ${props.$isActive ? '3px' : '1px'};
+    width: 1px;
     height: 100%;
-    background: ${props.theme.color((props.$isActive && 'white') || 'black')};
+    background: ${props.theme.color('black')};
   }
 `
       : ''}
 `;
 
+
+// If used elsewhere, this could be extracted to a shared styled component
 const AnimatedLink = styled.a`
   --line: ${props => props.theme.color('white')};
   text-decoration: none;
@@ -67,7 +72,18 @@ const InPageNavAnimatedLink = styled(AnimatedLink)<{
 }>`
   color: ${props =>
     props.$hasBackgroundBlend ? props.theme.color('white') : 'inherit'};
-  ${props => (props.$isActive ? '--background-size: 0%;' : '')}
+  position: relative;
+  &::before {
+    content: '';
+    display: ${props => (props.$isActive ? 'block' : 'none')};
+    position: absolute;
+    left: -${leftOffset};
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    height: 100%;
+    background: ${props => props.theme.color('white')};
+  }
 `;
 
 const stickyRootAttrs = `
@@ -153,7 +169,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
           const id = link.url.replace('#', '');
           const isActive = activeId === id;
           return (
-            <ListItem key={link.url} $isActive={isActive} $isSticky={isSticky}>
+            <ListItem key={link.url} $isSticky={isSticky}>
               {isSticky ? (
                 <NextLink
                   passHref

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -1,3 +1,4 @@
+import NextLink from 'next/link';
 import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -34,32 +35,39 @@ const ListItem = styled.li<{
       : ''}
 `;
 
-const Anchor = styled.a.attrs<{
-  $isActive?: boolean;
-  $hasBackgroundBlend?: boolean;
-  $isSticky?: boolean;
-}>(props => ({
-  className:
-    props.$isSticky && !props.$isActive ? font('intr', 5) : font('intb', 5),
-}))<{
-  $isActive?: boolean;
-  $hasBackgroundBlend?: boolean;
-  $isSticky?: boolean;
-}>`
-  ${props =>
-    props.$hasBackgroundBlend
-      ? `
-    color: ${props.theme.color('white')};
-    `
-      : ''}
+const AnimatedLink = styled.a`
+  --line: ${props => props.theme.color('white')};
+  text-decoration: none;
+  position: relative;
+  & > span {
+    background-image: linear-gradient(0deg, var(--line) 0%, var(--line) 100%);
+    background-position: 100% 100%;
+    background-repeat: no-repeat;
+    background-size: var(--background-size, 100%) 2px;
+    transition: background-size 0.2s linear 300ms;
+    font-size: 16px;
+    line-height: 20px;
+    transform: translateZ(0);
+    padding-bottom: 2px;
+  }
+  &:hover {
+    --background-size: 0%;
+  }
+`;
 
-  ${props =>
-    props.$isSticky
-      ? `
-    text-decoration: ${props.$isActive ? 'none' : 'underline'};
-    text-underline-position: under;
-    `
-      : ''}
+const Anchor = styled.a.attrs({
+  className: font('intb', 5),
+})`
+  color: ${props => props.theme.color('black')};
+`;
+
+const InPageNavAnimatedLink = styled(AnimatedLink)<{
+  $isActive?: boolean;
+  $hasBackgroundBlend?: boolean;
+}>`
+  color: ${props =>
+    props.$hasBackgroundBlend ? props.theme.color('white') : 'inherit'};
+  font-weight: ${props => (props.$isActive ? 'bold' : 'normal')};
 `;
 
 const stickyRootAttrs = `
@@ -140,6 +148,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
   return (
     <Root $isSticky={isSticky} $hasBackgroundBlend={hasBackgroundBlend}>
       <h2 className={fontStyle}>{titleText}</h2>
+
       <PlainList>
         {links.map((link: Link) => {
           const id = link.url.replace('#', '');
@@ -151,23 +160,35 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
               $isSticky={isSticky}
               $activeColor={activeColor}
             >
-              <Anchor
-                data-gtm-trigger="link_click_page_position"
-                href={link.url}
-                $isActive={isActive}
-                $hasBackgroundBlend={hasBackgroundBlend}
-                $isSticky={isSticky}
-                onClick={e => {
-                  e.preventDefault();
-                  setClickedId(id);
-                  const el = document.getElementById(id);
-                  if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                  }
-                }}
-              >
-                {link.text}
-              </Anchor>
+              {isSticky ? (
+                <NextLink
+                  passHref
+                  style={{ textDecoration: 'none' }}
+                  href={link.url}
+                  onClick={e => {
+                    e.preventDefault();
+                    setClickedId(id);
+                    const el = document.getElementById(id);
+                    if (el) {
+                      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }
+                  }}
+                >
+                  <InPageNavAnimatedLink
+                    $isActive={isActive}
+                    $hasBackgroundBlend={hasBackgroundBlend}
+                  >
+                    <span>{link.text}</span>
+                  </InPageNavAnimatedLink>
+                </NextLink>
+              ) : (
+                <Anchor
+                  data-gtm-trigger="link_click_page_position"
+                  href={link.url}
+                >
+                  {link.text}
+                </Anchor>
+              )}
             </ListItem>
           );
         })}


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/11951, implements changes from QA as described here: https://github.com/wellcomecollection/wellcomecollection.org/issues/11977


https://github.com/user-attachments/assets/43cc4148-e9c1-4bac-b592-33ab21731da0

Issues addressed:

- [x] Smooth scrolling animation when nav link clicked.
- [x] Increase the space above the section and the top of the page when navigating (demo only, can't be enforced in component).
- [x] Underline animation on link hover (re-use of previous animation styles by @rcantin-w)
- [x] Various font weight and size changes
- [x] Active highlight indicator same size as text container excluding padding

Issues not addressed:

 - Component renaming: This should be done separately if we're going to do it as it updates the name of an existing component.

## How to test

[Review the component in Cardigan](https://62f13cdbd0ff140768a8d87b-lkjzfwdlqx.chromatic.com/?path=/story/components-onthispageanchors--side-bar).

- [ ] Re-QA the issues addressed above, have things being satisfactorily resolved?

## How can we measure success?

Some really jolly nice in-page navigation.

## Have we considered potential risks?

This change is not (yet) added to a page so should be minimal. We should check instances of the existing component are un-impacted.
