### PR TITLE
Related works tweaks/fixes

### DIFF
--- a/content/webapp/components/RelatedWorks/RelatedWorks.Card.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.Card.tsx
@@ -66,28 +66,6 @@ const RelatedWorksCard: FunctionComponent<Props> = ({ work, resultIndex }) => {
             />
           </ImageWrapper>
         )}
-        {resultIndex === 0 && (
-          // Because we use `object-fit` on the image, border-radius won't work consistently, so we have to add an svg filter
-          // This is adapted from https://stackoverflow.com/questions/49567069/image-rounded-corners-issue-with-object-fit-contain/76106794#76106794
-          <svg style={{ visibility: 'hidden' }} width="0" height="0">
-            <defs>
-              <filter id="border-radius-mask">
-                <feGaussianBlur
-                  in="SourceGraphic"
-                  stdDeviation="2"
-                  result="blur"
-                />
-                <feColorMatrix
-                  in="blur"
-                  mode="matrix"
-                  values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 100 -50"
-                  result="mask"
-                />
-                <feComposite in="SourceGraphic" in2="mask" operator="atop" />
-              </filter>
-            </defs>
-          </svg>
-        )}
       </Card>
     </WorkLink>
   );

--- a/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
@@ -46,8 +46,16 @@ export const fetchRelatedWorks = async ({
   } = {};
 
   const subjectLabels = work.subjects.map(subject => subject.label).slice(0, 3);
-  const typeTechniques = work.genres.map(genres => genres.label).slice(0, 3);
-  const dateRange = getCenturyRange(work.production[0]?.dates[0]?.label);
+  const hasSubjectLabels = subjectLabels.length > 0;
+
+  // Only fetch type/techniques and date range if there are subject labels,
+  // otherwise results are too generic.
+  const typeTechniques = hasSubjectLabels
+    ? work.genres.map(genres => genres.label).slice(0, 3)
+    : undefined;
+  const dateRange = hasSubjectLabels
+    ? getCenturyRange(work.production[0]?.dates[0]?.label)
+    : undefined;
 
   const catalogueBasicQuery = async (
     params

--- a/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
@@ -37,9 +37,12 @@ export const fetchRelatedWorks = async ({
   work: Work;
   toggles: Toggles;
   setIsLoading: (isLoading: boolean) => void;
-}): Promise<{
-  [key: string]: { label: string; results: WorkBasic[] };
-}> => {
+}): Promise<
+  | {
+      [key: string]: { label: string; results: WorkBasic[] };
+    }
+  | undefined
+> => {
   setIsLoading(true);
   const results: {
     [key: string]: { label: string; results: WorkBasic[] };
@@ -115,16 +118,20 @@ export const fetchRelatedWorks = async ({
           ]
         : []),
 
-      ...typeTechniques.map(async label => {
-        const response = await catalogueBasicQuery({
-          'subjects.label': subjectLabels.map(
-            subjectLabel => `"${subjectLabel}"`
-          ),
-          'genres.label': [`"${label}"`],
-        });
+      ...(typeTechniques
+        ? [
+            typeTechniques.map(async label => {
+              const response = await catalogueBasicQuery({
+                'subjects.label': subjectLabels.map(
+                  subjectLabel => `"${subjectLabel}"`
+                ),
+                'genres.label': [`"${label}"`],
+              });
 
-        addToResultsObject('type', label, response);
-      }),
+              addToResultsObject('type', label, response);
+            }),
+          ]
+        : []),
     ]);
   } catch (error) {
     console.error('Error fetching related works:', error);

--- a/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
@@ -54,7 +54,7 @@ export const fetchRelatedWorks = async ({
   // Only fetch type/techniques and date range if there are subject labels,
   // otherwise results are too generic.
   const typeTechniques = hasSubjectLabels
-    ? work.genres.map(genres => genres.label).slice(0, 3)
+    ? work.genres.map(genres => genres.label).slice(0, 2)
     : undefined;
   const dateRange = hasSubjectLabels
     ? getCenturyRange(work.production[0]?.dates[0]?.label)
@@ -119,18 +119,16 @@ export const fetchRelatedWorks = async ({
         : []),
 
       ...(typeTechniques
-        ? [
-            typeTechniques.map(async label => {
-              const response = await catalogueBasicQuery({
-                'subjects.label': subjectLabels.map(
-                  subjectLabel => `"${subjectLabel}"`
-                ),
-                'genres.label': [`"${label}"`],
-              });
+        ? typeTechniques.map(async label => {
+            const response = await catalogueBasicQuery({
+              'subjects.label': subjectLabels.map(
+                subjectLabel => `"${subjectLabel}"`
+              ),
+              'genres.label': [`"${label}"`],
+            });
 
-              addToResultsObject('type', label, response);
-            }),
-          ]
+            addToResultsObject('type', label, response);
+          })
         : []),
     ]);
   } catch (error) {

--- a/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx
@@ -122,6 +122,10 @@ export const fetchRelatedWorks = async ({
     console.error('Error fetching related works:', error);
   }
 
+  if (Object.keys(results).length === 0) {
+    return undefined;
+  }
+
   // Order object keys to ensure consistent order
   const orderedKeys = Object.keys(results).sort((a, b) => {
     const order = ['subject-', 'date-range', 'type-'];

--- a/content/webapp/components/RelatedWorks/index.tsx
+++ b/content/webapp/components/RelatedWorks/index.tsx
@@ -116,6 +116,27 @@ const RelatedWorks = ({ work }: { work: Work }) => {
           </Container>
         </FullWidthRow>
       ))}
+
+      {/* Because we use `object-fit` on the image, border-radius won't work consistently, so we have to add an svg filter
+           This is adapted from https://stackoverflow.com/questions/49567069/image-rounded-corners-issue-with-object-fit-contain/76106794#76106794 */}
+      <svg
+        style={{ position: 'absolute', visibility: 'hidden' }}
+        width="0"
+        height="0"
+      >
+        <defs>
+          <filter id="border-radius-mask">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur" />
+            <feColorMatrix
+              in="blur"
+              mode="matrix"
+              values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 100 -50"
+              result="mask"
+            />
+            <feComposite in="SourceGraphic" in2="mask" operator="atop" />
+          </filter>
+        </defs>
+      </svg>
     </>
   ) : null;
 };

--- a/content/webapp/components/RelatedWorks/index.tsx
+++ b/content/webapp/components/RelatedWorks/index.tsx
@@ -24,6 +24,7 @@ const RelatedWorks = ({ work }: { work: Work }) => {
     [key: string]: { label: string; results: WorkBasic[] };
   }>();
   const [selectedTab, setSelectedTab] = useState<string | undefined>();
+  const [hasThumbnails, setHasThumbnails] = useState(false);
 
   useEffect(() => {
     setIsLoading(true);
@@ -37,6 +38,12 @@ const RelatedWorks = ({ work }: { work: Work }) => {
         setIsLoading,
       }).then(data => {
         setRelatedWorksTabs(data);
+        if (data)
+          setHasThumbnails(
+            Object.values(data).some(tab =>
+              tab.results.some(result => result.thumbnail?.url)
+            )
+          );
 
         setIsLoading(false);
       });
@@ -117,26 +124,32 @@ const RelatedWorks = ({ work }: { work: Work }) => {
         </FullWidthRow>
       ))}
 
-      {/* Because we use `object-fit` on the image, border-radius won't work consistently, so we have to add an svg filter
-           This is adapted from https://stackoverflow.com/questions/49567069/image-rounded-corners-issue-with-object-fit-contain/76106794#76106794 */}
-      <svg
-        style={{ position: 'absolute', visibility: 'hidden' }}
-        width="0"
-        height="0"
-      >
-        <defs>
-          <filter id="border-radius-mask">
-            <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur" />
-            <feColorMatrix
-              in="blur"
-              mode="matrix"
-              values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 100 -50"
-              result="mask"
-            />
-            <feComposite in="SourceGraphic" in2="mask" operator="atop" />
-          </filter>
-        </defs>
-      </svg>
+      {hasThumbnails && (
+        // Because we use `object-fit` on the image, border-radius won't work consistently, so we have to add an svg filter
+        //  This is adapted from https://stackoverflow.com/questions/49567069/image-rounded-corners-issue-with-object-fit-contain/76106794#76106794
+        <svg
+          style={{ position: 'absolute', visibility: 'hidden' }}
+          width="0"
+          height="0"
+        >
+          <defs>
+            <filter id="border-radius-mask">
+              <feGaussianBlur
+                in="SourceGraphic"
+                stdDeviation="2"
+                result="blur"
+              />
+              <feColorMatrix
+                in="blur"
+                mode="matrix"
+                values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 100 -50"
+                result="mask"
+              />
+              <feComposite in="SourceGraphic" in2="mask" operator="atop" />
+            </filter>
+          </defs>
+        </svg>
+      )}
     </>
   ) : null;
 };


### PR DESCRIPTION
## What does this change?

- Realised the `catalogueBasicQuery` helper returned `{}` when no results came up where it's better if it returns `undefined`, so fixed that. I can't remember the work that made me realise it was an issue, sorry 🙈 but the fix makes sense still.
- Moved the `SVG` so it's only injected once **per component** (so could still be injected more than once should we have the component more than once on the page. Doesn't currently happen, but something I'm thinking about!), instead of once per tab. It also checks first if any works has a thumbnail image and is therefore needed. Added positioned it absolute otherwise it added a space even though it was `0x0` in width/height 🤷‍♀️ 
- After chatting with Lauren, Type/Techniques and date range queries only happen if there is at least one subject label. Sorry if I changed that from the original logic when I changed how we fetched things!
- Fetches only 2 types, I think that was lost in a merge previously but was agreed upon.

## How to test

- https://www-dev.wellcomecollection.org/works/apvartqz has a valid year and a technique, but no subject label. The results were too generic, it should now not display anything.
- https://www-dev.wellcomecollection.org/works/a227y9ye currently displays date range results, it should now return nothing.
- https://www-dev.wellcomecollection.org/works/a2239muq should still have rounded borders on images (any work with thumbnails should!). The SVG should only be in the DOM once.
- Browse around and see if relevant results are still shown in various works.

## How can we measure success?

It works well and follows what we want 🤷‍♀️ 

## Have we considered potential risks?
N/A