### PR TITLE
Stop `RelatedWorks` from being declared if work has no subject

### DIFF
--- a/content/webapp/components/RelatedWorks/index.tsx
+++ b/content/webapp/components/RelatedWorks/index.tsx
@@ -17,7 +17,12 @@ import RelatedWorksCard from './RelatedWorks.Card';
 import { fetchRelatedWorks } from './RelatedWorks.helpers';
 import { FullWidthRow } from './RelatedWorks.styles';
 
-const RelatedWorks = ({ work }: { work: Work }) => {
+// This type is used to ensure that the `subjects` array has at least one item.
+export type WorkWithSubjects = Work & {
+  subjects: [Work['subjects'][0], ...Work['subjects']];
+};
+
+const RelatedWorks = ({ work }: { work: WorkWithSubjects }) => {
   const { toggles } = useContext(ServerDataContext);
   const [isLoading, setIsLoading] = useState(true);
   const [relatedWorksTabs, setRelatedWorksTabs] = useState<{
@@ -58,6 +63,11 @@ const RelatedWorks = ({ work }: { work: Work }) => {
       if (firstTabKey) setSelectedTab(firstTabKey);
     }
   }, [relatedWorksTabs]);
+
+  // Further check to ensure that the work has at least one subject
+  if (work.subjects.length === 0) {
+    throw new Error('work.subjects must have at least one item');
+  }
 
   if (isLoading)
     return (

--- a/content/webapp/components/RelatedWorks/index.tsx
+++ b/content/webapp/components/RelatedWorks/index.tsx
@@ -17,10 +17,13 @@ import RelatedWorksCard from './RelatedWorks.Card';
 import { fetchRelatedWorks } from './RelatedWorks.helpers';
 import { FullWidthRow } from './RelatedWorks.styles';
 
-// This type is used to ensure that the `subjects` array has at least one item.
 export type WorkWithSubjects = Work & {
-  subjects: [Work['subjects'][0], ...Work['subjects']];
+  subjects: [Work['subjects'][number], ...Work['subjects']];
 };
+
+export function hasAtLeastOneSubject(work: Work): work is WorkWithSubjects {
+  return Array.isArray(work.subjects) && work.subjects.length > 0;
+}
 
 const RelatedWorks = ({ work }: { work: WorkWithSubjects }) => {
   const { toggles } = useContext(ServerDataContext);
@@ -63,11 +66,6 @@ const RelatedWorks = ({ work }: { work: WorkWithSubjects }) => {
       if (firstTabKey) setSelectedTab(firstTabKey);
     }
   }, [relatedWorksTabs]);
-
-  // Further check to ensure that the work has at least one subject
-  if (work.subjects.length === 0) {
-    throw new Error('work.subjects must have at least one item');
-  }
 
   if (isLoading)
     return (

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -18,7 +18,7 @@ import ArchiveTree from '@weco/content/components/ArchiveTree';
 import BackToResults from '@weco/content/components/BackToResults';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout';
 import RelatedWorks, {
-  WorkWithSubjects,
+  hasAtLeastOneSubject,
 } from '@weco/content/components/RelatedWorks';
 import WorkDetails from '@weco/content/components/WorkDetails';
 import WorkHeader from '@weco/content/components/WorkHeader';
@@ -208,8 +208,8 @@ export const WorkPage: NextPage<Props> = ({
         )}
 
         {/* If the work has no subjects, it's not worth adding this component */}
-        {relatedContentOnWorks && work.subjects.length > 0 && (
-          <RelatedWorks work={work as WorkWithSubjects} />
+        {relatedContentOnWorks && hasAtLeastOneSubject(work) && (
+          <RelatedWorks work={work} />
         )}
       </CataloguePageLayout>
     </IsArchiveContext.Provider>

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -17,7 +17,9 @@ import ArchiveBreadcrumb from '@weco/content/components/ArchiveBreadcrumb';
 import ArchiveTree from '@weco/content/components/ArchiveTree';
 import BackToResults from '@weco/content/components/BackToResults';
 import CataloguePageLayout from '@weco/content/components/CataloguePageLayout';
-import RelatedWorks from '@weco/content/components/RelatedWorks';
+import RelatedWorks, {
+  WorkWithSubjects,
+} from '@weco/content/components/RelatedWorks';
 import WorkDetails from '@weco/content/components/WorkDetails';
 import WorkHeader from '@weco/content/components/WorkHeader';
 import IsArchiveContext from '@weco/content/contexts/IsArchiveContext';
@@ -204,7 +206,11 @@ export const WorkPage: NextPage<Props> = ({
             />
           </>
         )}
-        {relatedContentOnWorks && <RelatedWorks work={work} />}
+
+        {/* If the work has no subjects, it's not worth adding this component */}
+        {relatedContentOnWorks && work.subjects.length > 0 && (
+          <RelatedWorks work={work as WorkWithSubjects} />
+        )}
       </CataloguePageLayout>
     </IsArchiveContext.Provider>
   );


### PR DESCRIPTION
## What does this change?

I was thinking that since we changed the logic to not query types and date range if there is no subjects, that the component shouldn't even be declared if the work has no subject, since then it wouldn't even do anything. 

So I change the type of `work` in `RelatedWorks` to ensure it has at least one subject label, moving the conditions higher up with a type guard. 

I removed the conditions that were lower in the tree, since at that point, we know there's at least one subject label.

> [!NOTE]
> I also wonder if we should reduce the amount of data we're passing to `RelatedWorks`. It only needs the work id, its subjects, labels and date (if valid). We don't need to pass the whole Work object. [I made a separate PR for it](https://github.com/wellcomecollection/wellcomecollection.org/pull/12007), lmk what you think.

## How to test

Does it behave like in prod?

## How can we measure success?

No code is run at all for Rel Works if the work does not have at least one subject

## Have we considered potential risks?
N/A?