### PR TITLE
Increase lock time post click in page nav

### DIFF
--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -125,7 +125,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
     setLock(true);
     const timeout = setTimeout(() => {
       setLock(false);
-    }, 600); // 300ms lock
+    }, 600); // 600ms lock
     return () => clearTimeout(timeout);
   }, [clickedId]);
 


### PR DESCRIPTION
## What does this change?

This change aims to fix an issue with the in-page navigation where the wrong element can be selected after scroll.

**Before:**

![Jun-13-2025 14-26-54](https://github.com/user-attachments/assets/381c69c7-8bee-4056-bdbb-96993b7689d7)

**After:**

https://github.com/user-attachments/assets/37a5032b-070c-411b-8b94-ad4548a3b1e9

We increase the lock time to allow sufficient time to pass for the page to scroll to the new location.

## How to test

- [ ] [Preview the component in Cardigan](https://62f13cdbd0ff140768a8d87b-vqcwtbowdc.chromatic.com/?path=/story/components-onthispageanchors--side-bar), does it behave as expected?

## How can we measure success?

Consistent and unsurprising UI.

## Have we considered potential risks?

Risks should be minimal, this is a very small timing change.
