### PR TITLE
Fix 500 on works

### DIFF
--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -173,8 +173,12 @@ function getCanvasTextServiceId(canvas: Canvas): string | undefined {
   return textAnnotation?.id;
 }
 
-export const isChoiceBody = (item: IIIFItemProps): item is ChoiceBody => {
-  return typeof item !== 'string' && 'type' in item && item.type === 'Choice';
+export const isChoiceBody = (
+  item: IIIFItemProps | undefined
+): item is ChoiceBody | undefined => {
+  return Boolean(
+    item && typeof item !== 'string' && 'type' in item && item.type === 'Choice'
+  );
 };
 
 // Temporary types, as the provided AnnotationBody doesn't seem to be correct


### PR DESCRIPTION
## What does this change?

I noticed some [works were causing a 500 error](https://wellcomecollection.org/works/yycbn2r4).

Looks like this happens for [PDFs that are represented in the supplementing array of the a IIIF Manifest Canvas](https://github.com/wellcomecollection/wellcomecollection.org/blob/bf89ee5b3b3f2bfb4141643ffa56a19bcd448a1b/content/webapp/utils/iiif/v3/canvas.ts#L83). In this case the painting array, which gets passed to isChoiceBody can be empty, so we need to account for that.

## How to test

- Visit localhost:3000/works/yycbn2r4
- See the page render instead of returning a 500 error


## How can we measure success?

The page loads properly

## Have we considered potential risks?

n/a
