### PR TITLE
Scroll toolbar when too big

### DIFF
--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -19,6 +19,7 @@ const ToolbarContainer = styled.div`
   background-color: ${props => props.theme.color('accent.purple')};
   color: ${props => props.theme.color('white')};
   z-index: 100;
+  overflow-x: scroll;
 `;
 
 const LinkList = styled.ul.attrs({
@@ -179,7 +180,7 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
           });
           setIsClosed(true);
         }}
-        style={{ padding: '5px 10px 0' }}
+        style={{ padding: '5px 10px 0', position: 'relative' }}
       >
         <span className="visually-hidden">Close API Toolbar</span>
         <Icon iconColor="white" icon={cross} />

--- a/content/webapp/components/ArchiveBreadcrumb/index.tsx
+++ b/content/webapp/components/ArchiveBreadcrumb/index.tsx
@@ -52,6 +52,8 @@ const ArchiveBreadcrumbNav = styled.nav`
     }
 
     &:last-child {
+      margin-right: 0;
+
       &::after {
         display: none;
       }


### PR DESCRIPTION
## What does this change?

Just scrolls the API toolbar when it gets too big for the page. Works pages, for example, have a lot of content in there, and it creates this big white space on the right hand side, on smaller screens and mobile. When I'm developing, it often makes me think I've done bad CSS or something 😄 so treating myself to an overflow scroll, here.

Also noticed that some Archive Breadcrumbs were really big and caused an extra space on the right hand side too, on mobile (e.g. https://www-dev.wellcomecollection.org/works/a222zvge), so removed the margin from the last child.

<img width="250" alt="Screenshot 2025-06-16 at 11 15 39" src="https://github.com/user-attachments/assets/11a6f9f6-0897-4b14-9e5c-e24bda4c0896" />
<img width="250" alt="Screenshot 2025-06-16 at 11 15 52" src="https://github.com/user-attachments/assets/cdf5464d-efc1-4774-a1a2-07bc8526cac2" />


## How to test

Have API tool bar, go to [a works page](https://www-dev.wellcomecollection.org/works/zsgh5y3z), there shouldn't be a big gap on the right on a smaller screen anymore.

## How can we measure success?

It's nicer isn't it?

## Have we considered potential risks?
N/A