### PR TITLE
Fix iOS mobile RelatedWorksCard image size

### DIFF
--- a/content/webapp/components/RelatedWorks/RelatedWorks.styles.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.styles.tsx
@@ -88,18 +88,17 @@ export const ImageWrapper = styled.div`
   order: -1;
   margin-left: ${props => props.theme.spacingUnits['3']}px;
   margin-bottom: ${props => props.theme.spacingUnits['5']}px;
+  display: flex;
 
   img {
     display: block;
     object-fit: contain;
     width: 100%;
-    max-height: 100%;
     filter: url('#border-radius-mask');
 
     ${props => props.theme.media('medium')`
       width: unset;
       height: 100%;
-      max-height: unset;
 
       max-width: -webkit-fill-available; /* Chrome, Safari, Edge */
       max-width: -moz-available; /* Firefox */


### PR DESCRIPTION
For #12014

## What does this change?
Wraps the image in a `display: flex` element which by default stretches the child (img) to fill the available space, doing away with the need for a `max-height` which was the root of the [Safari bug](https://stackoverflow.com/questions/19119910/safari-height-100-element-inside-a-max-height-element)

## How to test
Visit a related work in Safari with `toggle_relatedContentOnWorks` set to `true` and check the images don't break out of the container

## How can we measure success?
Fewer UI bugs

## Have we considered potential risks?
n/a