### PR TITLE
Ignore the .zed dir (for code editor specific settings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ out/
 
 tsconfig.tsbuildinfo
 .server-data
+
+# Code editor
+.zed/


### PR DESCRIPTION
## What does this change?
Ignoring a directory used for setting things specific to the zed IDE. I'm trying out the [debugger](https://zed.dev/docs/debugger).

## How to test
n/a

## How can we measure success?
n/a

## Have we considered potential risks?
n/a

