### PR TITLE
Prevent tabs layout shift

### DIFF
--- a/content/webapp/components/Tabs/Tabs.Navigate.tsx
+++ b/content/webapp/components/Tabs/Tabs.Navigate.tsx
@@ -42,6 +42,7 @@ const TabsNavigate: FunctionComponent<Props> = ({
               as={typeof item.url === 'string' ? undefined : item.url.as}
             >
               <NavItemInner
+                text={item.text}
                 $selected={isSelected}
                 aria-current={isSelected ? 'page' : 'false'}
                 $isWhite={isWhite}

--- a/content/webapp/components/Tabs/Tabs.Navigate.tsx
+++ b/content/webapp/components/Tabs/Tabs.Navigate.tsx
@@ -5,7 +5,13 @@ import { IconSvg } from '@weco/common/icons';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
-import { IconWrapper, NavItemInner, Tab, TabsContainer } from './Tabs.styles';
+import {
+  IconWrapper,
+  NavItemInner,
+  NavItemShim,
+  Tab,
+  TabsContainer,
+} from './Tabs.styles';
 
 export type NavigateSelectableTextLink = {
   id: string;
@@ -42,7 +48,6 @@ const TabsNavigate: FunctionComponent<Props> = ({
               as={typeof item.url === 'string' ? undefined : item.url.as}
             >
               <NavItemInner
-                text={item.text}
                 $selected={isSelected}
                 aria-current={isSelected ? 'page' : 'false'}
                 $isWhite={isWhite}
@@ -56,6 +61,7 @@ const TabsNavigate: FunctionComponent<Props> = ({
                   }
                 }}
               >
+                <NavItemShim>{item.text}</NavItemShim>
                 {item.icon && (
                   <Space
                     as="span"

--- a/content/webapp/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/components/Tabs/Tabs.Switch.tsx
@@ -155,7 +155,11 @@ const TabsSwitch: FunctionComponent<Props> = ({
               aria-controls={`tabpanel-${item.id}`}
               aria-selected={item.id === selectedTab}
             >
-              <NavItemInner $selected={isSelected} $isWhite={isWhite}>
+              <NavItemInner
+                text={item.text}
+                $selected={isSelected}
+                $isWhite={isWhite}
+              >
                 <ConditionalWrapper
                   condition={Boolean(item.url && !isEnhanced)}
                   wrapper={children => <a href={item.url}>{children}</a>}

--- a/content/webapp/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/components/Tabs/Tabs.Switch.tsx
@@ -17,6 +17,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import {
   IconWrapper,
   NavItemInner,
+  NavItemShim,
   Tab,
   TabButton,
   TabsContainer,
@@ -155,11 +156,8 @@ const TabsSwitch: FunctionComponent<Props> = ({
               aria-controls={`tabpanel-${item.id}`}
               aria-selected={item.id === selectedTab}
             >
-              <NavItemInner
-                text={item.text}
-                $selected={isSelected}
-                $isWhite={isWhite}
-              >
+              <NavItemInner $selected={isSelected} $isWhite={isWhite}>
+                <NavItemShim>{item.text}</NavItemShim>
                 <ConditionalWrapper
                   condition={Boolean(item.url && !isEnhanced)}
                   wrapper={children => <a href={item.url}>{children}</a>}

--- a/content/webapp/components/Tabs/Tabs.styles.tsx
+++ b/content/webapp/components/Tabs/Tabs.styles.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -98,13 +99,23 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
       $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
     };
   }
-)<{ $isWhite?: boolean }>`
+)<{ $isWhite?: boolean; text: string | ReactNode }>`
   display: block;
   position: relative;
   z-index: 1;
   cursor: pointer;
   color: ${props => props.theme.color(props.$isWhite ? 'white' : 'black')};
   transition: all ${props => props.theme.transitionProperties};
+
+  /* Prevent tabs layout shift that would result from diffent font weights
+  by adding a pseudo-element with the bold (widest) text content */
+  &::before {
+    content: '${props => props.text?.toString()}';
+    display: block;
+    font-weight: 700;
+    height: 0;
+    visibility: hidden;
+  }
 
   &::after {
     content: '';

--- a/content/webapp/components/Tabs/Tabs.styles.tsx
+++ b/content/webapp/components/Tabs/Tabs.styles.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -99,23 +98,13 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
       $v: { size: 'm', properties: ['padding-top', 'padding-bottom'] },
     };
   }
-)<{ $isWhite?: boolean; text: string | ReactNode }>`
+)<{ $isWhite?: boolean }>`
   display: block;
   position: relative;
   z-index: 1;
   cursor: pointer;
   color: ${props => props.theme.color(props.$isWhite ? 'white' : 'black')};
   transition: all ${props => props.theme.transitionProperties};
-
-  /* Prevent tabs layout shift that would result from diffent font weights
-  by adding a pseudo-element with the bold (widest) text content */
-  &::before {
-    content: '${props => props.text?.toString()}';
-    display: block;
-    font-weight: 700;
-    height: 0;
-    visibility: hidden;
-  }
 
   &::after {
     content: '';
@@ -146,6 +135,14 @@ export const NavItemInner = styled(Space).attrs<{ $selected: boolean }>(
     width: 100%;
     background-color: transparent;
   }
+`;
+
+// Prevent tabs layout shift that would result from diffent font weights
+// by adding an element with the bold (widest) text content
+export const NavItemShim = styled.div`
+  font-weight: 700;
+  height: 0;
+  visibility: hidden;
 `;
 
 export const IconWrapper = styled.span`


### PR DESCRIPTION
## What does this change?
We change the font-weight of the selected tab which has a knock-on effect of shifting all other tabs one or two pixels horizontally.

Adding a `visibility: hidden; height: 0` element containing the tab's text content that has the inter bold font-weight (700) ensures the tabs always take up the same amount of space regardless of whether they're selected. Setting `visibility: hidden` means it won't be read by screenreaders either.

[Initial attempt](https://github.com/wellcomecollection/wellcomecollection.org/pull/12025/commits/7e34506e160931d81172f0b3771c8b39e10524c9) was to add this as a pseudo-element, but the fact the tab content can be a ReactNode (containing other nodes) made this problematic.

__before__
![before](https://github.com/user-attachments/assets/67588aca-97e3-4e95-a65e-58ad27804a4b)

__after__
![after](https://github.com/user-attachments/assets/122f0ebf-ce53-41c6-9614-455ecab2dece)


## How to test
- Visit a work with `toggle_relatedContentOnWorks` turned on and click on the tabs. Other tabs (what's on, search etc.) also improve.
- Concept tags (e.g. http://localhost:3000/concepts/bsu8ec74) also work despite containing inner elements

## How can we measure success?
Nicer UI

## Have we considered potential risks?
Can't think of any