### PR TITLE
Limit image size and center on mobile

### DIFF
--- a/content/webapp/components/RelatedWorks/RelatedWorks.styles.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.styles.tsx
@@ -93,7 +93,7 @@ export const ImageWrapper = styled.div`
     display: block;
     object-fit: contain;
     width: 100%;
-    max-width: 200px;
+    max-width: 200px; /* The size of the IIIF thumbnails */
     margin-left: auto;
     margin-right: auto;
     filter: url('#border-radius-mask');

--- a/content/webapp/components/RelatedWorks/RelatedWorks.styles.tsx
+++ b/content/webapp/components/RelatedWorks/RelatedWorks.styles.tsx
@@ -93,11 +93,15 @@ export const ImageWrapper = styled.div`
     display: block;
     object-fit: contain;
     width: 100%;
+    max-width: 200px;
+    margin-left: auto;
+    margin-right: auto;
     filter: url('#border-radius-mask');
 
     ${props =>
       props.theme.media('medium')(`
       margin-left: ${props.theme.spacingUnits['3']}px;
+      margin-right: unset;
       width: unset;
       height: 100%;
 


### PR DESCRIPTION
For #11996

## What does this change?
__before__
<img width="417" alt="Screenshot 2025-06-18 at 16 20 55" src="https://github.com/user-attachments/assets/b8439a08-0980-4abb-9770-b880b7c10d97" />

__after__
<img width="417" alt="Screenshot 2025-06-18 at 16 20 34" src="https://github.com/user-attachments/assets/ae4ff559-7875-4fd6-a6cf-b1589732f978" />

## How to test
- View RelatedWorksCard on a small screen and check the image doesn't exceed 200px.
- View it on a wider screen to check everything still looks ok

## How can we measure success?
Users get unpixelated images

## Have we considered potential risks?
n/a
