### PR TITLE
Installation: add related stories, change breadcrumb

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.Installation.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.Installation.tsx
@@ -20,7 +20,10 @@ import {
   fetchExhibitExhibition,
   fetchExhibitionRelatedContentClientSide,
 } from '@weco/content/services/prismic/fetch/exhibitions';
-import { Exhibition as InstallationType } from '@weco/content/types/exhibitions';
+import {
+  ExhibitionAbout,
+  Exhibition as InstallationType,
+} from '@weco/content/types/exhibitions';
 import { Page as PageType } from '@weco/content/types/pages';
 import { getFeaturedMedia } from '@weco/content/utils/page-header';
 
@@ -35,6 +38,9 @@ type Props = {
 const Installation: FunctionComponent<Props> = ({ installation, pages }) => {
   const [partOf, setPartOf] = useState<InstallationType>();
   const [exhibitionOfs, setExhibitionOfs] = useState<ExhibitionOf>([]);
+  const [exhibitionAbouts, setExhibitionAbouts] = useState<ExhibitionAbout[]>(
+    []
+  );
 
   useEffect(() => {
     fetchExhibitExhibition(installation.id).then(exhibition => {
@@ -47,6 +53,7 @@ const Installation: FunctionComponent<Props> = ({ installation, pages }) => {
       relatedContent => {
         if (isNotUndefined(relatedContent)) {
           setExhibitionOfs(relatedContent.exhibitionOfs);
+          setExhibitionAbouts(relatedContent.exhibitionAbouts);
         }
       }
     );
@@ -56,7 +63,8 @@ const Installation: FunctionComponent<Props> = ({ installation, pages }) => {
 
   const extraBreadcrumbs = [
     {
-      text: 'Installations',
+      url: '/exhibitions',
+      text: 'Exhibitions',
     },
     partOf
       ? {
@@ -143,6 +151,12 @@ const Installation: FunctionComponent<Props> = ({ installation, pages }) => {
             items={[...exhibitionOfs, ...pages]}
             title="Installation events"
           />
+        </Space>
+      )}
+
+      {exhibitionAbouts.length > 0 && (
+        <Space $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}>
+          <SearchResults items={exhibitionAbouts} title="Related stories" />
         </Space>
       )}
     </ContentPage>

--- a/content/webapp/components/Exhibition/Exhibition.helpers.tsx
+++ b/content/webapp/components/Exhibition/Exhibition.helpers.tsx
@@ -95,51 +95,31 @@ function getPlaceObject(
   );
 }
 
-function getAccessibilityItems(): ExhibitionItem[] {
+function getAccessibilityItems(exhibitionId: string): ExhibitionItem[] {
+  const createContent = (text: string, icon: IconSvg) => ({
+    description: [
+      {
+        type: 'paragraph',
+        text,
+        spans: [],
+      },
+    ] as prismic.RichTextField,
+    icon,
+  });
+
   const accessibilityItems: {
     description: prismic.RichTextField;
     icon: IconSvg;
   }[] = [
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.stepFreeAccess,
-          spans: [],
-        },
-      ],
-      icon: accessible,
-    },
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.largePrintGuides,
-          spans: [],
-        },
-      ],
-      icon: a11YVisual,
-    },
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.bsl,
-          spans: [],
-        },
-      ],
-      icon: bslSquare,
-    },
-    {
-      description: [
-        {
-          type: 'paragraph',
-          text: a11y.accessResources,
-          spans: [],
-        },
-      ],
-      icon: accessibility,
-    },
+    createContent(a11y.stepFreeAccess, accessible),
+    createContent(a11y.largePrintGuides, a11YVisual),
+    // Hopefully temporary condition to hide BSL and access resources from Finger Talks Installation
+    ...(exhibitionId !== 'aEqnVBEAACMA2k3b'
+      ? [
+          createContent(a11y.bsl, bslSquare),
+          createContent(a11y.accessResources, accessibility),
+        ]
+      : []),
   ];
 
   return accessibilityItems.filter(item => {
@@ -157,6 +137,6 @@ export function getInfoItems(exhibition: ExhibitionType): ExhibitionItem[] {
     getAdmissionObject(),
     getTodaysHoursObject(),
     getPlaceObject(exhibition),
-    ...getAccessibilityItems(),
+    ...getAccessibilityItems(exhibition.id),
   ].filter(isNotUndefined);
 }


### PR DESCRIPTION
## What does this change?

#12028 #12032

- Modifies Breadcrumb to point to Exhibitions listing (as per [Lauren request](https://wellcome.slack.com/archives/CUA669WHH/p1750337739581069))
- Display related stories to match other exhibitions
- Changes to the info displayed in yellow box IF Finger Talk installation (hopefully to be dealt with more elegantly soon) 

## How to test

Run locally and access [Finger talk](https://www-dev.wellcomecollection.org/exhibitions/finger-talk-installation) installation
Does it change anything on other exhibitions?

## How can we measure success?

Finger talks displays what it should

## Have we considered potential risks?
N/A apart from having a very specific conditional (risk of annoying code 😏 )