### PR TITLE
Pdf link styling for viewer on mobile

### DIFF
--- a/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
@@ -4,7 +4,7 @@ import { useAppContext } from '@weco/common/contexts/AppContext';
 import { useToggles } from '@weco/common/server-data/Context';
 import Space from '@weco/common/views/components/styled/Space';
 
-const IframePdfViewer = styled(Space)`
+const IframePdfViewer = styled.iframe`
   width: 100%;
   height: 90vh;
   display: block;
@@ -54,7 +54,7 @@ const IIIFItemPdf = ({
           {title}
         </PdfLink>
       ) : (
-        <IframePdfViewer as="iframe" title={title} src={src} />
+        <IframePdfViewer title={displayLabel} src={src} />
       )}
     </>
   );

--- a/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { pdf } from '@weco/common/icons';
 import { useToggles } from '@weco/common/server-data/Context';
+import { font } from '@weco/common/utils/classnames';
 import ButtonSolidLink from '@weco/common/views/components/Buttons/Buttons.SolidLink';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -16,23 +17,34 @@ const IframePdfViewer = styled.iframe`
   margin-right: auto;
 `;
 
-const PdfLink = styled.a`
+const PdfLink = styled(Space).attrs({
+  $v: {
+    size: 'l',
+    properties: ['padding-top', 'padding-bottom'],
+  },
+  $h: {
+    size: 'l',
+    properties: ['padding-left', 'padding-right'],
+  },
+})`
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
+  background-color: ${props => props.theme.color('neutral.700')};
+  border-radius: 6px;
   display: flex;
-  justify-content: center;
   align-items: center;
-  max-width: 280px;
-  min-height: 100px;
-  border: 1px solid ${props => props.theme.color('neutral.400')};
-  text-decoration: none;
-  transition: background-color 0.2s ease;
-  padding: 1rem 2rem;
+  flex-direction: column;
+  gap: 10px;
+  text-align: center;
 
-  &:hover {
-    background-color: ${props => props.theme.color('neutral.200')};
+  a {
+    min-width: 240px;
+
+    span {
+      margin: auto;
+    }
   }
 `;
 
@@ -47,19 +59,28 @@ const IIIFItemPdf = ({
 }) => {
   const { isMobileOrTabletDevice } = useAppContext();
   const { extendedViewer } = useToggles();
-    ? `${label} ${fileSize}` || `PDF ${fileSize}`
-    : label || 'PDF';
+  const substituteTitle = 'unknown title';
+  const displayLabel = label && label.trim() !== '-' ? label : substituteTitle;
   return (
     <>
       {isMobileOrTabletDevice && extendedViewer ? (
-        <PdfLink href={src} target="_blank" rel="noopener noreferrer">
-          {title}
+        <PdfLink>
           <Icon icon={pdf} sizeOverride="width: 48px; height: 48px;" />
+          <Space
+            className={font('intb', 5)}
+            $v={{ size: 'm', properties: ['margin-top', 'margin-bottom'] }}
+          >
+            {displayLabel}
+          </Space>
           <ButtonSolidLink
             link={src}
             text="Open"
             ariaLabel={`Open ${(displayLabel !== substituteTitle && label) || 'document'}`}
           />
+          <span className={font('intr', 6)}>
+            Size:{' '}
+            <span className={font('intb', 6)}>{fileSize || 'unknown'}</span>
+          </span>
         </PdfLink>
       ) : (
         <IframePdfViewer title={displayLabel} src={src} />

--- a/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
+import { pdf } from '@weco/common/icons';
 import { useToggles } from '@weco/common/server-data/Context';
+import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
 const IframePdfViewer = styled.iframe`
@@ -52,6 +54,7 @@ const IIIFItemPdf = ({
       {isMobileOrTabletDevice && extendedViewer ? (
         <PdfLink href={src} target="_blank" rel="noopener noreferrer">
           {title}
+          <Icon icon={pdf} sizeOverride="width: 48px; height: 48px;" />
         </PdfLink>
       ) : (
         <IframePdfViewer title={displayLabel} src={src} />

--- a/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
@@ -33,10 +33,20 @@ const PdfLink = styled.a`
   }
 `;
 
-const IIIFItemPdf = ({ src, label }: { src: string; label?: string }) => {
+const IIIFItemPdf = ({
+  src,
+  label,
+  fileSize,
+}: {
+  src: string;
+  label?: string;
+  fileSize?: string;
+}) => {
   const { isMobileOrTabletDevice } = useAppContext();
   const { extendedViewer } = useToggles();
-  const title = label || 'PDF';
+  const title = fileSize
+    ? `${label} ${fileSize}` || `PDF ${fileSize}`
+    : label || 'PDF';
   return (
     <>
       {isMobileOrTabletDevice && extendedViewer ? (

--- a/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/components/IIIFItem/IIIFItem.Pdf.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { pdf } from '@weco/common/icons';
 import { useToggles } from '@weco/common/server-data/Context';
+import ButtonSolidLink from '@weco/common/views/components/Buttons/Buttons.SolidLink';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -46,7 +47,6 @@ const IIIFItemPdf = ({
 }) => {
   const { isMobileOrTabletDevice } = useAppContext();
   const { extendedViewer } = useToggles();
-  const title = fileSize
     ? `${label} ${fileSize}` || `PDF ${fileSize}`
     : label || 'PDF';
   return (
@@ -55,6 +55,11 @@ const IIIFItemPdf = ({
         <PdfLink href={src} target="_blank" rel="noopener noreferrer">
           {title}
           <Icon icon={pdf} sizeOverride="width: 48px; height: 48px;" />
+          <ButtonSolidLink
+            link={src}
+            text="Open"
+            ariaLabel={`Open ${(displayLabel !== substituteTitle && label) || 'document'}`}
+          />
         </PdfLink>
       ) : (
         <IframePdfViewer title={displayLabel} src={src} />

--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -261,6 +261,10 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
   const isRestricted = isItemRestricted(item);
   const shouldShowItem = isRestricted && !userIsStaffWithRestricted;
   const { extendedViewer } = useToggles();
+  const itemLabel =
+    'label' in item
+      ? getLabelString(item.label as InternationalString)
+      : undefined;
   // N.B. Restricted images are handled differently from restricted audio/video and text.
   // The isItemRestricted function doesn't account for restricted images.
   // Instead there is a hasRestrictedImage property on the TransformedCanvas which is used by
@@ -361,38 +365,21 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
       );
 
     case item.type === 'Text' && item.id && !exclude.includes('Text'):
-      if ('label' in item) {
-        const itemLabel = item.label
-          ? getLabelString(item.label as InternationalString)
-          : '';
-        return (
-          <IIIFItemWrapper
-            shouldShowItem={shouldShowItem}
-            className="pdf-wrapper"
-            titleOverride={titleOverride}
-            canvas={canvas}
-            isRestricted={isRestricted}
-          >
-            <IIIFItemPdf
-              src={item.id}
-              label={itemLabel}
-              fileSize={getFileSize(canvas)}
-            />
-          </IIIFItemWrapper>
-        );
-      } else {
-        return (
-          <IIIFItemWrapper
-            shouldShowItem={shouldShowItem}
-            className="pdf-wrapper"
-            titleOverride={titleOverride}
-            canvas={canvas}
-            isRestricted={isRestricted}
-          >
-            <IIIFItemPdf src={item.id} />
-          </IIIFItemWrapper>
-        );
-      }
+      return (
+        <IIIFItemWrapper
+          shouldShowItem={shouldShowItem}
+          className="pdf-wrapper"
+          titleOverride={titleOverride}
+          canvas={canvas}
+          isRestricted={isRestricted}
+        >
+          <IIIFItemPdf
+            src={item.id}
+            label={itemLabel}
+            fileSize={getFileSize(canvas)}
+          />
+        </IIIFItemWrapper>
+      );
 
     case item.type === 'Image' && !exclude.includes('Image'):
       return (

--- a/content/webapp/components/IIIFItem/index.tsx
+++ b/content/webapp/components/IIIFItem/index.tsx
@@ -37,6 +37,7 @@ import {
 } from '@weco/content/types/manifest';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 import {
+  getFileSize,
   getImageServiceFromItem,
   getLabelString,
   isItemRestricted,
@@ -372,7 +373,11 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             canvas={canvas}
             isRestricted={isRestricted}
           >
-            <IIIFItemPdf src={item.id} label={itemLabel} />
+            <IIIFItemPdf
+              src={item.id}
+              label={itemLabel}
+              fileSize={getFileSize(canvas)}
+            />
           </IIIFItemWrapper>
         );
       } else {

--- a/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/components/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
-import { audio, file, video } from '@weco/common/icons';
+import { audio, file, pdf, video } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Icon from '@weco/common/views/components/Icon';
@@ -11,11 +11,7 @@ import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import { IIIFItemProps } from '@weco/content/components/IIIFItem';
 import { TransformedCanvas } from '@weco/content/types/manifest';
-import {
-  isAudioCanvas,
-  isChoiceBody,
-  isPDFCanvas,
-} from '@weco/content/utils/iiif/v3';
+import { isChoiceBody, isPDFCanvas } from '@weco/content/utils/iiif/v3';
 
 import IIIFViewerImage from './IIIFViewerImage';
 import Padlock from './Padlock';
@@ -110,9 +106,10 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
         ?.type
     : canvas.painting?.[0]?.type;
 
-  const hasIconPlaceholder =
-    !thumbnailSrc &&
-    (itemType === 'Sound' || isAudioCanvas(canvas) || isPDFCanvas(canvas));
+  const thumbnailSrcIsPlaceholder =
+    thumbnailSrc?.includes('/born-digital/placeholder-thumb/') || false;
+
+  const hasIconPlaceholder = !thumbnailSrc || thumbnailSrcIsPlaceholder;
 
   return (
     <IIIFViewerThumb>
@@ -129,7 +126,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
 
           {!isRestricted && (
             <>
-              {thumbnailSrc ? (
+              {!hasIconPlaceholder ? (
                 <>
                   {!thumbnailLoaded && <LL $small={true} $lighten={true} />}
 
@@ -155,7 +152,9 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
                             ? audio
                             : itemType === 'Video'
                               ? video
-                              : file
+                              : isPDFCanvas(canvas)
+                                ? pdf
+                                : file
                         }
                         iconColor="white"
                         sizeOverride="width: 53px; height: 53px;"

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -676,7 +676,7 @@ export function isPDFCanvas(canvas?: TransformedCanvas): boolean {
         return false;
       });
     } else {
-      return 'format' in supplement[0]
+      return supplement[0] && 'format' in supplement[0]
         ? supplement[0].format === 'application/pdf'
         : false;
     }
@@ -806,7 +806,7 @@ export function hasNonImages(
   return !!hasNonImage;
 }
 
-export function getFormatString(format: string): string | undefined {
+export function getFormatString(format?: string): string | undefined {
   switch (format) {
     case 'application/pdf':
       return 'PDF';


### PR DESCRIPTION
## What does this change?

For [#12024](https://github.com/wellcomecollection/wellcomecollection.org/issues/12024)

Implements the [designs for pdf links](https://www.figma.com/design/OxxzV0GrHOEofLRb9sm2fP/File-viewer?node-id=118-5322&t=n7lwR1o575Cu7PMK-1) in the viewer on mobile devices:

<img width="350" alt="Screenshot 2025-06-20 at 15 21 58" src="https://github.com/user-attachments/assets/b4e905d3-3ed2-43f7-a18c-395f92bb5f7a" />


Also tweaks the IIIFCanvasThumbnail so that we use our icons for PDFs and other files over the place holder images we get in the iiif manifest

Before:
<img width="1430" alt="Screenshot 2025-06-20 at 10 26 06" src="https://github.com/user-attachments/assets/74fc3090-017d-4a2e-b4a7-09c0c3ef4b06" />

<img width="1489" alt="Screenshot 2025-06-20 at 15 28 35" src="https://github.com/user-attachments/assets/bd5f6b1d-7c04-4831-9b37-2ff0d0366087" />

After:
<img width="1411" alt="Screenshot 2025-06-20 at 10 25 38" src="https://github.com/user-attachments/assets/65269d20-870d-40c1-b06a-0169a9b72d47" />

<img width="1411" alt="Screenshot 2025-06-20 at 15 01 17" src="https://github.com/user-attachments/assets/bc8d7e7d-1c3c-460a-88ad-4d8169feeff5" />

## How to test

- Enable the extendedViewer toggle
- Visit [an item page with PDFs](https://www-dev.wellcomecollection.org/works/zu2q4k2w/items)
- On desktop you should still see the PDF
- Open dev tools and change the user agent to a mobile device
<img width="1018" alt="Screenshot 2025-06-17 at 17 43 41" src="https://github.com/user-attachments/assets/a4ba0ee8-8f37-4ac3-9527-3ad8fb5ae72c" />
- The page should now show a link for the PDF instead of the iframe
- open the grid view and see that we're using the PDF icon instead of the placeholder thumbnail from the iiif manifest

## How can we measure success?

Mobile users can access the PDFs

## Have we considered potential risks?

n/a
