### PR TITLE
Prismic linting: Add an indication as to what the text might be around a faulty link

### DIFF
--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -46,13 +46,21 @@ const { slackWebhookUrl } = yargs(process.argv.slice(2))
 // the object to get more debugging information, but I hope this
 // is good enough for now.
 function detectEur01Safelinks(doc: any): string[] {
-  if (
-    JSON.stringify(doc).indexOf(
-      'https://eur01.safelinks.protection.outlook.com'
-    ) !== -1
-  ) {
+  const linkIndex = JSON.stringify(doc).indexOf(
+    'https://eur01.safelinks.protection.outlook.com'
+  );
+  if (linkIndex !== -1) {
+    const textSlice = JSON.stringify(doc).slice(
+      linkIndex - 250 > 0 ? linkIndex - 250 : 0,
+      linkIndex + 150
+    );
+
+    const text = textSlice.slice(
+      textSlice.indexOf(',"text":') + 8,
+      textSlice.indexOf('spans')
+    );
     return [
-      'One of the links is an eur01.safelinks URL, which has probably been copy/pasted from an email. Replace this URL with an un-safelink’d version.',
+      `One of the links is an eur01.safelinks URL, which has probably been copy/pasted from an email. Replace this URL with an un-safelink’d version. The text around it is potentially: "${text}"`,
     ];
   }
 

--- a/prismic-model/lintPrismicData.ts
+++ b/prismic-model/lintPrismicData.ts
@@ -52,10 +52,12 @@ function detectEur01Safelinks(doc: any): string[] {
   if (linkIndex !== -1) {
     const textSlice = JSON.stringify(doc).slice(
       linkIndex - 250 > 0 ? linkIndex - 250 : 0,
-      linkIndex + 150
+      linkIndex
     );
 
     const text = textSlice.slice(
+      // "text" alone could be the parent object.
+      // The comma ensure it's preced by "type": "paragraph", or something like it
       textSlice.indexOf(',"text":') + 8,
       textSlice.indexOf('spans')
     );


### PR DESCRIPTION
## What does this change?

It can be hard to find where a faulty link is when it's flagged in a document with a huge amount of text ([see Slack](https://wellcome.slack.com/archives/C3N7J05TK/p1750825028476759)), so I thought I'd add this. It seems to work fine as I tested, if it print horrendous things we can remove it.

## How to test

I put a faulty link in https://wellcomecollection.prismic.io/builder/pages/ZIclmBAAAMwEH7EL?s=archived&v=aF0AkxAAACUAvYj6 to test with if you'd like to! (republish it and run `lintPrismicData` locally

## How can we measure success?

Easier for Editorial to fix those

## Have we considered potential risks?
N/A