### PR TITLE
Disable Asia–Pacific updown monitoring

### DIFF
--- a/updown/README.md
+++ b/updown/README.md
@@ -16,7 +16,7 @@ Our checks are configured in `updown-checks.ts`.
 Update this file, then either merge a PR or deploy manually with:
 
 ```console
-$ AWS_PROFILE=platform-dev yarn apply
+$ AWS_PROFILE=platform-developer yarn apply
 ```
 
 This will deploy your new checks to Updown.

--- a/updown/types.ts
+++ b/updown/types.ts
@@ -6,6 +6,7 @@ export type Check = {
   emailAlerts?: boolean;
   slackAlerts?: ('digital-general' | 'alerts-channel')[];
   apdexThreshold?: ApdexThreshold;
+  disabled_locations: string[];
 };
 
 export type UpdownCheck = {

--- a/updown/updown-checks.ts
+++ b/updown/updown-checks.ts
@@ -7,54 +7,64 @@ export default [
     name: 'Homepage',
     emailAlerts: true,
     slackAlerts: ['digital-general', 'alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/stories',
     name: 'Stories',
     emailAlerts: true,
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/whats-on',
     name: "What's on",
     emailAlerts: true,
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/visit-us',
     name: 'Visit us',
     emailAlerts: true,
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/articles/graphic-gallery--green',
     name: 'Story',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/events/cancelled--stronger--smarter----better-',
     name: 'Event',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/exhibitions/can-graphic-design-save-your-life-',
     name: 'Exhibition',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/visual-stories/genetic-automata-visual-story',
     name: 'Visual Story',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/collections',
     name: 'Collections search',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/robots.txt',
     name: 'robots.txt',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/search/works?query=botany',
@@ -62,32 +72,38 @@ export default [
     emailAlerts: true,
     slackAlerts: ['digital-general', 'alerts-channel'],
     apdexThreshold: 1.0, // We expect this to be a slower page
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/works/e7vav3ss',
     name: 'Work',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/works/e7vav3ss/items',
     name: 'Work items',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/search/images?query=skeletons',
     name: 'Images search',
     emailAlerts: true,
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/works/pbxd2mgd/images?id=q6h754ua',
     name: 'Image',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://content.wellcomecollection.org/concepts/patspgf3',
     name: 'Concept',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
     apdexThreshold: 1.0, // We expect this to be a slower page
   },
   {
@@ -95,34 +111,40 @@ export default [
     name: 'Images API: Search',
     emailAlerts: true,
     slackAlerts: ['digital-general', 'alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://api.wellcomecollection.org/catalogue/v2/images/sws5gyfw',
     name: 'Images API: Image',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://api.wellcomecollection.org/catalogue/v2/works?query=botany',
     name: 'Works API: Search',
     emailAlerts: true,
     slackAlerts: ['digital-general', 'alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://api.wellcomecollection.org/catalogue/v2/works/tp3rer3n',
     name: 'Works API: Work',
     slackAlerts: ['alerts-channel'],
     apdexThreshold: 1.0, // We expect this to be slower
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://i.wellcomecollection.org/assets/icons/favicon-16x16.png',
     name: 'Assets: Favicon',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     url: 'https://dlcs.io/health',
     name: 'DLCS: API: IIIF (origin)',
     emailAlerts: true,
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
   {
     // This is from Wikimedia Commons linking to Wellcome Images:
@@ -130,5 +152,6 @@ export default [
     url: 'https://wellcomeimages.org/indexplus/image/L0030772.html',
     name: 'Wellcome Images Redirect',
     slackAlerts: ['alerts-channel'],
+    disabled_locations: ['sin'],
   },
 ] as Check[];


### PR DESCRIPTION
## What does this change?

This change disables uptime monitoring in the asia pacific region, to avoid false positives on bot-traffic throttles.

## How to test

View the updown dashboard, are these changes reflected there?

## How can we measure success?

- Less false positives in downtime alarms.

## Have we considered potential risks?

It is possible that temporary outages due to bot traffic in these regions are early signifiers of potential issues in other regions. We will still be able to see geographic region specific issue in AWS WAF.
