### PR TITLE
Two col themes realz

### DIFF
--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -36,6 +36,25 @@ type SpaceProperty =
 
 const breakpointNames = ['small', 'medium', 'large'];
 
+function pageGridOffset(property: string): string {
+  return `
+  position: relative;
+  ${property}: -${themeValues.containerPadding.small}px;
+
+  ${themeValues.media('medium')(`
+    ${property}: -${themeValues.containerPadding.medium}px;
+    `)}
+
+  ${themeValues.media('large')(`
+    ${property}: -${themeValues.containerPadding.large}px;
+    `)}
+
+  ${themeValues.media('xlarge')(`
+    ${property}: calc((100vw - ${themeValues.sizes.xlarge}px) / 2 * -1 - ${themeValues.containerPadding.xlarge}px);
+  `)};
+  `;
+}
+
 function makeSpacePropertyValues(
   size: SpaceSize,
   properties: SpaceProperty[],
@@ -63,6 +82,7 @@ function makeSpacePropertyValues(
 const theme = {
   ...themeValues,
   makeSpacePropertyValues,
+  pageGridOffset,
 };
 
 type Classes = typeof classes;

--- a/content/webapp/components/CatalogueImageGallery/ScrollableGalleryButtons.tsx
+++ b/content/webapp/components/CatalogueImageGallery/ScrollableGalleryButtons.tsx
@@ -26,6 +26,7 @@ const ScrollButton = styled('button').attrs({
 const ScrollButtonsContainer = styled(Space)`
   display: flex;
   justify-content: flex-end;
+  ${props => props.theme.pageGridOffset('left')};
 `;
 
 type Props = {

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -129,10 +129,7 @@ const MobileNavButton = styled.button`
   color: white;
 
   .icon {
-    content: '+' / '';
     transition: transform ${props => props.theme.transitionProperties};
-    font-size: 1.5rem;
-    line-height: 1;
   }
 
   nav:has(ul.is-hidden-s) & {
@@ -240,7 +237,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
       <h2 className={`${fontStyle} is-hidden-s`}>{titleText}</h2>
       <MobileNavButton ref={buttonRef} onClick={toggleList}>
         {titleText}
-        {isEnhanced && <Icon icon={cross} />}
+        {isEnhanced && <Icon icon={cross} matchText />}
       </MobileNavButton>
       <PlainList ref={listRef} id={listId}>
         {links.map((link: Link) => {

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -172,14 +172,17 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
     buttonRef.current.setAttribute('aria-controls', listId);
   }, [buttonRef.current]);
 
-  // When an anchor is clicked, lock for a short time before allowing scroll to clear
+  // When an anchor is clicked, wait till scroll has finished
   useEffect(() => {
     if (!clickedId) return;
-    setLock(true);
-    const timeout = setTimeout(() => {
+
+    function handleScrollEnd() {
       setLock(false);
-    }, 600); // 600ms lock
-    return () => clearTimeout(timeout);
+    }
+    document.addEventListener('scrollend', handleScrollEnd, { passive: true });
+
+    setLock(true);
+    return () => document.removeEventListener('scrollend', handleScrollEnd);
   }, [clickedId]);
 
   // When the user scrolls, clear clickedId if it is set and not locked

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -257,23 +257,23 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
                     legacyBehavior
                     style={{ textDecoration: 'none' }}
                     href={link.url}
-                    data-gtm-trigger="link_click_page_position"
-                    onClick={e => {
-                      e.preventDefault();
-                      hideMobileList();
-                      setClickedId(id);
-                      const el = document.getElementById(id);
-                      if (el) {
-                        el.scrollIntoView({
-                          behavior: 'smooth',
-                          block: 'start',
-                        });
-                      }
-                    }}
                   >
                     <InPageNavAnimatedLink
                       $isActive={isActive}
                       $hasBackgroundBlend={hasBackgroundBlend}
+                      data-gtm-trigger="link_click_page_position"
+                      onClick={e => {
+                        e.preventDefault();
+                        hideMobileList();
+                        setClickedId(id);
+                        const el = document.getElementById(id);
+                        if (el) {
+                          el.scrollIntoView({
+                            behavior: 'smooth',
+                            block: 'start',
+                          });
+                        }
+                      }}
                     >
                       <span>{link.text}</span>
                     </InPageNavAnimatedLink>

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -172,17 +172,14 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
     buttonRef.current.setAttribute('aria-controls', listId);
   }, [buttonRef.current]);
 
-  // When an anchor is clicked, wait till scroll has finished
+  // When an anchor is clicked, lock for a short time before allowing scroll to clear
   useEffect(() => {
     if (!clickedId) return;
-
-    function handleScrollEnd() {
-      setLock(false);
-    }
-    document.addEventListener('scrollend', handleScrollEnd, { passive: true });
-
     setLock(true);
-    return () => document.removeEventListener('scrollend', handleScrollEnd);
+    const timeout = setTimeout(() => {
+      setLock(false);
+    }, 1000); // 1s lock
+    return () => clearTimeout(timeout);
   }, [clickedId]);
 
   // When the user scrolls, clear clickedId if it is set and not locked

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -254,6 +254,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
                 <ListItem>
                   <NextLink
                     passHref
+                    legacyBehavior
                     style={{ textDecoration: 'none' }}
                     href={link.url}
                     data-gtm-trigger="link_click_page_position"

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -138,7 +138,7 @@ const MobileNavButton = styled.button`
     }
   }
 
-  ${props => props.theme.media('medium')`
+  ${props => props.theme.media('large')`
     display: none;
   `}
 `;
@@ -208,6 +208,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
   useEffect(() => {
     if (!listRef.current) return;
     listRef.current.classList.add('is-hidden-s');
+    listRef.current.classList.add('is-hidden-m');
   }, [listRef.current]);
 
   function toggleList() {
@@ -215,9 +216,12 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
 
     if (listRef.current.classList.contains('is-hidden-s')) {
       listRef.current.classList.remove('is-hidden-s');
+      listRef.current.classList.remove('is-hidden-m');
+
       buttonRef.current.setAttribute('aria-expanded', 'true');
     } else {
       listRef.current.classList.add('is-hidden-s');
+      listRef.current.classList.add('is-hidden-m');
       buttonRef.current.setAttribute('aria-expanded', 'false');
     }
   }
@@ -226,6 +230,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
     if (!listRef.current || !buttonRef.current) return;
 
     listRef.current.classList.add('is-hidden-s');
+    listRef.current.classList.add('is-hidden-m');
     buttonRef.current.setAttribute('aria-expanded', 'false');
   }
 
@@ -234,7 +239,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
 
   return (
     <Root $isSticky={isSticky} $hasBackgroundBlend={hasBackgroundBlend}>
-      <h2 className={`${fontStyle} is-hidden-s`}>{titleText}</h2>
+      <h2 className={`${fontStyle} is-hidden-s is-hidden-m`}>{titleText}</h2>
       <MobileNavButton ref={buttonRef} onClick={toggleList}>
         {titleText}
         {isEnhanced && <Icon icon={cross} matchText />}

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -1,5 +1,12 @@
 import NextLink from 'next/link';
-import { FunctionComponent, useEffect, useId, useRef, useState } from 'react';
+import {
+  Fragment,
+  FunctionComponent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
@@ -240,9 +247,9 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
           const id = link.url.replace('#', '');
           const isActive = activeId === id;
           return (
-            <>
+            <Fragment key={link.url}>
               {isSticky ? (
-                <ListItem key={link.url}>
+                <ListItem>
                   <NextLink
                     passHref
                     style={{ textDecoration: 'none' }}
@@ -279,7 +286,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
                   </Anchor>
                 </li>
               )}
-            </>
+            </Fragment>
           );
         })}
       </PlainList>

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -90,10 +90,12 @@ const stickyRootAttrs = `
   z-index: 1;
 `;
 
-const Root = styled(Space).attrs({
-  $h: { size: 'l', properties: ['padding-left', 'padding-right'] },
+const Root = styled(Space).attrs<{ $isSticky?: boolean }>(props => ({
+  $h: props.$isSticky
+    ? undefined
+    : { size: 'l', properties: ['padding-left', 'padding-right'] },
   $v: { size: 'l', properties: ['padding-top', 'padding-bottom'] },
-})<{
+}))<{
   $isSticky?: boolean;
   $hasBackgroundBlend?: boolean;
 }>`

--- a/content/webapp/components/ThemeCollaborators/index.tsx
+++ b/content/webapp/components/ThemeCollaborators/index.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { organisation, user } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
-import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import CollaboratorCard from '@weco/content/components/CollaboratorCard';
 import {
   ConceptType,
@@ -41,7 +40,7 @@ const ThemeCollaborators: FunctionComponent<Props> = ({ concepts }) => {
 
   return (
     <>
-      <Heading>Frequent collaborators</Heading>
+      <Heading id="frequent-collaborators">Frequent collaborators</Heading>
       <CollaboratorsWrapper>
         {concepts.slice(0, COLLABORATOR_COUNT_LIMIT).map(concept => (
           <CollaboratorCard

--- a/content/webapp/components/ThemeImages/ThemeImagesSection.tsx
+++ b/content/webapp/components/ThemeImages/ThemeImagesSection.tsx
@@ -72,7 +72,7 @@ const ThemeImagesSection: FunctionComponent<Props> = ({
 
   return (
     <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-      <SectionHeading>
+      <SectionHeading id={`images-${getThemeTabLabel(type, concept.type)}`}>
         Images {getThemeTabLabel(type, concept.type)} {concept.label}
       </SectionHeading>
       <CatalogueImageGallery

--- a/content/webapp/components/ThemeImages/index.tsx
+++ b/content/webapp/components/ThemeImages/index.tsx
@@ -1,9 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
-import { WobblyEdge } from '@weco/common/views/components/WobblyEdge';
 import ThemeImagesSection from '@weco/content/components/ThemeImages/ThemeImagesSection';
 import { themeTabOrder } from '@weco/content/components/ThemeWorks';
 import {
@@ -34,19 +32,16 @@ const ThemeImages: FunctionComponent<Props> = ({ sectionsData, concept }) => {
 
   return (
     <>
-      <WobblyEdge backgroundColor="neutral.700" />
       <ThemeImagesWrapper as="section" data-testid="images-section">
-        <Container>
-          {themeTabOrder.map(tabType => (
-            <ThemeImagesSection
-              key={tabType}
-              singleSectionData={sectionsData[tabType].images}
-              totalResults={sectionsData[tabType].totalResults.images!}
-              concept={concept}
-              type={tabType}
-            />
-          ))}
-        </Container>
+        {themeTabOrder.map(tabType => (
+          <ThemeImagesSection
+            key={tabType}
+            singleSectionData={sectionsData[tabType].images}
+            totalResults={sectionsData[tabType].totalResults.images!}
+            concept={concept}
+            type={tabType}
+          />
+        ))}
       </ThemeImagesWrapper>
     </>
   );

--- a/content/webapp/components/ThemeRelatedConceptsGroup/index.tsx
+++ b/content/webapp/components/ThemeRelatedConceptsGroup/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
+import { dasherize } from '@weco/common/utils/grammar';
 import Button, { ButtonColors } from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -49,7 +50,9 @@ const ThemeRelatedConceptsGroup = ({
 
   return (
     <>
-      {labelType === 'heading' && <SectionHeading>{label}</SectionHeading>}
+      {labelType === 'heading' && (
+        <SectionHeading id={dasherize(label)}>{label}</SectionHeading>
+      )}
       <RelatedConceptsContainer>
         {labelType === 'inline' && <span>{label}</span>}
         {relatedConcepts.map(item => (

--- a/content/webapp/components/ThemeSourcedDescription/index.tsx
+++ b/content/webapp/components/ThemeSourcedDescription/index.tsx
@@ -168,12 +168,18 @@ const ThemeSourcedDescription: FunctionComponent<Props> = ({
   useEffect(() => {
     const hideSourceBox = () => {
       if (isSourcePilFocused()) blurActiveElement();
+      updateSourceBoxPosition();
     };
 
     // Hide source box on screen resize to stop it from overflowing the screen
     window.addEventListener('resize', hideSourceBox);
     return () => window.removeEventListener('resize', hideSourceBox);
   }, [sourcePillRef]);
+
+  useEffect(() => {
+    // Prevent horizontal scroll on initial render
+    updateSourceBoxPosition();
+  }, []);
 
   return (
     <>

--- a/content/webapp/components/ThemeWorks/index.tsx
+++ b/content/webapp/components/ThemeWorks/index.tsx
@@ -8,7 +8,6 @@ import {
   formatNumber,
   pluralize,
 } from '@weco/common/utils/grammar';
-import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 import { WobblyEdge } from '@weco/common/views/components/WobblyEdge';
 import theme from '@weco/common/views/themes/default';
@@ -48,6 +47,13 @@ const WorksCount = styled(Space).attrs({
 })`
   color: ${props => props.theme.color('neutral.600')};
   border-top: 1px solid ${props => props.theme.color('warmNeutral.300')};
+`;
+
+const WobblyEdgeWrapper = styled.div`
+  z-index: 0;
+  position: relative;
+  margin-left: calc((100vw - 100%) * -1);
+  ${props => props.theme.pageGridOffset('margin-right')};
 `;
 
 const getAllWorksLink = (tab: ThemeTabType, concept: Concept) => {
@@ -90,38 +96,37 @@ const ThemeWorks: FunctionComponent<Props> = ({ concept, sectionsData }) => {
 
   return (
     <>
-      <WobblyEdge backgroundColor="white" />
+      <WobblyEdgeWrapper>
+        <WobblyEdge backgroundColor="white" />
+      </WobblyEdgeWrapper>
       <Space $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}>
-        <Container>
-          <h2 className={font('intsb', 2)}>Works</h2>
-          {tabs.length > 1 && (
-            <Tabs
-              label="Works tabs"
-              tabBehaviour="switch"
-              selectedTab={selectedTab}
-              items={tabs}
-              setSelectedTab={tab => setSelectedTab(tab as ThemeTabType)}
-              trackWithSegment
-              hideBorder
-            />
-          )}
-        </Container>
+        <h2 className={font('intsb', 2)}>Works</h2>
+        {tabs.length > 1 && (
+          <Tabs
+            label="Works tabs"
+            tabBehaviour="switch"
+            selectedTab={selectedTab}
+            items={tabs}
+            setSelectedTab={tab => setSelectedTab(tab as ThemeTabType)}
+            trackWithSegment
+            hideBorder
+          />
+        )}
+
         <Space as="section" data-testid="works-section">
-          <Container>
-            <div role="tabpanel">
-              <WorksCount>{pluralize(totalWorksCount, 'work')}</WorksCount>
-              <Space $v={{ size: 'l', properties: ['margin-top'] }}>
-                <WorksSearchResults works={activePanel.works!.pageResults} />
-              </Space>
-              <Space $v={{ size: 'l', properties: ['padding-top'] }}>
-                <MoreLink
-                  name={`All works (${formattedTotalCount})`}
-                  url={getAllWorksLink(selectedTab, concept)}
-                  colors={theme.buttonColors.greenGreenWhite}
-                />
-              </Space>
-            </div>
-          </Container>
+          <div role="tabpanel">
+            <WorksCount>{pluralize(totalWorksCount, 'work')}</WorksCount>
+            <Space $v={{ size: 'l', properties: ['margin-top'] }}>
+              <WorksSearchResults works={activePanel.works!.pageResults} />
+            </Space>
+            <Space $v={{ size: 'l', properties: ['padding-top'] }}>
+              <MoreLink
+                name={`All works (${formattedTotalCount})`}
+                url={getAllWorksLink(selectedTab, concept)}
+                colors={theme.buttonColors.greenGreenWhite}
+              />
+            </Space>
+          </div>
         </Space>
       </Space>
     </>

--- a/content/webapp/components/ThemeWorks/index.tsx
+++ b/content/webapp/components/ThemeWorks/index.tsx
@@ -100,7 +100,9 @@ const ThemeWorks: FunctionComponent<Props> = ({ concept, sectionsData }) => {
         <WobblyEdge backgroundColor="white" />
       </WobblyEdgeWrapper>
       <Space $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}>
-        <h2 className={font('intsb', 2)}>Works</h2>
+        <h2 id="works" className={font('intsb', 2)}>
+          Works
+        </h2>
         {tabs.length > 1 && (
           <Tabs
             label="Works tabs"

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -466,24 +466,32 @@ export const ConceptPage: NextPage<Props> = ({
   const { frequentCollaborators, relatedTopics } =
     conceptResponse.relatedConcepts || {};
   const relatedConceptsGroupLabel = 'Related topics';
+  const personOrAllFields =
+    conceptResponse.type === 'Person' || themePagesAllFields;
   const navLinks = [
-    sectionsData.by.images
+    sectionsData.by.images?.totalResults
       ? {
           text: `Images ${getThemeTabLabel('by', conceptResponse.type)}`,
           url: `#images-${getThemeTabLabel('by', conceptResponse.type)}`,
         }
       : undefined,
-    sectionsData.about.images
+    sectionsData.about.images?.totalResults
       ? {
           text: `Images ${getThemeTabLabel('about', conceptResponse.type)}`,
           url: `#images-${getThemeTabLabel('about', conceptResponse.type)}`,
         }
       : undefined,
+    sectionsData.in.images?.totalResults
+      ? {
+          text: `Images ${getThemeTabLabel('in', conceptResponse.type)}`,
+          url: `#images-${getThemeTabLabel('in', conceptResponse.type)}`,
+        }
+      : undefined,
     { text: 'Works', url: '#works' },
-    frequentCollaborators
+    frequentCollaborators?.length && personOrAllFields
       ? { text: 'Frequent collaborators', url: '#frequent-collaborators' }
       : undefined,
-    relatedTopics
+    relatedTopics?.length && personOrAllFields
       ? {
           text: relatedConceptsGroupLabel,
           url: `#${dasherize(relatedConceptsGroupLabel)}`,

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -104,7 +104,15 @@ const NavGridCell = styled(GridCell)<{
     left: 100%;
   }
 
-  ${props => props.theme.media('medium')`
+  ${props =>
+    props.theme.media('medium')(`
+      &::before,
+      &::after {
+        width: ${themeValues.containerPadding.medium}px;
+      }
+  `)}
+
+  ${props => props.theme.media('large')`
     position: unset;
     background-color: unset;
     z-index: unset;
@@ -468,7 +476,7 @@ export const ConceptPage: NextPage<Props> = ({
         <Grid style={{ background: 'white', rowGap: 0 }}>
           <NavGridCell
             $isEnhanced={isEnhanced}
-            $sizeMap={{ s: [12], m: [3], l: [2], xl: [2] }}
+            $sizeMap={{ s: [12], m: [12], l: [2], xl: [2] }}
             $isMobileNavInverted={isMobileNavInverted}
           >
             <OnThisPageAnchors
@@ -499,7 +507,7 @@ export const ConceptPage: NextPage<Props> = ({
             />
           </NavGridCell>
 
-          <GridCell $sizeMap={{ s: [12], m: [9], l: [10], xl: [10] }}>
+          <GridCell $sizeMap={{ s: [12], m: [12], l: [10], xl: [10] }}>
             <StretchWrapper>
               <ThemeImages
                 sectionsData={sectionsData}

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { FunctionComponent, JSX, useState } from 'react';
 import styled from 'styled-components';
 
+import { useAppContext } from '@weco/common/contexts/AppContext';
 import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
 import { ImagesLinkSource } from '@weco/common/data/segment-values';
 import { getServerData } from '@weco/common/server-data';
@@ -71,8 +72,8 @@ const linkSources = new Map([
   ['imagesIn', 'concept/images_in'],
 ]);
 
-const NavGridCell = styled(GridCell)`
-  position: sticky;
+const NavGridCell = styled(GridCell)<{ $isEnhanced: boolean }>`
+  position: ${props => (props.$isEnhanced ? 'sticky' : 'relative')};
   top: 0;
   background-color: ${props => props.theme.color('neutral.700')};
   z-index: 3;
@@ -364,6 +365,7 @@ export const ConceptPage: NextPage<Props> = ({
 }) => {
   useHotjar(true);
   const { newThemePages, themePagesAllFields } = useToggles();
+  const { isEnhanced } = useAppContext();
 
   const pathname = usePathname();
   const worksTabs = tabOrder
@@ -439,7 +441,10 @@ export const ConceptPage: NextPage<Props> = ({
       <WobblyEdge backgroundColor="neutral.700" />
       <Container>
         <Grid style={{ background: 'white', rowGap: 0 }}>
-          <NavGridCell $sizeMap={{ s: [12], m: [3], l: [2], xl: [2] }}>
+          <NavGridCell
+            $isEnhanced={isEnhanced}
+            $sizeMap={{ s: [12], m: [3], l: [2], xl: [2] }}
+          >
             <OnThisPageAnchors
               links={[
                 {

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -511,7 +511,7 @@ export const ConceptPage: NextPage<Props> = ({
       apiToolbarLinks={apiToolbarLinks}
     >
       <ThemeHeader concept={conceptResponse} />
-      <WobblyEdge backgroundColor="neutral.700" />
+      {hasImages && <WobblyEdge backgroundColor="neutral.700" />}
       <Container>
         <Grid style={{ background: 'white', rowGap: 0 }}>
           <NavGridCell

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -108,9 +108,11 @@ const NavGridCell = styled(GridCell)<{
     position: unset;
     background-color: unset;
     z-index: unset;
+    transition: unset;
 
     &::before,
     &::after {
+      transition: unset;
       display: none;
     }
   `}

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -508,7 +508,7 @@ export const ConceptPage: NextPage<Props> = ({
         <Grid style={{ background: 'white', rowGap: 0 }}>
           <NavGridCell
             $isEnhanced={isEnhanced}
-            $sizeMap={{ s: [12], m: [12], l: [2], xl: [2] }}
+            $sizeMap={{ s: [12], m: [12], l: [3], xl: [2] }}
             $isMobileNavInverted={isMobileNavInverted}
           >
             <OnThisPageAnchors
@@ -518,7 +518,7 @@ export const ConceptPage: NextPage<Props> = ({
             />
           </NavGridCell>
 
-          <GridCell $sizeMap={{ s: [12], m: [12], l: [10], xl: [10] }}>
+          <GridCell $sizeMap={{ s: [12], m: [12], l: [9], xl: [10] }}>
             <StretchWrapper>
               <ThemeImages
                 sectionsData={sectionsData}

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -81,7 +81,7 @@ const NavGridCell = styled(GridCell)`
   &::after {
     content: '';
     position: absolute;
-    width: 20px;
+    width: ${themeValues.containerPadding.small}px;
     bottom: 0;
     top: 0;
     z-index: 10;

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -74,7 +74,7 @@ const linkSources = new Map([
 const NavGridCell = styled(GridCell)`
   position: sticky;
   top: 0;
-  background-color: ${props => props.theme.color('white')};
+  background-color: ${props => props.theme.color('neutral.700')};
   z-index: 3;
 
   &::before,
@@ -85,7 +85,7 @@ const NavGridCell = styled(GridCell)`
     bottom: 0;
     top: 0;
     z-index: 10;
-    background-color: white;
+    background-color: ${props => props.theme.color('neutral.700')};
   }
 
   &::before {
@@ -101,8 +101,8 @@ const NavGridCell = styled(GridCell)`
     background-color: unset;
     z-index: unset;
 
-    &:before,
-    &:after {
+    &::before,
+    &::after {
       display: none;
     }
   `}
@@ -438,7 +438,7 @@ export const ConceptPage: NextPage<Props> = ({
       <ThemeHeader concept={conceptResponse} />
       <WobblyEdge backgroundColor="neutral.700" />
       <Container>
-        <Grid style={{ background: 'white' }}>
+        <Grid style={{ background: 'white', rowGap: 0 }}>
           <NavGridCell $sizeMap={{ s: [12], m: [3], l: [2], xl: [2] }}>
             <OnThisPageAnchors
               links={[


### PR DESCRIPTION
For #11994 

## What does this change?
- Moves the theme page into a two-column layout
- Adds the OnThisPageAnchors component to the sidebar
- Adds some mobile behaviour for the OnThisPageAnchors
- Stretches the images to be flush to the edge of the window

## How to test
- Turn on `toggle_newThemePages`
- Visit a theme page (http://localhost:3000/concepts/patspgf3)
- Play around with browser size/try to break stuff
- Check everything's still ok with the toggle off
- 
## How can we measure success?
More engaging and easier to navigate theme pages

## Have we considered potential risks?
Lots of new shiny stuff and toggled content