### PR TITLE
Visual bug fix: Max height on dropdowns

### DIFF
--- a/common/views/components/Buttons/Buttons.Dropdown.tsx
+++ b/common/views/components/Buttons/Buttons.Dropdown.tsx
@@ -47,7 +47,7 @@ const Dropdown = styled(Space).attrs<{ $isTight: boolean }>(props => ({
     transform 350ms ease;
   border-radius: ${props => props.theme.borderRadiusUnit}px;
   box-shadow: ${props => props.theme.basicBoxShadow};
-  max-height: 400px;
+  max-height: 40vh;
 
   &,
   &.fade-exit-done {

--- a/common/views/components/Buttons/Buttons.Dropdown.tsx
+++ b/common/views/components/Buttons/Buttons.Dropdown.tsx
@@ -47,6 +47,7 @@ const Dropdown = styled(Space).attrs<{ $isTight: boolean }>(props => ({
     transform 350ms ease;
   border-radius: ${props => props.theme.borderRadiusUnit}px;
   box-shadow: ${props => props.theme.basicBoxShadow};
+  max-height: 400px;
 
   &,
   &.fade-exit-done {


### PR DESCRIPTION
## What does this change?

Dana's flagged a visual bug that seems to have been there for a long time (I stopped looking after seeing it was there at the end of May and can't recall changes to Dropdown that would've caused this).

[Slack convo](https://wellcome.slack.com/archives/CUA669WHH/p1751540606514549)

Opted for a max-height (although arbitrary number picked, suggestions welcomed) as it was hard to use anyway:
Currently:
<img width="1184" alt="Screenshot 2025-07-03 at 12 26 10" src="https://github.com/user-attachments/assets/5b7a5e39-e083-4e3f-b348-1ce197e89d63" />

This branch:
<img width="566" alt="Screenshot 2025-07-03 at 12 25 44" src="https://github.com/user-attachments/assets/5d2bef12-e5ed-4a9f-ab7a-06bf15fc1964" />

If we think more changes are required, please flag so. This is vm a quick fix.

## How to test

Run it?

## How can we measure success?

No more huge white space under footer, but also easier to use as it's not mega long anymore.

## Have we considered potential risks?
N/A?