### PR TITLE
Check for works before adding nav item

### DIFF
--- a/content/webapp/views/concepts/concept/index.tsx
+++ b/content/webapp/views/concepts/concept/index.tsx
@@ -320,7 +320,9 @@ const ConceptPage: NextPage<Props> = ({
     }
 
     // Add works section
-    hasWorks && links.push({ text: 'Works', url: '#works' });
+    if (hasWorks) {
+      links.push({ text: 'Works', url: '#works' });
+    }
 
     // Add frequent collaborators
     if (frequentCollaborators?.length && personOrAllFields) {


### PR DESCRIPTION
For #12103

## What does this change?
Prevents including a 'works' nav item if there aren't any works

## How to test
I can't find any concepts without works ([the one referenced in the issue](https://wellcomecollection.org/concepts/k4t8ncej) does have works now)

## How can we measure success?
No broken ui

## Have we considered potential risks?
n/a

