### PR TITLE
Move hotjar placeholder  into right column

### DIFF
--- a/content/webapp/views/concepts/concept/index.tsx
+++ b/content/webapp/views/concepts/concept/index.tsx
@@ -413,18 +413,17 @@ const ConceptPage: NextPage<Props> = ({
                 </Space>
               </>
             )}
+            {
+              // This is a placeholder for the Hotjar embedded survey to be injected
+              // when the concept is a Person. It should be removed when the survey
+              // is no longer used.
+            }
+            {conceptResponse.type === 'Person' && (
+              <HotJarPlaceholder id="hotjar-embed-placeholder-concept-person" />
+            )}
           </GridCell>
         </Grid>
       </Container>
-
-      {
-        // This is a placeholder for the Hotjar embedded survey to be injected
-        // when the concept is a Person. It should be removed when the survey
-        // is no longer used.
-      }
-      {conceptResponse.type === 'Person' && (
-        <HotJarPlaceholder id="hotjar-embed-placeholder-concept-person" />
-      )}
     </CataloguePageLayout>
   ) : (
     <CataloguePageLayout


### PR DESCRIPTION
For #12103

## What does this change?
Aligns the hotjar poll with the other elements in the right column

## How to test
The poll only appears on prod, so you'll have to trust me

<img width="1258" alt="Screenshot 2025-07-10 at 10 47 31" src="https://github.com/user-attachments/assets/4d36b0ff-e56f-4b8a-a0a1-b54538b11488" />

## How can we measure success?
nicer UI

## Have we considered potential risks?
n/a