### PR TITLE
Allow click to dismiss overlay

### DIFF
--- a/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.styles.tsx
+++ b/content/webapp/components/OnThisPageAnchors/OnThisPageAnchors.styles.tsx
@@ -6,17 +6,15 @@ import { themeValues } from '@weco/common/views/themes/config';
 
 const leftOffset = '12px';
 
-export const BackgroundOverlay = styled.div<{ $isActive: boolean }>`
+export const BackgroundOverlay = styled.div`
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: ${props =>
-    props.$isActive ? props.theme.color('black') : 'transparent'};
-  opacity: ${props => (props.$isActive ? 0.7 : 0)};
-  transition: opacity ${props => props.theme.transitionProperties};
-  z-index: ${props => (props.$isActive ? '10' : '-1')};
+  background-color: ${props => props.theme.color('black')};
+  opacity: 0.7;
+  z-index: 10;
 `;
 
 export const ListItem = styled.li<{ $hasStuck: boolean }>`

--- a/content/webapp/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/components/OnThisPageAnchors/index.tsx
@@ -133,16 +133,18 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
 
   return (
     <>
-      <BackgroundOverlay
-        data-lock-scroll={`${isListActive}`}
-        $isActive={isListActive}
-        onClick={() => setIsListActive(false)}
-      />
+      {isListActive && (
+        <BackgroundOverlay
+          data-lock-scroll="true"
+          onClick={() => setIsListActive(false)}
+        />
+      )}
       <div ref={onThisPageAnchorsStickyRef}></div>
       <FocusTrap
         active={isListActive}
         focusTrapOptions={{
           returnFocusOnDeactivate: false,
+          clickOutsideDeactivates: true,
         }}
       >
         <Root


### PR DESCRIPTION
## What does this change?
Only show the overlay at all if the mobile menu is active, so that elements underneath aren't prevented from being clicked.

Add the `clickOutsideDeactivates` option to `FocusTrap` that allows dismissing of the trap when the overlay is clicked

## How to test
Visit [a concept](http://localhost:3000/concepts/patspgf3#works) with a small screen. Check you can click on things. Check you can click on the overlay once the menu is open to dismiss the menu and overlay.

## How can we measure success?
People can use the website

## Have we considered potential risks?
We lose the overlay transition (I don't think this is a big deal, but we can work out a way to reintroduce it if it is)