### PR TITLE
Apply scroll margin to the data-id sections

### DIFF
--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -164,6 +164,16 @@ export const typography = css<GlobalStyleProps>`
     margin: 0 0 0.6em;
   }
 
+  [data-id] :is(h2, h3) {
+    /* Enough space to clear the sticky header */
+    scroll-margin-top: 3rem;
+
+    @media (min-width: ${themeValues.sizes.large}px) {
+      /* Align the top of the heading with the top of the side navigation */
+      scroll-margin-top: ${themeValues.spaceAtBreakpoints.large.l}px;
+    }
+  }
+
   a {
     color: inherit;
     text-decoration: underline;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -164,6 +164,10 @@ export const typography = css<GlobalStyleProps>`
     margin: 0 0 0.6em;
   }
 
+  /*
+  OnThisPageAnchors.sticky relies on sections with data-id attributes
+  and we want to adjust the scroll margin for headings within those sections
+  */
   [data-id] :is(h2, h3) {
     /* Enough space to clear the sticky header */
     scroll-margin-top: 3rem;


### PR DESCRIPTION
For #12103 

## What does this change?
Applies `scroll-margin-top` to h2s and h3s that are children of `data-id` sections (which we have recently created to deal with the scroll-spy OnThisPageAnchors).

There's enough (3rem) margin to clear the sticky header on mobile, then an equivalent amount of space as the side nav has, to make the top of the header align with the top of the side nav on desktop.

__desktop__
<img width="706" height="346" alt="image" src="https://github.com/user-attachments/assets/fce0f030-6704-40fa-ba43-1076a224ec98" />

__mobile__
<img width="568" height="348" alt="image" src="https://github.com/user-attachments/assets/830c1305-2442-4281-9698-24b11915abe7" />


- [x] @dana-saur to confirm/deny heading should be visible on mobile

## How to test
- Visit a [concept](http://localhost:3000/concepts/patspgf3) page, click in the side nav, verify there is space above the headings
- Make the window small, click in the mobile nav, verify the headings are visible below the nav

## How can we measure success?
Nicer UI

## Have we considered potential risks?
Maybe the [data-id] selector is a bit vague (could be section[data-id] perhaps?) I don't mind it like this, but happy to change it if others don't like it.