### PR TITLE
Remove hash entirely after closing expanded image modal

### DIFF
--- a/content/webapp/components/CatalogueImageGallery/useExpandedImage.ts
+++ b/content/webapp/components/CatalogueImageGallery/useExpandedImage.ts
@@ -25,7 +25,16 @@ const useExpandedImage = (
   );
 
   const setImageIdInURL = (id: string) => {
-    window.location.hash = id;
+    if (id) {
+      window.location.hash = id;
+    } else {
+      // Remove hash completely from URL instead of leaving empty hash
+      history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search
+      );
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## What does this change?
This makes sure there isn't a `#` in the url (without an `id`) when the expanded image modal is closed

## How to test
Visit a [page with an image gallery](http://localhost:3000/concepts/patspgf3), click on an image – check the `#{id}` is in the url, close the image, check there isn't a `#` in the url

## How can we measure success?
Clean urls

## Have we considered potential risks?
can't think of any