### PR TITLE
Take padding off placeholder (use container where needed)

### DIFF
--- a/content/webapp/views/pages/concepts/concept/concept.styles.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.styles.tsx
@@ -82,10 +82,8 @@ export const HotJarPlaceholder = styled.div`
   margin: -2rem auto 2rem;
   width: 100%;
   max-width: ${themeValues.sizes.xlarge}px;
-
   display: grid;
   justify-items: start;
-  padding: 0 ${themeValues.containerPadding.small}px;
 
   div:has(form) {
     min-width: 250px;
@@ -94,14 +92,12 @@ export const HotJarPlaceholder = styled.div`
   grid-template-columns: 1fr auto;
 
   ${themeValues.media('medium')(`
-    padding: 0 ${themeValues.containerPadding.medium}px;
     div:has(form) {
       min-width: 350px;
     }
   `)}
 
   ${themeValues.media('large')(`
-    padding: 0 ${themeValues.containerPadding.large}px;
     div:has(form) {
       min-width: 450px;
     }

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -496,7 +496,9 @@ const ConceptPage: NextPage<Props> = ({
         // is no longer used.
       }
       {conceptResponse.type === 'Person' && (
-        <HotJarPlaceholder id="hotjar-embed-placeholder-concept-person" />
+        <Container>
+          <HotJarPlaceholder id="hotjar-embed-placeholder-concept-person" />
+        </Container>
       )}
     </CataloguePageLayout>
   );


### PR DESCRIPTION
## What does this change?
Using the `Container` to determine the right amount of space around the hotjar component instead of being defined on the placeholder itself. This allows us to align it properly whether it's in the right-hand column or not.


__before__
<img width="775" height="484" alt="image" src="https://github.com/user-attachments/assets/862ac6b4-3635-4ce0-9f11-0bbadccb4bdf" />

__after__ (probably)
<img width="988" height="693" alt="Screenshot 2025-07-10 at 15 10 10" src="https://github.com/user-attachments/assets/3fad4c90-efa8-4f6f-b8b2-6123a980e183" />


## How to test
Think you'll have to trust me again

## How can we measure success?
Nicer ui

## Have we considered potential risks?
I've missed something because I can't see it locally (but I don't think I have)

