### PR TITLE
Use data-lock-scroll with :has() instead of is-scroll-locked classes

### DIFF
--- a/common/views/components/Header/index.tsx
+++ b/common/views/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import { FocusTrap } from 'focus-trap-react';
 import NextLink from 'next/link';
-import { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { FunctionComponent, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
@@ -99,27 +99,15 @@ const Header: FunctionComponent<Props> = ({
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const { isEnhanced } = useAppContext();
 
-  useEffect(() => {
-    if (document && document.documentElement) {
-      if (searchDropdownIsActive || burgerMenuIsActive) {
-        document.documentElement.classList.add('is-scroll-locked');
-        document.getElementById('global-search-input')?.focus();
-      } else {
-        document.documentElement.classList.remove('is-scroll-locked');
-      }
-    }
-
-    return () => {
-      document.documentElement.classList.remove('is-scroll-locked');
-    };
-  }, [searchDropdownIsActive, burgerMenuIsActive]);
-
   return (
     <FocusTrap
       active={searchDropdownIsActive || burgerMenuIsActive}
       focusTrapOptions={{ preventScroll: true }}
     >
-      <header className="is-hidden-print">
+      <header
+        className="is-hidden-print"
+        data-lock-scroll={searchDropdownIsActive || burgerMenuIsActive}
+      >
         <Wrapper $isBurgerOpen={burgerMenuIsActive}>
           <div style={{ position: 'relative' }}>
             <HeaderContainer>

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -98,20 +98,6 @@ const Modal: FunctionComponent<Props> = ({
     }
   }, [isActive]);
 
-  useEffect(() => {
-    if (document && document.documentElement) {
-      if (isActive && hasAcknowledgedCookieBanner) {
-        document.documentElement.classList.add('is-scroll-locked');
-      } else {
-        document.documentElement.classList.remove('is-scroll-locked');
-      }
-    }
-
-    return () => {
-      document.documentElement.classList.remove('is-scroll-locked');
-    };
-  }, [isActive, hasAcknowledgedCookieBanner]);
-
   return (
     <FocusTrap
       active={isActive && hasAcknowledgedCookieBanner}
@@ -120,6 +106,7 @@ const Modal: FunctionComponent<Props> = ({
       <div>
         {isActive && showOverlay && (
           <Overlay
+            data-lock-scroll="true"
             onClick={() => {
               if (!removeCloseButton) {
                 setIsActive(false);

--- a/common/views/themes/base/layout.ts
+++ b/common/views/themes/base/layout.ts
@@ -1,5 +1,3 @@
-import { themeValues } from '@weco/common/views/themes/config';
-
 export const layout = `
 * {
   &,
@@ -7,12 +5,6 @@ export const layout = `
   &::after {
     box-sizing: border-box;
   }
-}
-
-.is-scroll-locked {
-  margin: 0;
-  height: 100vh;
-  overflow: hidden;
 }
 
 @supports selector(:has(a)) {
@@ -28,19 +20,5 @@ export const layout = `
       scroll-behavior: smooth;
     }
   }
-}
-
-
-
-
-.is-scroll-locked--to-medium {
-  ${themeValues.mediaBetween(
-    'small',
-    'medium'
-  )(`
-      margin: 0;
-      height: 100vh;
-      overflow: hidden;
-  `)}
 }
 `;

--- a/content/webapp/views/components/ExpandedImage/index.tsx
+++ b/content/webapp/views/components/ExpandedImage/index.tsx
@@ -247,14 +247,6 @@ const ExpandedImage: FunctionComponent<Props> = ({
     }
   }, [detailedWork]);
 
-  useEffect(() => {
-    document?.documentElement?.classList.add('is-scroll-locked');
-
-    return () => {
-      document?.documentElement?.classList.remove('is-scroll-locked');
-    };
-  }, []);
-
   const iiifImageLocation = image?.locations[0];
   const license =
     iiifImageLocation?.license &&
@@ -291,7 +283,7 @@ const ExpandedImage: FunctionComponent<Props> = ({
   const displayTitle = detailedWork?.title ?? '';
 
   return (
-    <Container>
+    <Container data-lock-scroll={isActive}>
       <ImageInfoWrapper>
         {iiifImageLocation && expandedImageLink && (
           <ImageWrapper>

--- a/content/webapp/views/components/SearchFilters/SearchFilters.Mobile.tsx
+++ b/content/webapp/views/components/SearchFilters/SearchFilters.Mobile.tsx
@@ -186,32 +186,18 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
   const [isActive, setIsActive] = useState(false);
 
   useSkipInitialEffect(() => {
-    function setPageScrollLock(value: boolean) {
-      if (document.documentElement) {
-        if (value) {
-          document.documentElement.classList.add('is-scroll-locked--to-medium');
-        } else {
-          document.documentElement.classList.remove(
-            'is-scroll-locked--to-medium'
-          );
-        }
-      }
-    }
-
     const focusables =
       filtersModalRef &&
       filtersModalRef.current &&
       getFocusableElements<HTMLDivElement>(filtersModalRef.current);
 
     if (isActive) {
-      setPageScrollLock(true);
       focusables &&
         focusables.forEach(focusable => focusable.removeAttribute('tabIndex'));
       const firstFocusable = focusables && focusables[0];
 
       firstFocusable && firstFocusable.focus();
     } else {
-      setPageScrollLock(false);
       focusables &&
         focusables.forEach(focusable =>
           focusable.setAttribute('tabIndex', '-1')
@@ -236,7 +222,7 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
   }
 
   return (
-    <SearchFiltersContainer>
+    <SearchFiltersContainer data-lock-scroll={isActive}>
       <ShameButtonWrap>
         <StyledButton
           type={ButtonTypes.button}


### PR DESCRIPTION
## What does this change?
Removes our `.is-scroll-locked` classes (and associated `useEffects`) in favour of having a component having a `data-lock-scroll` attribute which, in conjunction with `:has()` gives us a more declarative way to determine when to lock/unlock scroll

## How to test
Check that scroll locks for modals, the burger nav, the desktop and mobile filters.

## How can we measure success?
Less code easier to maintain

## Have we considered potential risks?
can't think of any