### PR TITLE
Pin scroll position when opening/closing image modal

### DIFF
--- a/content/webapp/views/components/CatalogueImageGallery/useExpandedImage.ts
+++ b/content/webapp/views/components/CatalogueImageGallery/useExpandedImage.ts
@@ -61,11 +61,19 @@ const useExpandedImage = (
 
   useEffect(() => {
     if (expandedImage !== undefined) {
+      // Store the current scroll position
+      const scrollY = window.scrollY;
       hasBeenExpanded.current = true;
       setImageIdInURL(expandedImage?.id || '');
+      // The browser will try to scroll to the #id but we
+      // want to keep it where it is
+      window.scroll(0, scrollY);
     } else if (hasBeenExpanded.current) {
       // clear the url of the fragments and also removes the # symbol
       setImageIdInURL('');
+      // The url now has an empty hash so the browser will try to scroll
+      // to the top but we want to keep it where it is
+      window.scroll(0, scrollY);
     }
   }, [expandedImage]);
 


### PR DESCRIPTION
## What does this change?
Stops the browser scrolling to the hash of the clicked image when opening the image modal. This has apparently always been a thing, but now that we add `scroll-behavior: smooth` it is much more noticeable/jarring.

__before__
![before](https://github.com/user-attachments/assets/a6d7c5db-5d2f-4d74-9cdb-6b8d89b4a03b)

__after__
![after](https://github.com/user-attachments/assets/82e8ad19-767f-486d-b6fd-af75fb055fff)


## How to test
Visit a [page with an image modal](http://localhost:3000/concepts/patspgf3), click the images, check there's little to no visible scrolling either when the image opens or closes

## How can we measure success?
People don't feel like they're going to be sick when they open an image

## Have we considered potential risks?
can't think of any