### PR TITLE
Add data-id to work link component

### DIFF
--- a/content/webapp/views/components/ImageWithTasl/ImageWithTasl.WorkLink.tsx
+++ b/content/webapp/views/components/ImageWithTasl/ImageWithTasl.WorkLink.tsx
@@ -33,7 +33,7 @@ const WorkLinkComponent = ({ taslSourceLink }: { taslSourceLink?: string }) => {
   if (!taslSourceLink) return null;
 
   return (
-    <div style={{ display: 'block' }}>
+    <div style={{ display: 'block' }} data-id="work-link-component">
       <WorkLinkContainer className={font('intm', 5)}>
         <WorkIcon
           src="https://i.wellcomecollection.org/assets/icons/favicon-32x32.png"


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/wellcomecollection.org/issues/12096#issuecomment-3058131514

We think we could use the `DOM Ready` trigger with a DOM variable in GTM to send an event when an element in detected on the page and this helps us test.

## How to test

Is it in the DOM?


## How can we measure success?

It works!

## Have we considered potential risks?
There are none.