### PR TITLE
Only lock scroll if nav has stuck

### DIFF
--- a/content/webapp/views/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/views/components/OnThisPageAnchors/index.tsx
@@ -135,7 +135,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
     <>
       {isListActive && (
         <BackgroundOverlay
-          data-lock-scroll="true"
+          data-lock-scroll={hasStuck}
           onClick={() => setIsListActive(false)}
         />
       )}


### PR DESCRIPTION
## What does this change?
When you open the mobile navigation currently it locks the page so you can't scroll, but it is possible that the nav is low down on the page at that point, and that you consequently can't get to some of the items inside it. This PR only locks the page scroll once the nav has stuck to the top of the screen so all the items can be tapped.

## How to test
Go to a [concept page](http://localhost:3000/concepts/patspgf3) with a narrow enough screen to have the mobile version of the nav. Click on 'On this page' before it has scrolled and stuck to the top of the screen, and verify that you can still scroll the page up until the point that it sticks to the top of the screen.

## How can we measure success?
People can navigate the page

## Have we considered potential risks?
Can't think of any