### PR TITLE
Add custom pageview event to _app for GTM

### DIFF
--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -131,6 +131,14 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
     };
   }, []);
 
+  // GTM can't seem to handle pageview events when we use NextLink,
+  // so we push a custom event to the dataLayer and that instead
+  useEffect(() => {
+    window.dataLayer?.push({
+      event: 'custom_pageview',
+    });
+  }, [router.pathname]);
+
   useEffect(() => {
     if (pageProps.pageview) {
       trackPageview({

--- a/content/webapp/views/components/ImageWithTasl/ImageWithTasl.WorkLink.tsx
+++ b/content/webapp/views/components/ImageWithTasl/ImageWithTasl.WorkLink.tsx
@@ -33,7 +33,7 @@ const WorkLinkComponent = ({ taslSourceLink }: { taslSourceLink?: string }) => {
   if (!taslSourceLink) return null;
 
   return (
-    <div style={{ display: 'block' }} data-id="work-link-component">
+    <div style={{ display: 'block' }} data-gtm-id="work-link-component">
       <WorkLinkContainer className={font('intm', 5)}>
         <WorkIcon
           src="https://i.wellcomecollection.org/assets/icons/favicon-32x32.png"


### PR DESCRIPTION
## What does this change?

So there is an issue with GTM and `NextLink`. As it uses client-side navigation (via the Next.js router) instead of triggering a full page reload, the default GTM pageview trigger (which listens for traditional page loads) seems to not fire on route changes.

From what I've seen online, the solution is to trigger our own pageview event on route changes (see risks below).

The GTM side is;
A tag that fires the GA event on EITHER just "DOM Ready: the component is there" OR "custom pageview event: the component is there", which covers all cases.

<img width="400" height="840" alt="Screenshot 2025-07-14 at 13 56 46" src="https://github.com/user-attachments/assets/4f2ad94a-e223-4b21-8d2e-629dfb0c890f" />

**I'll be honest here; I don't know why it needs both to work. I thought just the custom event should work but it doesn't seem to work without the DOM Ready event?? Any ideas?**

<img width="613" height="286" alt="Screenshot 2025-07-14 at 14 07 17" src="https://github.com/user-attachments/assets/0cc66ef0-a761-4954-bd5e-f47e708c15ce" />
The variable is our first DOM Element variable I think, I think it's a nice way to detect if some elements are in the page which is a request that comes often

I changed `data-id` to `data-gtm-id` too because it should be clear it's used within GTM. 

## How to test

Run locally with the GTM preview and make sure the `featured_works_displayed` event is triggered on the right pages (list of example pages [here](https://github.com/wellcomecollection/wellcomecollection.org/pull/12098)), from a few different places;

- Story listing
- Story search listing
- All search listing

Ofc it doesn't just show on stories so do have a look at other examples!

## How can we measure success?

If this works, then our input can be minimal when Analytics want to know when X element is displayed - we'll know it can mostly be done within GTM.

## Have we considered potential risks?
This is something that does fire on every pathname change; is it too extra??