### PR TITLE
Use WorkLink in htmlserializer

### DIFF
--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -218,7 +218,7 @@ export const typography = css<GlobalStyleProps>`
       margin-bottom: 0;
     }
 
-    * + * {
+    * + *:not(.spaced-text-reset) {
       margin-top: ${themeValues.spacedTextTopMargin};
     }
 

--- a/content/webapp/views/components/HTMLSerializers/index.tsx
+++ b/content/webapp/views/components/HTMLSerializers/index.tsx
@@ -7,6 +7,11 @@ import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { dasherize } from '@weco/common/utils/grammar';
 import { getMimeTypeFromExtension } from '@weco/content/utils/mime';
 import DownloadLink from '@weco/content/views/components/DownloadLink';
+import {
+  WorkIcon,
+  WorkLink,
+  WorkLinkContainer,
+} from '@weco/content/views/components/ImageWithTasl/ImageWithTasl.WorkLink';
 
 const DocumentType = styled.span`
   color: ${props => props.theme.color('neutral.600')};
@@ -107,11 +112,28 @@ export const defaultSerializer: JSXFunctionSerializer = (
 
       const isInPage = linkUrl.match(/^https:\/\/(#.*)/i);
       const hashLink = isInPage && isInPage[1];
+      const isWorkLink = linkUrl.match(
+        /^https:\/\/wellcomecollection.org\/works/i
+      );
 
       const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
 
       const documentType =
         fileExtension && fileExtension[0].substring(1).toUpperCase();
+
+      if (isWorkLink) {
+        return (
+          <WorkLinkContainer data-id="work-link-component">
+            <WorkIcon
+              src="https://i.wellcomecollection.org/assets/icons/favicon-32x32.png"
+              alt=""
+            />
+            <WorkLink className="link-reset spaced-text-reset" href={linkUrl}>
+              {children}
+            </WorkLink>
+          </WorkLinkContainer>
+        );
+      }
 
       if (hashLink) {
         return (

--- a/content/webapp/views/components/HTMLSerializers/index.tsx
+++ b/content/webapp/views/components/HTMLSerializers/index.tsx
@@ -10,7 +10,6 @@ import DownloadLink from '@weco/content/views/components/DownloadLink';
 import {
   WorkIcon,
   WorkLink,
-  WorkLinkContainer,
 } from '@weco/content/views/components/ImageWithTasl/ImageWithTasl.WorkLink';
 
 const DocumentType = styled.span`
@@ -123,7 +122,11 @@ export const defaultSerializer: JSXFunctionSerializer = (
 
       if (isWorkLink) {
         return (
-          <WorkLinkContainer data-id="work-link-component">
+          <div
+            data-id="work-link-component"
+            className="spaced-text-reset"
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          >
             <WorkIcon
               src="https://i.wellcomecollection.org/assets/icons/favicon-32x32.png"
               alt=""
@@ -131,7 +134,7 @@ export const defaultSerializer: JSXFunctionSerializer = (
             <WorkLink className="link-reset spaced-text-reset" href={linkUrl}>
               {children}
             </WorkLink>
-          </WorkLinkContainer>
+          </div>
         );
       }
 

--- a/content/webapp/views/components/ImageWithTasl/ImageWithTasl.WorkLink.tsx
+++ b/content/webapp/views/components/ImageWithTasl/ImageWithTasl.WorkLink.tsx
@@ -3,21 +3,21 @@ import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
-const WorkLinkContainer = styled(Space).attrs({
+export const WorkLinkContainer = styled(Space).attrs({
   $v: { size: 'm', properties: ['margin-top'] },
 })`
   display: inline-flex;
   align-items: center;
 `;
 
-const WorkLink = styled.a`
+export const WorkLink = styled.a`
   margin-left: 0.25rem;
   text-decoration-style: dotted;
   text-underline-offset: 26%;
   text-decoration-thickness: 8%;
 `;
 
-const WorkIcon = styled.img`
+export const WorkIcon = styled.img`
   width: 16px;
   height: 16px;
 `;


### PR DESCRIPTION
For #12066 

## What does this change?
Reuses the styled component from ImageWithTasl.WorkLink for use with links to works from Prismic text slices. Now that we're using it in two places, where would we prefer to declare `WorkLink`? inside the Styled directory maybe?

## How to test
Visit a [story containing a link to a work](http://localhost:3000/stories/how-the-slave-trades-medical-legacies-persist), verify the style of those links is distinct from the others

<img width="333" height="155" alt="image" src="https://github.com/user-attachments/assets/5176854d-67a4-4b96-84aa-364d37c5fc08" />

I had to update the lobotomised owl selector to stop margin-top being added to the wrapper and the link (since they both had previous which would have been matched by `* + *`). The original article suggested [using a class to remove the margin](https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/#section11) but I think that pre-dated the existence of `:not()` which feels like a better fit to me?

## How can we measure success?
With GTM

## Have we considered potential risks?
Can't think of any