### PR TITLE
OnThisPageAnchors design QA amends

### DIFF
--- a/content/webapp/views/components/OnThisPageAnchors/OnThisPageAnchors.styles.tsx
+++ b/content/webapp/views/components/OnThisPageAnchors/OnThisPageAnchors.styles.tsx
@@ -7,8 +7,15 @@ import { themeValues } from '@weco/common/views/themes/config';
 
 const leftOffset = '12px';
 
-export const InPageNavList = styled(PlainList)`
-  border-bottom: 1px solid ${props => props.theme.color('white')};
+export const InPageNavList = styled(PlainList)<{ $isSticky: boolean }>`
+  ${props =>
+    props.$isSticky
+      ? `border-bottom: 1px solid ${props.theme.color('white')}`
+      : ''};
+
+  ${props => props.theme.media('large')`
+    border-bottom: 0;
+  `}
 `;
 export const BackgroundOverlay = styled.div`
   position: fixed;

--- a/content/webapp/views/components/OnThisPageAnchors/index.tsx
+++ b/content/webapp/views/components/OnThisPageAnchors/index.tsx
@@ -227,7 +227,7 @@ const OnThisPageAnchors: FunctionComponent<Props> = ({
               {isEnhanced && <Icon icon={cross} matchText />}
             </MobileNavButton>
           )}
-          <InPageNavList ref={listRef} id={listId}>
+          <InPageNavList ref={listRef} id={listId} $isSticky={isSticky}>
             {links.map((link: Link) => {
               const id = link.url.replace('#', '');
               const isActive = activeId === id;


### PR DESCRIPTION
## What does this change?
- makes the nav white instead of green
- alters the transition type/speed
- removes the transition to/from 'On this page' when opening/closing nav
- adds a border below the nav when opened before it has stuck
- prevents scroll introduced by the focus-trap (I think)

## How to test
Visit a concept page and check the things listed above happen

## How can we measure success?
Happy designers

## Have we considered potential risks?
can't think of any