### PR TITLE
Add an e2e for concept -> work -> concept back button

### DIFF
--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -40,6 +40,28 @@ const test = base.extend<{
   },
 });
 
+test.describe('navigating to/from a work page from a concept page', () => {
+  test('the concept -> work -> concept journey with the browser back button', async ({
+    armyPage,
+  }) => {
+    // Click on the first work in the "works by" section
+    await armyPage.worksByTabPanel.getByRole('listitem').first().click();
+
+    // The work page should be visible
+    await expect(armyPage.page).toHaveURL(/\/works\//);
+
+    // Click the browser back button
+    await armyPage.page.goBack();
+
+    // The concept page should be visible again
+    await expect(armyPage.page).toHaveURL(/\/concepts\//);
+
+    // Check something we know should exist on the concept page is visible
+    // (we have had instances of the URL being correct but displaying the wrong content)
+    await expect(armyPage.worksAboutTab).toBeVisible();
+  });
+});
+
 test.describe('a Concept representing an Agent with no Images', () => {
   test('only has works tabs', async ({ thackrahPage }) => {
     // It has two tabs for works


### PR DESCRIPTION
## What does this change?
We previously encountered a [bug](https://github.com/wellcomecollection/wellcomecollection.org/issues/12042#issuecomment-3049213573) where navigating from a concept to a work and back again didn't present the correct concept page information even though the URL was correct. Adding an e2e to make sure we don't introduce a regression.

## How to test
`cd playwright && yarn test test/concept.test.ts`

## How can we measure success?
We get notified if things break before anyone else knows

## Have we considered potential risks?
n/a