### PR TITLE
Scrollable image gallery; Add something specific to long last images

### DIFF
--- a/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.Buttons.tsx
+++ b/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.Buttons.tsx
@@ -61,13 +61,13 @@ const ScrollableGalleryButtons: FunctionComponent<Props> = ({
     if (!targetRef.current) return;
     updateScrollButtons();
 
-    targetRef.current.addEventListener('scroll', updateScrollButtons);
+    targetRef.current.addEventListener('scrollend', updateScrollButtons);
     window.addEventListener('resize', updateScrollButtons);
     return () => {
-      targetRef.current?.removeEventListener('scroll', updateScrollButtons);
+      targetRef.current?.removeEventListener('scrollend', updateScrollButtons);
       window.removeEventListener('resize', updateScrollButtons);
     };
-  });
+  }, []);
 
   const scrollByChildImageWidth = (direction: SwipeDirection) => {
     if (!targetRef.current) return;
@@ -90,7 +90,17 @@ const ScrollableGalleryButtons: FunctionComponent<Props> = ({
             child => child.offsetLeft < currScrollLeft + containerPadding
           );
 
-    if (!child) return;
+    if (!child) {
+      if (direction === 'right') {
+        // This is a suggested patch for when the last image is too long to fit in the viewport.
+        // Scroll to the end of the last child.
+        return targetRef.current.scrollTo({
+          left: currScrollLeft + children[children.length - 1].offsetWidth,
+          behavior: 'smooth',
+        });
+      }
+      return;
+    }
 
     targetRef.current.scrollTo({
       left: child.offsetLeft - containerPadding,
@@ -100,9 +110,7 @@ const ScrollableGalleryButtons: FunctionComponent<Props> = ({
 
   useSwipeable(targetRef, scrollByChildImageWidth);
 
-  if (!canScrollLeft && !canScrollRight) {
-    return null;
-  }
+  if (!canScrollLeft && !canScrollRight) return null;
 
   return (
     <ScrollButtonsContainer>


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12104

Addresses this one specific case where the last image is so long that we never reach "the end" and the Next button is never disabled: https://wellcomecollection.org/concepts/usqyr9ur

I don't love it, I tried to do really complex maths to make it nicer, etc. but there was a lot of edge casing to consider; I wonder if we could use scroll libraries instead?

## How to test

Go on the page www-dev.wellcomecollection.org/concepts/usqyr9ur and test you do get to reach the end of the container and the Next button does disable.

Does it affect negatively other scrollable image containers?

## How can we measure success?

Less broken looking

## Have we considered potential risks?

Does it affect any other cases?