### PR TITLE
Don't lock scroll on desktop

### DIFF
--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
@@ -52,17 +52,27 @@ const InPageNavigationSticky: FunctionComponent<Props> = ({
   const [hasStuck, setHasStuck] = useState(false);
   const [isListActive, setIsListActive] = useState(false);
   const [scrollPosition, setScrollposition] = useState(0);
+  const prevHasStuckRef = useRef(false);
 
   const shouldLockScroll = useMemo(() => {
     return windowSize !== 'large' && isListActive && hasStuck;
   }, [windowSize, isListActive, hasStuck]);
 
   useEffect(() => {
-    // We close the mobile nav if the user resizes their window to the large bp
-    if (windowSize === 'large' && hasStuck) {
+    // We close the mobile nav if it's open when we're going from !hasStuck to hasStuck
+
+    if (hasStuck && !prevHasStuckRef.current && isListActive) {
       setIsListActive(false);
     }
-  }, [windowSize, hasStuck]);
+    prevHasStuckRef.current = hasStuck;
+  }, [hasStuck, isListActive]);
+
+  useEffect(() => {
+    // We close the mobile nav if the user resizes their window to the large bp
+    if (windowSize === 'large' && hasStuck && isListActive) {
+      setIsListActive(false);
+    }
+  }, [windowSize, hasStuck, isListActive]);
 
   useEffect(() => {
     if (!buttonRef.current) return;


### PR DESCRIPTION
## What does this change?
Currently if you open the mobile nav (`isListActive`) then resize your browser to the large breakpoint the scroll is still locked with the dark overlay on top of the other page elements. 

This adds the window size to the conditions under which we show the overlay/lock scroll.

## How to test
Open the mobile version of the InPageNavigation (on e.g. a [concept page](http://localhost:3000/concepts/jt2q9muw)). Check the scroll is locked and overlay present. Resize the window till the desktop version of the InPageNavigation is visible. Check that you can scroll and the overlay isn't visible.

## How can we measure success?
Better UX

## Have we considered potential risks?
n/a