### PR TITLE
Use window.matchMedia to determine AppContext windowSize

### DIFF
--- a/common/contexts/AppContext/index.tsx
+++ b/common/contexts/AppContext/index.tsx
@@ -122,7 +122,6 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     ];
 
     const handleMediaChange = () => {
-      console.log(getWindowSize());
       setWindowSize(getWindowSize());
     };
 

--- a/common/contexts/AppContext/index.tsx
+++ b/common/contexts/AppContext/index.tsx
@@ -63,19 +63,6 @@ function checkForMobileOrTabletDevice(): boolean {
   );
 }
 
-function getWindowSize(): Size {
-  switch (true) {
-    case window.innerWidth < theme.sizes.medium:
-      return 'small';
-    case window.innerWidth < theme.sizes.large:
-      return 'medium';
-    case window.innerWidth < theme.sizes.xlarge:
-      return 'large';
-    default:
-      return 'xlarge';
-  }
-}
-
 export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
@@ -110,9 +97,44 @@ export const AppContextProvider: FunctionComponent<PropsWithChildren> = ({
     setWindowSize(getWindowSize());
   }
 
+  const smallMatch = `(max-width: ${theme.sizes.medium - 1}px)`;
+  const mediumMatch = `(max-width: ${theme.sizes.large - 1}px)`;
+  const largeMatch = `(max-width: ${theme.sizes.xlarge - 1}px)`;
+
+  function getWindowSize(): Size {
+    if (window.matchMedia(smallMatch).matches) {
+      return 'small';
+    }
+    if (window.matchMedia(mediumMatch).matches) {
+      return 'medium';
+    }
+    if (window.matchMedia(largeMatch).matches) {
+      return 'large';
+    }
+    return 'xlarge';
+  }
+
   useEffect(() => {
-    window.addEventListener('resize', updateWindowSize);
-    return () => window.removeEventListener('resize', updateWindowSize);
+    const mediaQueries = [
+      window.matchMedia(smallMatch),
+      window.matchMedia(mediumMatch),
+      window.matchMedia(largeMatch),
+    ];
+
+    const handleMediaChange = () => {
+      console.log(getWindowSize());
+      setWindowSize(getWindowSize());
+    };
+
+    mediaQueries.forEach(mq => {
+      mq.addEventListener('change', handleMediaChange);
+    });
+
+    return () => {
+      mediaQueries.forEach(mq => {
+        mq.removeEventListener('change', handleMediaChange);
+      });
+    };
   }, []);
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
## What does this change?
Uses the [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Testing_media_queries) API to determine what breakpoint we're at, which should be more performant than the 'resize' listener that we're using currently

## How to test
Visit a [page that shows search filters](http://localhost:3000/search/works?query=test) and check they change from the desktop version to the mobile version at the small breakpoint

## How can we measure success?
Less jank

## Have we considered potential risks?
Can't think of any
