### PR TITLE
Concept Page QA

### DIFF
--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
@@ -8,10 +8,12 @@ import { themeValues } from '@weco/common/views/themes/config';
 const leftOffset = '12px';
 
 export const InPageNavList = styled(PlainList)<{ $isOnWhite: boolean }>`
+  padding-bottom: ${themeValues.spacingUnits['4']}px;
   border-bottom: 1px solid
     ${props => props.theme.color(props.$isOnWhite ? 'neutral.300' : 'white')};
 
   ${props => props.theme.media('large')`
+    padding-bottom: 0;
     border-bottom: 0;
   `}
 `;

--- a/content/webapp/views/components/SourcedDescription/index.tsx
+++ b/content/webapp/views/components/SourcedDescription/index.tsx
@@ -36,7 +36,7 @@ const SourceBoxContainer = styled.div<{ $marginLeft: number }>`
     visibility 200ms ease,
     opacity 200ms ease;
   visibility: hidden;
-  z-index: 3;
+  z-index: 4;
 `;
 
 const showSourceBox = css`


### PR DESCRIPTION
For #12128

## What does this change?
- Makes sure source description container is above mobile nav
- Adds some padding at the bottom of the mobile nav

## How to test
- Visit a [concept page](http://localhost:3000/concepts/usqyr9ur) with a narrow window and hover the 'Wikidata' button – check the tooltip is above the mobile nav
- Open the mobile nav and check there's 12px padding at the bottom

## How can we measure success?
UI works/looks nicer

## Have we considered potential risks?
n/a