### PR TITLE
Scroll bug on Android/Chrome; Round up container "scroll left" value

### DIFF
--- a/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.Buttons.tsx
+++ b/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.Buttons.tsx
@@ -66,7 +66,9 @@ const ScrollableGalleryButtons: FunctionComponent<Props> = ({
     const container = containerRef.current;
     if (!container) return;
 
-    const currScrollLeft = container.scrollLeft;
+    // Math.ceil is required because Chrome Android does not round up
+    // and this causes the scroll to not work correctly.
+    const currScrollLeft = Math.ceil(container.scrollLeft);
     const children = Array.from(container.children) as HTMLElement[];
 
     const containerPaddingLeft = parseFloat(


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12133

[See this comment](https://github.com/wellcomecollection/wellcomecollection.org/issues/12133#issuecomment-3097621326)

On browserstack for Chrome mobile:
<img width="164" height="69" alt="Screenshot 2025-07-21 at 18 13 20" src="https://github.com/user-attachments/assets/dcafc67b-4d86-440a-8a1b-e778a1af1cd7" />

On normal browser:
<img width="187" height="53" alt="Screenshot 2025-07-21 at 18 13 25" src="https://github.com/user-attachments/assets/c474a7bc-01ca-4a42-ab45-3d2c7c242801" />


## How to test

Honestly, think we'll just have to merge this to staging and test there.
I've tested it in Browserstack in a very awkward manner by running code in the console there and I really feel it's a good path to go down on.

## How can we measure success?

Scroll works on Chrome Android

## Have we considered potential risks?
Pretty low risk this. 