### PR TITLE
Scroll bug on android; Change Math ceil to Math round

### DIFF
--- a/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.Buttons.tsx
+++ b/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.Buttons.tsx
@@ -66,9 +66,9 @@ const ScrollableGalleryButtons: FunctionComponent<Props> = ({
     const container = containerRef.current;
     if (!container) return;
 
-    // Math.ceil is required because Chrome Android does not round up
+    // Math.round is required because Chrome Android does not round numbers,
     // and this causes the scroll to not work correctly.
-    const currScrollLeft = Math.ceil(container.scrollLeft);
+    const currScrollLeft = Math.round(container.scrollLeft);
     const children = Array.from(container.children) as HTMLElement[];
 
     const containerPaddingLeft = parseFloat(


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12133

Follow up to https://github.com/wellcomecollection/wellcomecollection.org/pull/12146

I'd originally tested with Math.round, then only tested scroll right with Math.ceil, which was a mistake as it doesn't work for Left. I've test both now and believe this should do it

## How to test

I've tested manually in browserstack, but again think we're better off getting this to staging. Happy to demonstrate though!

## How can we measure success?

Scrolling in Android Chrome

## Have we considered potential risks?
N/A