### PR TITLE
Allow dataGtmProps to be spread onto the Button

### DIFF
--- a/common/views/components/Buttons/Buttons.Solid.tsx
+++ b/common/views/components/Buttons/Buttons.Solid.tsx
@@ -8,6 +8,7 @@ import {
 import { classNames } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
+import { dataGtmPropsToAttributes } from './Buttons.helpers';
 import {
   BaseButtonInner,
   ButtonIconWrapper,
@@ -30,7 +31,7 @@ const Button: ForwardRefRenderFunction<HTMLButtonElement, ButtonSolidProps> = (
     clickHandler,
     ariaControls,
     ariaExpanded,
-    dataGtmTrigger,
+    dataGtmProps,
     dataTestId,
     ariaLive,
     disabled,
@@ -48,12 +49,12 @@ const Button: ForwardRefRenderFunction<HTMLButtonElement, ButtonSolidProps> = (
 
   return (
     <StyledButton
+      {...dataGtmPropsToAttributes(dataGtmProps)}
       ref={ref}
       type={type}
       aria-controls={ariaControls}
       aria-expanded={ariaExpanded}
       aria-live={ariaLive}
-      data-gtm-trigger={dataGtmTrigger}
       data-testid={dataTestId}
       onClick={handleClick}
       disabled={disabled}

--- a/common/views/components/Buttons/Buttons.SolidLink.tsx
+++ b/common/views/components/Buttons/Buttons.SolidLink.tsx
@@ -11,6 +11,7 @@ import {
   ButtonSolidBaseProps,
   StyledButton,
 } from '.';
+import { dataGtmPropsToAttributes } from './Buttons.helpers';
 
 export type ButtonSolidLinkProps = ButtonSolidBaseProps & {
   clickHandler?: (event: SyntheticEvent<HTMLButtonElement>) => void;
@@ -30,7 +31,7 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
   clickHandler,
   ariaControls,
   ariaExpanded,
-  dataGtmTrigger,
+  dataGtmProps,
   size,
   ariaLabel,
   colors,
@@ -55,9 +56,9 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
       }
     >
       <StyledButton
+        {...dataGtmPropsToAttributes(dataGtmProps)}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
-        data-gtm-trigger={dataGtmTrigger}
         onClick={handleClick}
         href={getHref(link)}
         $ariaLabel={ariaLabel}

--- a/common/views/components/Buttons/Buttons.helpers.tsx
+++ b/common/views/components/Buttons/Buttons.helpers.tsx
@@ -1,0 +1,15 @@
+export function dataGtmPropsToAttributes(
+  dataGtmProps?: Record<string, string>
+): Record<string, string> {
+  if (!dataGtmProps) {
+    return {};
+  }
+
+  return Object.entries(dataGtmProps).reduce(
+    (acc, [key, value]) => {
+      acc[`data-gtm-${key}`] = value;
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}

--- a/common/views/components/Buttons/Buttons.types.ts
+++ b/common/views/components/Buttons/Buttons.types.ts
@@ -34,8 +34,8 @@ export type ButtonSolidBaseProps = {
   isTextHidden?: boolean;
   ariaControls?: string;
   ariaExpanded?: boolean;
-  dataGtmTrigger?: string;
   dataTestId?: string;
+  dataGtmProps?: Record<string, string>;
   ariaLive?: 'off' | 'polite' | 'assertive';
   colors?: ButtonColors;
   isIconAfter?: boolean;

--- a/common/views/components/NewsletterPromo/index.tsx
+++ b/common/views/components/NewsletterPromo/index.tsx
@@ -170,7 +170,9 @@ const NewsletterPromo: FunctionComponent = () => {
 
                 <Button
                   variant="ButtonSolid"
-                  dataGtmTrigger="newsletter_promo_subscribe"
+                  dataGtmProps={{
+                    trigger: 'newsletter_promo_subscribe',
+                  }}
                   text={isSubmitting ? 'Sending…' : 'Subscribe'}
                   disabled={isSubmitting}
                 />

--- a/content/webapp/views/components/CopyButtons/CopyButtons.Content.tsx
+++ b/content/webapp/views/components/CopyButtons/CopyButtons.Content.tsx
@@ -69,7 +69,9 @@ const CopyContent: FunctionComponent<Props> = ({
         <ButtonContainer>
           <Button
             variant="ButtonSolid"
-            dataGtmTrigger="copy_content"
+            dataGtmProps={{
+              trigger: 'copy_content',
+            }}
             colors={themeValues.buttonColors.pumiceTransparentCharcoal}
             size="small"
             aria-live="assertive"

--- a/content/webapp/views/components/CopyButtons/CopyButtons.Url.tsx
+++ b/content/webapp/views/components/CopyButtons/CopyButtons.Url.tsx
@@ -70,7 +70,9 @@ const CopyUrl: FunctionComponent<Props> = ({
         >
           <Button
             variant="ButtonSolid"
-            dataGtmTrigger="copy_url"
+            dataGtmProps={{
+              trigger: 'copy_url',
+            }}
             colors={themeValues.buttonColors.pumiceTransparentCharcoal}
             size="small"
             aria-live="assertive"

--- a/content/webapp/views/components/EventSchedule/EventSchedule.BookingButton.tsx
+++ b/content/webapp/views/components/EventSchedule/EventSchedule.BookingButton.tsx
@@ -43,7 +43,9 @@ const BookingEnquiryLink: FunctionComponent<Props> = ({ event }) => {
         link={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}
         icon={email}
         text="Email to book"
-        dataGtmTrigger="click_to_book"
+        dataGtmProps={{
+          trigger: 'click_to_book',
+        }}
       />
     );
   }

--- a/content/webapp/views/components/EventbriteButtons/index.tsx
+++ b/content/webapp/views/components/EventbriteButtons/index.tsx
@@ -55,7 +55,9 @@ const EventbriteButtons: FunctionComponent<Props> = ({ event }) => {
                     variant="ButtonSolidLink"
                     link={`https://www.eventbrite.com/e/${event.eventbriteId}`}
                     icon={ticket}
-                    dataGtmTrigger="click_to_book"
+                    dataGtmProps={{
+                      trigger: 'click_to_book',
+                    }}
                     text={
                       isHybridEvent ? 'In-venue tickets' : 'Check for tickets'
                     }
@@ -79,7 +81,9 @@ const EventbriteButtons: FunctionComponent<Props> = ({ event }) => {
                     variant="ButtonSolidLink"
                     link={`https://www.eventbrite.com/e/${event.onlineEventbriteId}`}
                     icon={ticket}
-                    dataGtmTrigger="click_to_book"
+                    dataGtmProps={{
+                      trigger: 'click_to_book',
+                    }}
                     text={
                       isHybridEvent ? 'Online tickets' : 'Check for tickets'
                     }

--- a/content/webapp/views/components/ImageGallery/index.tsx
+++ b/content/webapp/views/components/ImageGallery/index.tsx
@@ -260,7 +260,13 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
                   ref={openButtonRef}
                   ariaControls={id}
                   ariaExpanded={isActive}
-                  dataGtmTrigger={isActive ? undefined : 'show_image_gallery'}
+                  dataGtmProps={
+                    isActive
+                      ? {
+                          trigger: 'show_image_gallery',
+                        }
+                      : undefined
+                  }
                   icon={gallery}
                   clickHandler={handleOpenClicked}
                   text={pluralize(items.length, 'image')}

--- a/content/webapp/views/pages/events/event/index.tsx
+++ b/content/webapp/views/pages/events/event/index.tsx
@@ -265,7 +265,9 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
                       link={event.thirdPartyBooking.url}
                       icon={ticket}
                       text="Check for tickets"
-                      dataGtmTrigger="click_to_book"
+                      dataGtmProps={{
+                        trigger: 'click_to_book',
+                      }}
                     />
                     {event.thirdPartyBooking.name && (
                       <Space $v={{ size: 's', properties: ['margin-top'] }}>
@@ -288,7 +290,9 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
                     link={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}
                     icon={email}
                     text="Email to book"
-                    dataGtmTrigger="click_to_book"
+                    dataGtmProps={{
+                      trigger: 'click_to_book',
+                    }}
                   />
                 )}
 

--- a/content/webapp/views/pages/newsletter.Signup.tsx
+++ b/content/webapp/views/pages/newsletter.Signup.tsx
@@ -215,7 +215,9 @@ const NewsletterSignup: FunctionComponent<Props> = ({
             <Button
               variant="ButtonSolid"
               text="Subscribe"
-              dataGtmTrigger="newsletter_signup_subscribe"
+              dataGtmProps={{
+                trigger: 'newsletter_signup_subscribe',
+              }}
             />
           </Space>
 

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/RequestDialog/index.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/RequestDialog/index.tsx
@@ -190,7 +190,9 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
           <Button
             variant="ButtonSolid"
             text="Confirm request"
-            dataGtmTrigger="requesting_confirm"
+            dataGtmProps={{
+              trigger: 'requesting_confirm',
+            }}
             disabled={!item.availableDates?.length}
           />
         </ConfirmRequestButtonWrapper>

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
@@ -190,7 +190,9 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
           disabled={userState !== 'signedin'}
           ref={requestButtonRef}
           text="Request item"
-          dataGtmTrigger="requesting_initiate"
+          dataGtmProps={{
+            trigger: 'requesting_initiate',
+          }}
           clickHandler={() => {
             setRequestModalIsActive(true);
           }}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.IIIFClickthrough.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.IIIFClickthrough.tsx
@@ -60,7 +60,9 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
             <Space as="span" $h={{ size: 'm', properties: ['margin-right'] }}>
               <Button
                 variant="ButtonSolid"
-                dataGtmTrigger="show_the_content"
+                dataGtmProps={{
+                  trigger: 'show_the_content',
+                }}
                 text="Show the content"
                 clickHandler={() => {
                   const authServiceWindow = window.open(

--- a/content/webapp/views/pages/works/work/WorkDetails/index.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/index.tsx
@@ -198,7 +198,9 @@ const WorkDetails: FunctionComponent<Props> = ({
         <WorkDetailsSection headingText="Selected images from this work">
           <Button
             variant="ButtonSolidLink"
-            dataGtmTrigger="view_selected_images"
+            dataGtmProps={{
+              trigger: 'view_selected_images',
+            }}
             colors={themeValues.buttonColors.greenTransparentGreen}
             text={
               work.images.length > 1

--- a/content/webapp/views/pages/works/work/items.tsx
+++ b/content/webapp/views/pages/works/work/items.tsx
@@ -263,7 +263,9 @@ const WorkItemPage: NextPage<Props> = ({
             >
               <Button
                 variant="ButtonSolid"
-                dataGtmTrigger="show_the_content"
+                dataGtmProps={{
+                  trigger: 'show_the_content',
+                }}
                 text="Show the content"
                 clickHandler={() => {
                   const authServiceWindow = window.open(

--- a/identity/webapp/views/pages/registration/index.tsx
+++ b/identity/webapp/views/pages/registration/index.tsx
@@ -218,7 +218,9 @@ const RegistrationPage: NextPage<Props> = ({
                       <FullWidthButton>
                         <Button
                           variant="ButtonSolid"
-                          dataGtmTrigger="create_library_account"
+                          dataGtmProps={{
+                            trigger: 'create_library_account',
+                          }}
                           type={ButtonTypes.submit}
                           text="Create library account"
                         />


### PR DESCRIPTION
## What does this change?
The Button component currently takes a `dataGtmTrigger` prop which it passes down to it's children to output as a `data-gtm-trigger` attribute on the rendered element, but I realised that I was going to need to add at least one new attribute (position-in-list) for the concepts work, and potentially several (and more in the future).

It would be a pain to have to declare each new attribute we wanted to pass through, so allowing an object to be spread onto the child element should simplify things.

## How to test
I haven't added anything new in this PR, just changed the Button instances of `dataGtmTrigger="x"` to `dataGtmProps={{trigger: 'x'}}`. I would validate that you can still see the `data-gtm-trigger` attribute being added in the rendered markup for a couple of components.

## How can we measure success?
We can add new attributes containing information to track without having to drill new props down to the Button

## Have we considered potential risks?
typos

