### PR TITLE
Add gtm trigger to SourceBox

### DIFF
--- a/content/webapp/views/components/SourcedDescription/index.tsx
+++ b/content/webapp/views/components/SourcedDescription/index.tsx
@@ -9,6 +9,7 @@ import {
 import styled, { css } from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Space from '@weco/common/views/components/styled/Space';
 import { SourceOntology } from '@weco/content/services/wellcome/catalogue/types';
 
@@ -194,7 +195,7 @@ const SourcedDescription: FunctionComponent<{
           {getReadableSource(source)}
         </SourceLabel>
         <SourceBoxContainer $marginLeft={sourceBoxMarginLeft}>
-          <SourceBox>
+          <SourceBox {...dataGtmPropsToAttributes({ trigger: 'source_box' })}>
             <span className={font('intm', 6)}>Source:</span>
             <SourceLink>
               {source === 'wikidata' && <WikidataLogo width={16} />}


### PR DESCRIPTION
For #12131

## What does this change?
Adds a trigger to the `SourceBox` that is shown on hover(/tap) 

## How to test
You can preview the `source_box_shown` GA event firing 

## How can we measure success?
We can measure component usage

## Have we considered potential risks?
Not specifically, although worth mentioning that I had to use the 'Every time an element appears on screen' version of the trigger, rather than the 'Once per page' version, probably because of the way our routing is done client-side.