### PR TITLE
Add gtm props to Collaborator

### DIFF
--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -1,7 +1,8 @@
-export type DataGtmAttr = 'trigger' | 'position-in-list';
+type DataGtmAttr = 'trigger' | 'position-in-list';
+export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;
 
 export function dataGtmPropsToAttributes(
-  dataGtmProps?: Partial<Record<DataGtmAttr, string>>
+  dataGtmProps?: DataGtmProps
 ): Record<string, string> {
   if (!dataGtmProps) {
     return {};

--- a/common/views/components/Buttons/Buttons.types.ts
+++ b/common/views/components/Buttons/Buttons.types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 import { IconSvg } from '@weco/common/icons';
-import { DataGtmAttr } from '@weco/common/utils/gtm';
+import { DataGtmProps } from '@weco/common/utils/gtm';
 import { PaletteColor } from '@weco/common/views/themes/config';
 export type ButtonSize = 'small' | 'medium';
 
@@ -35,7 +35,7 @@ export type ButtonSolidBaseProps = {
   ariaControls?: string;
   ariaExpanded?: boolean;
   dataTestId?: string;
-  dataGtmProps?: Partial<Record<DataGtmAttr, string>>;
+  dataGtmProps?: DataGtmProps;
   ariaLive?: 'off' | 'polite' | 'assertive';
   colors?: ButtonColors;
   isIconAfter?: boolean;

--- a/content/webapp/views/pages/concepts/concept/concept.Collaborators.Card.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Collaborators.Card.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { IconSvg } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
+import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 
 const StyledLink = styled(NextLink).attrs({
@@ -61,11 +62,21 @@ type Props = {
   href: string;
   label: string;
   icon: IconSvg;
+  dataGtmProps?: DataGtmProps;
 };
 
-const CollaboratorCard: FunctionComponent<Props> = ({ href, label, icon }) => {
+const CollaboratorCard: FunctionComponent<Props> = ({
+  href,
+  label,
+  icon,
+  dataGtmProps,
+}) => {
   return (
-    <StyledLink href={href} className="link-reset">
+    <StyledLink
+      href={href}
+      className="link-reset"
+      {...dataGtmPropsToAttributes(dataGtmProps)}
+    >
       <CollaboratorLabel>{label}</CollaboratorLabel>
       <IconWrapper>
         <Icon icon={icon} />

--- a/content/webapp/views/pages/concepts/concept/concept.Collaborators.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Collaborators.tsx
@@ -39,8 +39,12 @@ const Collaborators: FunctionComponent<{
         Frequent collaborators
       </h2>
       <CollaboratorsWrapper>
-        {concepts.slice(0, COLLABORATOR_COUNT_LIMIT).map(concept => (
+        {concepts.slice(0, COLLABORATOR_COUNT_LIMIT).map((concept, index) => (
           <CollaboratorCard
+            dataGtmProps={{
+              trigger: 'frequent_collaborators',
+              'position-in-list': `${index + 1}`,
+            }}
             key={concept.id}
             href={`/concepts/${concept.id}`}
             icon={iconFromConceptType(concept.conceptType)}


### PR DESCRIPTION
## What does this change?
Uses the dataGtmPropsToAttributes helper in the Collaborator component for the trigger and position-in-list

## How to test
Check the data-attributes are on the collaborator cards at the bottom of a [concept page](http://localhost:3000/concepts/jt2q9muw)

## How can we measure success?
Component usage can be tracked

## Have we considered potential risks?
Can't think of any