### PR TITLE
Allow dataGtmProps to be passed in higher up to differentiate RelatedConceptsGroups

### DIFF
--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -1,8 +1,4 @@
-type DataGtmAttr =
-  | 'trigger'
-  | 'position-in-list'
-  | 'relationship-type'
-  | 'topic-type';
+type DataGtmAttr = 'trigger' | 'position-in-list';
 export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;
 
 export function dataGtmPropsToAttributes(

--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -1,4 +1,8 @@
-type DataGtmAttr = 'trigger' | 'position-in-list' | 'relationship-type';
+type DataGtmAttr =
+  | 'trigger'
+  | 'position-in-list'
+  | 'relationship-type'
+  | 'topic-type';
 export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;
 
 export function dataGtmPropsToAttributes(

--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -1,4 +1,4 @@
-type DataGtmAttr = 'trigger' | 'position-in-list';
+export type DataGtmAttr = 'trigger' | 'position-in-list';
 export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;
 
 export function dataGtmPropsToAttributes(

--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -1,4 +1,4 @@
-type DataGtmAttr = 'trigger' | 'position-in-list';
+type DataGtmAttr = 'trigger' | 'position-in-list' | 'relationship-type';
 export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;
 
 export function dataGtmPropsToAttributes(

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -102,6 +102,10 @@ const ThemeHeader: FunctionComponent<{
         <>
           {(concept.type === 'Person' || themePagesAllFields) && (
             <RelatedConceptsGroup
+              dataGtmProps={index => ({
+                trigger: 'field_of_work',
+                'position-in-list': `${index + 1}`,
+              })}
               label="Field of work"
               labelType="inline"
               relatedConcepts={fieldsOfWork}

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -102,10 +102,7 @@ const ThemeHeader: FunctionComponent<{
         <>
           {(concept.type === 'Person' || themePagesAllFields) && (
             <RelatedConceptsGroup
-              dataGtmProps={index => ({
-                trigger: 'field_of_work',
-                'position-in-list': `${index + 1}`,
-              })}
+              dataGtmTriggerName="field_of_work"
               label="Field of work"
               labelType="inline"
               relatedConcepts={fieldsOfWork}

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -36,7 +36,10 @@ type Props = {
   labelType: 'inline' | 'heading';
   relatedConcepts?: RelatedConcept[];
   buttonColors?: ButtonColors;
-  dataGtmProps?: (index: number) => DataGtmProps;
+  dataGtmProps?: (
+    index: number,
+    relationshipType?: RelatedConcept['relationshipType']
+  ) => DataGtmProps;
 };
 
 const RelatedConceptsGroup: FunctionComponent<Props> = ({
@@ -70,7 +73,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
           >
             <Space className={font('intr', 5)}>
               <Button
-                dataGtmProps={dataGtmProps?.(index)}
+                dataGtmProps={dataGtmProps?.(index, item.relationshipType)}
                 variant="ButtonSolidLink"
                 colors={
                   buttonColors || themeValues.buttonColors.slateTransparentBlack

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import { dasherize } from '@weco/common/utils/grammar';
+import { DataGtmProps } from '@weco/common/utils/gtm';
 import Button, { ButtonColors } from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -35,6 +36,7 @@ type Props = {
   labelType: 'inline' | 'heading';
   relatedConcepts?: RelatedConcept[];
   buttonColors?: ButtonColors;
+  dataGtmProps?: (index: number) => DataGtmProps;
 };
 
 const RelatedConceptsGroup: FunctionComponent<Props> = ({
@@ -42,6 +44,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
   labelType,
   relatedConcepts,
   buttonColors,
+  dataGtmProps,
 }: Props) => {
   if (!relatedConcepts || relatedConcepts.length === 0) {
     return null;
@@ -67,10 +70,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
           >
             <Space className={font('intr', 5)}>
               <Button
-                dataGtmProps={{
-                  trigger: 'field_of_work',
-                  'position-in-list': `${index + 1}`,
-                }}
+                dataGtmProps={dataGtmProps?.(index)}
                 variant="ButtonSolidLink"
                 colors={
                   buttonColors || themeValues.buttonColors.slateTransparentBlack

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -36,10 +36,7 @@ type Props = {
   labelType: 'inline' | 'heading';
   relatedConcepts?: RelatedConcept[];
   buttonColors?: ButtonColors;
-  dataGtmProps?: (
-    index: number,
-    relationshipType?: RelatedConcept['relationshipType']
-  ) => DataGtmProps;
+  dataGtmProps?: (index: number, topicType?: 'TODO') => DataGtmProps;
 };
 
 const RelatedConceptsGroup: FunctionComponent<Props> = ({
@@ -73,7 +70,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
           >
             <Space className={font('intr', 5)}>
               <Button
-                dataGtmProps={dataGtmProps?.(index, item.relationshipType)}
+                dataGtmProps={dataGtmProps?.(index, 'TODO')}
                 variant="ButtonSolidLink"
                 colors={
                   buttonColors || themeValues.buttonColors.slateTransparentBlack

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -36,7 +36,7 @@ type Props = {
   labelType: 'inline' | 'heading';
   relatedConcepts?: RelatedConcept[];
   buttonColors?: ButtonColors;
-  dataGtmProps?: (index: number, topicType?: 'TODO') => DataGtmProps;
+  dataGtmProps?: (index: number) => DataGtmProps;
 };
 
 const RelatedConceptsGroup: FunctionComponent<Props> = ({
@@ -70,7 +70,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
           >
             <Space className={font('intr', 5)}>
               <Button
-                dataGtmProps={dataGtmProps?.(index, 'TODO')}
+                dataGtmProps={dataGtmProps?.(index)}
                 variant="ButtonSolidLink"
                 colors={
                   buttonColors || themeValues.buttonColors.slateTransparentBlack

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -69,10 +69,10 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
           >
             <Space className={font('intr', 5)}>
               <Button
-                dataGtmProps={{
+                {...(dataGtmTriggerName && {
                   trigger: dataGtmTriggerName,
                   'position-in-list': `${index + 1}`,
-                }}
+                })}
                 variant="ButtonSolidLink"
                 colors={
                   buttonColors || themeValues.buttonColors.slateTransparentBlack

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -70,8 +70,10 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
             <Space className={font('intr', 5)}>
               <Button
                 {...(dataGtmTriggerName && {
-                  trigger: dataGtmTriggerName,
-                  'position-in-list': `${index + 1}`,
+                  dataGtmProps: {
+                    trigger: dataGtmTriggerName,
+                    'position-in-list': `${index + 1}`,
+                  },
                 })}
                 variant="ButtonSolidLink"
                 colors={

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import { dasherize } from '@weco/common/utils/grammar';
-import { DataGtmProps } from '@weco/common/utils/gtm';
 import Button, { ButtonColors } from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -36,7 +35,7 @@ type Props = {
   labelType: 'inline' | 'heading';
   relatedConcepts?: RelatedConcept[];
   buttonColors?: ButtonColors;
-  dataGtmProps?: (index: number) => DataGtmProps;
+  dataGtmTriggerName?: string;
 };
 
 const RelatedConceptsGroup: FunctionComponent<Props> = ({
@@ -44,7 +43,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
   labelType,
   relatedConcepts,
   buttonColors,
-  dataGtmProps,
+  dataGtmTriggerName,
 }: Props) => {
   if (!relatedConcepts || relatedConcepts.length === 0) {
     return null;
@@ -70,7 +69,10 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
           >
             <Space className={font('intr', 5)}>
               <Button
-                dataGtmProps={dataGtmProps?.(index)}
+                dataGtmProps={{
+                  trigger: dataGtmTriggerName,
+                  'position-in-list': `${index + 1}`,
+                }}
                 variant="ButtonSolidLink"
                 colors={
                   buttonColors || themeValues.buttonColors.slateTransparentBlack

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -391,6 +391,10 @@ const ConceptPage: NextPage<Props> = ({
                   }}
                 >
                   <RelatedConceptsGroup
+                    dataGtmProps={index => ({
+                      trigger: 'related_topics',
+                      'position-in-list': `${index + 1}`,
+                    })}
                     label={relatedConceptsGroupLabel}
                     labelType="heading"
                     relatedConcepts={relatedTopics}

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -13,7 +13,6 @@ import {
   dasherize,
   formatNumber,
 } from '@weco/common/utils/grammar';
-import { DataGtmProps } from '@weco/common/utils/gtm';
 import { ReturnedResults } from '@weco/common/utils/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -392,10 +391,7 @@ const ConceptPage: NextPage<Props> = ({
                   }}
                 >
                   <RelatedConceptsGroup
-                    dataGtmProps={(index): DataGtmProps => ({
-                      trigger: 'related_topics',
-                      'position-in-list': `${index + 1}`,
-                    })}
+                    dataGtmTriggerName="related_topics"
                     label={relatedConceptsGroupLabel}
                     labelType="heading"
                     relatedConcepts={relatedTopics}

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -13,6 +13,7 @@ import {
   dasherize,
   formatNumber,
 } from '@weco/common/utils/grammar';
+import { DataGtmProps } from '@weco/common/utils/gtm';
 import { ReturnedResults } from '@weco/common/utils/search';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -391,7 +392,7 @@ const ConceptPage: NextPage<Props> = ({
                   }}
                 >
                   <RelatedConceptsGroup
-                    dataGtmProps={(index, relationshipType) => ({
+                    dataGtmProps={(index, relationshipType): DataGtmProps => ({
                       trigger: 'related_topics',
                       'position-in-list': `${index + 1}`,
                       'relationship-type': relationshipType || undefined,

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -392,10 +392,9 @@ const ConceptPage: NextPage<Props> = ({
                   }}
                 >
                   <RelatedConceptsGroup
-                    dataGtmProps={(index, type): DataGtmProps => ({
+                    dataGtmProps={(index): DataGtmProps => ({
                       trigger: 'related_topics',
                       'position-in-list': `${index + 1}`,
-                      'topic-type': type || undefined,
                     })}
                     label={relatedConceptsGroupLabel}
                     labelType="heading"

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -394,9 +394,7 @@ const ConceptPage: NextPage<Props> = ({
                     dataGtmProps={(index, relationshipType) => ({
                       trigger: 'related_topics',
                       'position-in-list': `${index + 1}`,
-                      ...(relationshipType && {
-                        'relationship-type': relationshipType,
-                      }),
+                      'relationship-type': relationshipType || undefined,
                     })}
                     label={relatedConceptsGroupLabel}
                     labelType="heading"

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -392,10 +392,10 @@ const ConceptPage: NextPage<Props> = ({
                   }}
                 >
                   <RelatedConceptsGroup
-                    dataGtmProps={(index, relationshipType): DataGtmProps => ({
+                    dataGtmProps={(index, type): DataGtmProps => ({
                       trigger: 'related_topics',
                       'position-in-list': `${index + 1}`,
-                      'relationship-type': relationshipType || undefined,
+                      'topic-type': type || undefined,
                     })}
                     label={relatedConceptsGroupLabel}
                     labelType="heading"

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -391,9 +391,12 @@ const ConceptPage: NextPage<Props> = ({
                   }}
                 >
                   <RelatedConceptsGroup
-                    dataGtmProps={index => ({
+                    dataGtmProps={(index, relationshipType) => ({
                       trigger: 'related_topics',
                       'position-in-list': `${index + 1}`,
+                      ...(relationshipType && {
+                        'relationship-type': relationshipType,
+                      }),
                     })}
                     label={relatedConceptsGroupLabel}
                     labelType="heading"


### PR DESCRIPTION
For #12131 

## What does this change?
Different RelatedConcepts need different data-gtm-attributes, so we need to move where the props get passed in higher up

## How to test
Check the RelatedConcept tags at the top of a concept page have a `data-trigger="field_of_work"` attribute, and the ones at the bottom of a concept page have a `data-trigger="related_topics"` attribute. We should also be able to get the `relationshipType` (frequently referenced together, related to, broader than etc. ) sent along if it exists.

## How can we measure success?
We can track things

## Have we considered potential risks?
n/a