### PR TITLE
Make featured works icon a set size

### DIFF
--- a/common/views/components/FeaturedWorkLink/index.tsx
+++ b/common/views/components/FeaturedWorkLink/index.tsx
@@ -12,9 +12,9 @@ const WorkLinkWithIcon = styled.a`
 
     background-image: url('https://i.wellcomecollection.org/assets/icons/favicon-32x32.png');
     background-repeat: no-repeat;
-    background-size: 1em;
+    background-size: 14px; /* 14px is the smallest size it should be and we want them all to be the same */
     background-position: center;
-    padding-right: 1.25em;
+    padding-right: 18px;
   }
 `;
 


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12159

Also amended padding as it was in `em` and looked strange with a smaller logo.

## How to test

[Article with this in captions and under images](https://www-dev.wellcomecollection.org/stories/a-history-of-art-in-hospitals)
[Article with this in Text and under images](https://www-dev.wellcomecollection.org/stories/YZJzrhEAACUARhC3)

## How can we measure success?

Looks the same everywhere

## Have we considered potential risks?
N/A