### PR TITLE
Add tracking for InPageNavigation

### DIFF
--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -1,4 +1,4 @@
-type DataGtmAttr = 'trigger' | 'position-in-list';
+type DataGtmAttr = 'trigger' | 'position-in-list' | 'label';
 export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;
 
 export function dataGtmPropsToAttributes(

--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
@@ -15,6 +15,7 @@ import { useAppContext } from '@weco/common/contexts/AppContext';
 import { useActiveAnchor } from '@weco/common/hooks/useActiveAnchor';
 import { cross } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import { Link } from '@weco/content/types/link';
 
@@ -242,7 +243,7 @@ const InPageNavigationSticky: FunctionComponent<Props> = ({
           </MobileNavButton>
 
           <InPageNavList ref={listRef} id={listId} $isOnWhite={!!isOnWhite}>
-            {links.map((link: Link) => {
+            {links.map((link: Link, index) => {
               const id = link.url.replace('#', '');
               const isActive = activeId === id;
               return (
@@ -258,7 +259,11 @@ const InPageNavigationSticky: FunctionComponent<Props> = ({
                         $hasStuck={hasStuck}
                         $isActive={isActive}
                         $isOnWhite={!!isOnWhite}
-                        data-gtm-trigger="link_click_page_position"
+                        {...dataGtmPropsToAttributes({
+                          trigger: 'link_click_page_position',
+                          'position-in-list': `${index + 1}`,
+                          label: id,
+                        })}
                         onClick={() => {
                           setClickedId(id);
                           setIsListActive(false);


### PR DESCRIPTION
## What does this change?
Adding the `data-label` and `position-in-list` to the `InPageNavigation` for tracking. We want a bespoke label instead of `{{ Click Text }}` because the text can change for e.g. "images by/using/featuring x" but we just want to send 'images-by'

## How to test
Preview GTM and check a `concept_nav_tab_click` event is being sent to GA with the above params

## How can we measure success?
Moar tracking

## Have we considered potential risks?
n/a