### PR TITLE
Remove bespoke active style from ViewerSidebar buttons

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
@@ -75,11 +75,6 @@ const AccordionInner = styled(Space).attrs({
     color: inherit;
     font-size: inherit;
 
-    &:active {
-      outline: ${props => props.theme.highContrastOutlineFix};
-      box-shadow: ${props => props.theme.focusBoxShadow};
-    }
-
     span {
       display: flex;
       justify-content: space-between;


### PR DESCRIPTION
## What does this change?
If you click on e.g. Licence and re-use in the viewer sidebar currently, the button that toggles showing the content gets a yellow border when it's active. This is a style that we only want to apply when the user's navigating with a keyboard and [we updated this globally a couple of years ago](https://github.com/wellcomecollection/wellcomecollection.org/blob/4e8f73796387b5e47c3abee899681f06896102fd/common/views/themes/base/wellcome-normalize.ts#L30-L40) so I think we should remove it here

## How to test
Visit a [page in the viewer](http://localhost:3000/works/ww3byp9j/images?id=bym8rg4n), click Licence and re-use, verify the button doesn't get a yellow border. Navigate to the button with the keyboard and verify it does get a yellow border

## How can we measure success?
Less jarring/more consistent UI

## Have we considered potential risks?
Maybe it was deliberately like this for some reason that I've forgotten about. But I doubt it.