### PR TITLE
Define the grid with custom properties

### DIFF
--- a/common/views/components/styled/Grid.tsx
+++ b/common/views/components/styled/Grid.tsx
@@ -5,6 +5,82 @@ import { themeValues } from '@weco/common/views/themes/config';
 type StartSpan = [span: number, start?: number];
 export type SizeMap = Record<string, StartSpan>;
 
+/* Global grid custom properties for calculating track widths */
+const GlobalGridStyles = styled.div`
+  /* Grid calculation custom properties */
+  --grid-columns: 12;
+  --grid-gaps: 11;
+
+  /* Small breakpoint */
+  --gap-size: ${themeValues.gutter.small}px;
+  --one-column-width: calc(
+    (100% - (var(--grid-gaps) * var(--gap-size))) / var(--grid-columns)
+  );
+  --two-column-width: calc((var(--one-column-width) * 2) + var(--gap-size));
+  --three-column-width: calc(
+    (var(--one-column-width) * 3) + (var(--gap-size) * 2)
+  );
+  --four-column-width: calc(
+    (var(--one-column-width) * 4) + (var(--gap-size) * 3)
+  );
+  --five-column-width: calc(
+    (var(--one-column-width) * 5) + (var(--gap-size) * 4)
+  );
+  --six-column-width: calc(
+    (var(--one-column-width) * 6) + (var(--gap-size) * 5)
+  );
+  --seven-column-width: calc(
+    (var(--one-column-width) * 7) + (var(--gap-size) * 6)
+  );
+  --eight-column-width: calc(
+    (var(--one-column-width) * 8) + (var(--gap-size) * 7)
+  );
+  --nine-column-width: calc(
+    (var(--one-column-width) * 9) + (var(--gap-size) * 8)
+  );
+  --ten-column-width: calc(
+    (var(--one-column-width) * 10) + (var(--gap-size) * 9)
+  );
+  --eleven-column-width: calc(
+    (var(--one-column-width) * 11) + (var(--gap-size) * 10)
+  );
+  --twelve-column-width: 100%;
+
+  ${themeValues.media('medium')(`
+    --gap-size: ${themeValues.gutter.medium}px;
+    --one-column-width: calc((100% - (var(--grid-gaps) * var(--gap-size))) / var(--grid-columns));
+    --two-column-width: calc((var(--one-column-width) * 2) + var(--gap-size));
+    --three-column-width: calc((var(--one-column-width) * 3) + (var(--gap-size) * 2));
+    --four-column-width: calc((var(--one-column-width) * 4) + (var(--gap-size) * 3));
+    --five-column-width: calc((var(--one-column-width) * 5) + (var(--gap-size) * 4));
+    --six-column-width: calc((var(--one-column-width) * 6) + (var(--gap-size) * 5));
+    --seven-column-width: calc((var(--one-column-width) * 7) + (var(--gap-size) * 6));
+    --eight-column-width: calc((var(--one-column-width) * 8) + (var(--gap-size) * 7));
+    --nine-column-width: calc((var(--one-column-width) * 9) + (var(--gap-size) * 8));
+    --ten-column-width: calc((var(--one-column-width) * 10) + (var(--gap-size) * 9));
+    --eleven-column-width: calc((var(--one-column-width) * 11) + (var(--gap-size) * 10));
+    --twelve-column-width: 100%;
+  `)}
+
+  ${themeValues.media('large')(`
+    --gap-size: ${themeValues.gutter.large}px;
+    --one-column-width: calc((100% - (var(--grid-gaps) * var(--gap-size))) / var(--grid-columns));
+    --two-column-width: calc((var(--one-column-width) * 2) + var(--gap-size));
+    --three-column-width: calc((var(--one-column-width) * 3) + (var(--gap-size) * 2));
+    --four-column-width: calc((var(--one-column-width) * 4) + (var(--gap-size) * 3));
+    --five-column-width: calc((var(--one-column-width) * 5) + (var(--gap-size) * 4));
+    --six-column-width: calc((var(--one-column-width) * 6) + (var(--gap-size) * 5));
+    --seven-column-width: calc((var(--one-column-width) * 7) + (var(--gap-size) * 6));
+    --eight-column-width: calc((var(--one-column-width) * 8) + (var(--gap-size) * 7));
+    --nine-column-width: calc((var(--one-column-width) * 9) + (var(--gap-size) * 8));
+    --ten-column-width: calc((var(--one-column-width) * 10) + (var(--gap-size) * 9));
+    --eleven-column-width: calc((var(--one-column-width) * 11) + (var(--gap-size) * 10));
+    --twelve-column-width: 100%;
+  `)}
+`;
+
+export const GridProvider = GlobalGridStyles;
+
 export const Grid = styled.div<{ $noGap?: boolean }>`
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -28,6 +28,7 @@ import { deserialiseProps } from '@weco/common/utils/json';
 import CivicUK from '@weco/common/views/components/CivicUK';
 import ErrorPage from '@weco/common/views/components/ErrorPage';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator';
+import { GridProvider } from '@weco/common/views/components/styled/Grid';
 import theme, { GlobalStyle } from '@weco/common/views/themes/default';
 
 // Error pages can't send anything via the data fetching methods as
@@ -183,26 +184,28 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
             <AppContextProvider>
               <SearchContextProvider>
                 <ThemeProvider theme={theme}>
-                  <GlobalStyle
-                    toggles={serverData.toggles}
-                    isFontsLoaded={useIsFontsLoaded()}
-                  />
-
-                  <LoadingIndicator />
-
-                  {displayCookieBanner && <CivicUK apiKey={civicUkApiKey} />}
-
-                  {!pageProps.err && (
-                    <Component {...deserialiseProps(pageProps)} />
-                  )}
-                  {pageProps.err && (
-                    <ErrorPage
-                      statusCode={pageProps.err.statusCode}
-                      title={pageProps.err.message}
+                  <GridProvider>
+                    <GlobalStyle
+                      toggles={serverData.toggles}
+                      isFontsLoaded={useIsFontsLoaded()}
                     />
-                  )}
 
-                  <SegmentScript hasAnalyticsConsent={hasAnalyticsConsent} />
+                    <LoadingIndicator />
+
+                    {displayCookieBanner && <CivicUK apiKey={civicUkApiKey} />}
+
+                    {!pageProps.err && (
+                      <Component {...deserialiseProps(pageProps)} />
+                    )}
+                    {pageProps.err && (
+                      <ErrorPage
+                        statusCode={pageProps.err.statusCode}
+                        title={pageProps.err.message}
+                      />
+                    )}
+
+                    <SegmentScript hasAnalyticsConsent={hasAnalyticsConsent} />
+                  </GridProvider>
                 </ThemeProvider>
               </SearchContextProvider>
             </AppContextProvider>


### PR DESCRIPTION
## What does this change?
Claude's suggestion for figuring out grid track widths involves defining everything in the grid with custom properties then making them available to the rest of the app with a provider. I only eyeballed the result but it seemed close – not sure if it was bang on or if I even think this is a good idea  ¯\\\_(ツ)\_/¯ 

## How to test
Make a styled component with e.g. `margin-left: var(--three-column-width);` and see if it the right amount of space

## How can we measure success?
We could use grid track sizes with relative ease

## Have we considered potential risks?
Maybe, possibly feels like an unnecessary hammer-to-a-nut situation (and possibly still isn't quite bang on for some other unspecified reason)

