### PR TITLE
Safari fix

### DIFF
--- a/content/webapp/views/pages/concepts/concept/concept.styles.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.styles.tsx
@@ -56,8 +56,8 @@ export const NavGridCell = styled(GridCell)<{
   ${props => props.theme.media('large')`
     position: unset;
     background-color: unset;
-    z-index: unset;
     transition: unset;
+    mix-blend-mode: difference;
 
     &::before,
     &::after {


### PR DESCRIPTION
For #12168 

## What does this change?
Makes the side nav show up in Safari

<img width="981" height="540" alt="image" src="https://github.com/user-attachments/assets/6da78155-43c0-4610-880f-ca414cbb161a" />


## How to test
- Open a concept in Safari 17.3 (MacOS Sonoma)in Browserstack
- Check the nav is there, that is has mix-blend-mode: difference working on desktop, and that the mobile styles remain unchanged
- have a look in Firefox and Chrome for good measure

## How can we measure success?
People can see the nav(!)

## Have we considered potential risks?
Perhaps I've inadvertently broken something else (don't think so though)
