### PR TITLE
Make the dark overlay appear consistently across browsers when mobile nav stuck and open

### DIFF
--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
@@ -25,7 +25,6 @@ export const BackgroundOverlay = styled.div`
   bottom: 0;
   background-color: ${props => props.theme.color('black')};
   opacity: 0.7;
-  z-index: 10;
 `;
 
 export const ListItem = styled.li<{ $hasStuck: boolean; $isOnWhite: boolean }>`

--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { CSSTransition, SwitchTransition } from 'react-transition-group';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
@@ -151,10 +152,15 @@ const InPageNavigationSticky: FunctionComponent<Props> = ({
   return (
     <>
       {shouldLockScroll && (
-        <BackgroundOverlay
-          data-lock-scroll={true}
-          onClick={() => setIsListActive(false)}
-        />
+        <>
+          {createPortal(
+            <BackgroundOverlay
+              data-lock-scroll={true}
+              onClick={() => setIsListActive(false)}
+            />,
+            document.body
+          )}
+        </>
       )}
       <div ref={InPageNavigationStickyRef}></div>
       <FocusTrap

--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.tsx
@@ -153,6 +153,9 @@ const InPageNavigationSticky: FunctionComponent<Props> = ({
     <>
       {shouldLockScroll && (
         <>
+          {/* https://github.com/wellcomecollection/wellcomecollection.org/pull/12171
+          This portal is required because of an older version of Safari, 
+          consider removing once moved to v21 */}
           {createPortal(
             <BackgroundOverlay
               data-lock-scroll={true}


### PR DESCRIPTION
## What does this change?
Moves the overlay to the end of `document.body` using a [React portal](https://react.dev/reference/react-dom/createPortal).

My other attempts to make Safari `position: fixed` relative to the viewport (mostly sticking `transform: translateY(0)` on things and hoping for the best) didn't bear fruit.

## How to test
Open a concept in old Safari, make the window small and open the mobile nav when it's stuck. Check you can see a dark overlay behind the nav, that scroll is locked and that clicking the overlay dismisses it/unlocks scroll. Check this still works in other browsers.

## How can we measure success?
Cross-browser consistency

## Have we considered potential risks?
A bit of extra React magic just for old Safari? I think it's probably ok though?