### PR TITLE
GH workflow; dependabot PRs to be assigned automatically

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   add-to-project:
-    if: github.actor == 'dependabot[bot]' || github.actor == 'rcantin-w'
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign PR to a rotating user


### PR DESCRIPTION
Assigns devs to Dependabot PRs on a rota to ensure it gets looked at frequently and timely.

Closes #12158 (to be recreated)