### PR TITLE
View all buttons

### DIFF
--- a/content/webapp/views/components/MoreLink/index.tsx
+++ b/content/webapp/views/components/MoreLink/index.tsx
@@ -9,11 +9,18 @@ type Props = {
   url: string | LinkProps;
   name: string;
   colors?: ButtonColors;
+  ariaLabel?: string;
 };
 
-const MoreLink: FunctionComponent<Props> = ({ url, name, colors }) => {
+const MoreLink: FunctionComponent<Props> = ({
+  url,
+  name,
+  colors,
+  ariaLabel,
+}) => {
   return (
     <Button
+      ariaLabel={ariaLabel}
       variant="ButtonSolidLink"
       colors={colors || themeValues.buttonColors.charcoalTransparentCharcoal}
       isIconAfter

--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -20,7 +20,6 @@ import { toLink as toImagesLink } from '@weco/content/views/components/SearchPag
 
 import {
   getSectionTypeLabel,
-  getThemeSectionHeading,
   SectionData,
   ThemePageSectionsData,
   themeTabOrder,
@@ -96,7 +95,8 @@ const ImageSection: FunctionComponent<Props> = ({
       <Space $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
         {labelBasedCount > singleSectionData.pageResults.length && (
           <MoreLink
-            name={`All images ${getThemeSectionHeading(type, concept)}`}
+            ariaLabel={`View all ${getSectionTypeLabel(type, config, 'images')}`}
+            name="View all"
             url={getAllImagesLink(type, concept, pathname)}
             colors={theme.buttonColors.greenGreenWhite}
           />

--- a/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
@@ -3,11 +3,7 @@ import styled from 'styled-components';
 
 import { WorksLinkSource } from '@weco/common/data/segment-values';
 import { font } from '@weco/common/utils/classnames';
-import {
-  capitalize,
-  formatNumber,
-  pluralize,
-} from '@weco/common/utils/grammar';
+import { capitalize, pluralize } from '@weco/common/utils/grammar';
 import Space from '@weco/common/views/components/styled/Space';
 import { WobblyEdge } from '@weco/common/views/components/WobblyEdge';
 import theme from '@weco/common/views/themes/default';
@@ -79,9 +75,6 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
     return null;
 
   const labelBasedCount = activePanel.totalResults.works;
-  const formattedLabelBasedCount = formatNumber(labelBasedCount, {
-    isCompact: true,
-  });
 
   return (
     <>
@@ -126,7 +119,8 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
             {labelBasedCount > activePanel.works.pageResults.length && (
               <Space $v={{ size: 'l', properties: ['padding-top'] }}>
                 <MoreLink
-                  name={`All works (${formattedLabelBasedCount})`}
+                  ariaLabel={`View all works for ${concept.label}`}
+                  name="View all"
                   url={getAllWorksLink(selectedTab, concept)}
                   colors={theme.buttonColors.greenGreenWhite}
                 />

--- a/content/webapp/views/pages/concepts/concept/concept.helpers.ts
+++ b/content/webapp/views/pages/concepts/concept/concept.helpers.ts
@@ -1,12 +1,9 @@
 import { ReturnedResults } from '@weco/common/utils/search';
 import { ConceptConfig } from '@weco/content/contexts/ConceptPageContext/concept.config';
 import {
-  Concept,
-  ConceptType,
   Image as ImageType,
   WorkBasic,
 } from '@weco/content/services/wellcome/catalogue/types';
-import { conceptTypeDisplayName } from '@weco/content/utils/concepts';
 
 export type ThemeTabType = 'by' | 'in' | 'about';
 export const themeTabOrder: ThemeTabType[] = ['by', 'in', 'about'];
@@ -22,26 +19,6 @@ export type ThemePageSectionsData = {
   about: SectionData;
   by: SectionData;
   in: SectionData;
-};
-
-const getThemeTabLabel = (tabType: ThemeTabType, conceptType: ConceptType) => {
-  if (tabType === 'about' && conceptType === 'Person') return 'featuring';
-  return tabType;
-};
-
-export const getThemeSectionHeading = (
-  tabType: ThemeTabType,
-  concept: Concept,
-  isLong = false
-) => {
-  const tabLabel = getThemeTabLabel(tabType, concept.type);
-  const conceptTypeLabel = conceptTypeDisplayName(concept).toLowerCase();
-
-  if (isLong && concept.type === 'Person') {
-    return `${tabLabel} ${concept.displayLabel || concept.label}`;
-  }
-
-  return `${tabLabel} this ${conceptTypeLabel}`;
 };
 
 export function getSectionTypeLabel(

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -43,7 +43,7 @@ import CataloguePageLayout from '@weco/content/views/layouts/CataloguePageLayout
 import Collaborators from './concept.Collaborators';
 import Header from './concept.Header';
 import {
-  getThemeSectionHeading,
+  getSectionTypeLabel,
   SectionData,
   ThemePageSectionsData,
   themeTabOrder,
@@ -305,7 +305,7 @@ const ConceptPage: NextPage<Props> = ({
     for (const section of themeTabOrder) {
       if (sectionsData[section].images?.totalResults) {
         links.push({
-          text: `Images ${getThemeSectionHeading(section, conceptResponse, true)}`,
+          text: getSectionTypeLabel(section, config, 'images') || 'Images',
           url: `#images-${section}`,
         });
       }

--- a/playwright/test/pages/concept.ts
+++ b/playwright/test/pages/concept.ts
@@ -8,7 +8,6 @@ export class ConceptPage {
   readonly worksSection: Locator;
   readonly imagesSection: Locator;
   readonly allWorksLink: Locator;
-  readonly allImagesLink: Locator;
   readonly allImagesByLink: Locator;
   readonly allImagesAboutLink: Locator;
   readonly allImagesInLink: Locator;

--- a/playwright/test/pages/concept.ts
+++ b/playwright/test/pages/concept.ts
@@ -37,8 +37,7 @@ export class ConceptPage {
     this.worksSection = page.getByTestId('works-section');
     this.imagesSection = page.getByTestId('images-section');
 
-    this.allWorksLink = this.allRecordsLink('works');
-    this.allImagesLink = this.allRecordsLink('images');
+    this.allWorksLink = this.allRecordsLink();
     this.allImagesByLink = this.allRecordsByAboutInLink('images', 'by');
     this.allImagesAboutLink = this.allRecordsByAboutInLink('images', 'about');
     this.allImagesInLink = this.allRecordsByAboutInLink('images', 'in');
@@ -67,9 +66,9 @@ export class ConceptPage {
     this.worksInTabPanel = this.tabPanel(this.worksSection, labels.worksIn);
   }
 
-  allRecordsLink = (recordType: string) => {
+  allRecordsLink = () => {
     const allRecords = this.page.getByRole('link', {
-      name: new RegExp(`^All ${recordType} \\([0-9,\\.K]+\\)`),
+      name: /^View all works.*/,
       exact: false, // match substring, the actual link also includes the right-arrow.
     });
     return allRecords;
@@ -79,9 +78,25 @@ export class ConceptPage {
     recordType: string,
     qualifier: 'by' | 'about' | 'in'
   ) => {
+    const possibleWordsForQualifier = () => {
+      switch (qualifier) {
+        case 'by':
+          return '(by|produced by)';
+        case 'about':
+          return '(featuring|referencing|about)';
+        case 'in':
+          return '(of)';
+        default:
+          throw new Error(`Unknown qualifier: ${qualifier}`);
+      }
+    };
     const allRecords = this.page.getByRole('link', {
-      name: new RegExp(`^All ${recordType} ${qualifier}`),
-      exact: false, // match substring, the actual link also includes the right-arrow.
+      name: new RegExp(
+        `^View all ${recordType} ${possibleWordsForQualifier()}.*`,
+        'i'
+      ),
+      exact: false,
+      // match substring, the actual link also includes the right-arrow.
     });
     return allRecords;
   };


### PR DESCRIPTION
## What does this change?
Change the all images/works buttons to 'View all' with extra aria-label content.

## How to test
Visit a [concept](http://localhost:3000/concepts/patspgf3), check the 'all' buttons say 'View all' and have additional aria-label information

## How can we measure success?
Better UI/UX

## Have we considered potential risks?
We probably need to validate that this approach is reasonable with a11y testing.