### PR TITLE
Limit image section line lengths to single line with ellipsis

### DIFF
--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -38,6 +38,9 @@ const SectionHeading = styled(Space).attrs({
   $v: { size: 's', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('white')};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 `;
 
 const getAllImagesLink = (


### PR DESCRIPTION
## What does this change?
There's a design requirement to limit lengths of e.g. 'Images by {person with maybe a very long name}` to a single line. This accomplishes that.

## How to test
Make a concept page small and check there's an ellipsis on the heading

<img width="301" height="442" alt="image" src="https://github.com/user-attachments/assets/a32adb31-f423-4e3e-a7a5-56f7bf89e8be" />

## How can we measure success?
?

## Have we considered potential risks?
We're hiding content, but it's probably ok (the headings are also being made smaller in a separate PR, so this will happen less frequently in any event)
