### PR TITLE
Make collaborator max always 4

### DIFF
--- a/content/webapp/contexts/ConceptPageContext/concept.config.tsx
+++ b/content/webapp/contexts/ConceptPageContext/concept.config.tsx
@@ -19,9 +19,7 @@ export type ConceptConfig = {
   worksBy: ConceptSection;
   worksAbout: ConceptSection;
   worksIn: ConceptSection;
-  collaborators: ConceptSection & {
-    maxCount?: number;
-  };
+  collaborators: ConceptSection;
   relatedTopics: ConceptSection & { excludedTopics?: ConceptType[] };
 };
 
@@ -114,7 +112,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         collaborators: {
           display: true,
           label: 'Frequent collaborators',
-          maxCount: 12,
         },
         relatedTopics: {
           display: true,
@@ -163,7 +160,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         collaborators: {
           display: true,
           label: 'Frequent collaborators',
-          maxCount: 12,
         },
         relatedTopics: {
           display: true,
@@ -211,7 +207,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         collaborators: {
           display: true,
           label: 'Frequent collaborators',
-          maxCount: 12,
         },
         relatedTopics: {
           display: true,
@@ -300,7 +295,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         collaborators: {
           display: true,
           label: `Top contributors to the collections in ${concept.displayLabel || concept.label}`,
-          maxCount: 4,
         },
         relatedTopics: {
           display: true,
@@ -348,7 +342,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
           display: true,
           label:
             'Top contributors to the collections using this type/technique',
-          maxCount: 4,
         },
         relatedTopics: {
           display: true,

--- a/content/webapp/views/pages/concepts/concept/concept.Collaborators.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Collaborators.tsx
@@ -11,7 +11,7 @@ import {
 
 import CollaboratorCard from './concept.Collaborators.Card';
 
-const COLLABORATOR_COUNT_LIMIT = 3;
+const COLLABORATOR_COUNT_LIMIT = 4;
 
 const CollaboratorsWrapper = styled.div`
   display: flex;
@@ -43,20 +43,18 @@ const Collaborators: FunctionComponent<{
         {config.collaborators.label || 'Frequent collaborators'}
       </h2>
       <CollaboratorsWrapper>
-        {concepts
-          .slice(0, config.collaborators.maxCount || COLLABORATOR_COUNT_LIMIT)
-          .map((concept, index) => (
-            <CollaboratorCard
-              dataGtmProps={{
-                trigger: 'frequent_collaborators',
-                'position-in-list': `${index + 1}`,
-              }}
-              key={concept.id}
-              href={`/concepts/${concept.id}`}
-              icon={iconFromConceptType(concept.conceptType)}
-              label={concept.label}
-            />
-          ))}
+        {concepts.slice(0, COLLABORATOR_COUNT_LIMIT).map((concept, index) => (
+          <CollaboratorCard
+            dataGtmProps={{
+              trigger: 'frequent_collaborators',
+              'position-in-list': `${index + 1}`,
+            }}
+            key={concept.id}
+            href={`/concepts/${concept.id}`}
+            icon={iconFromConceptType(concept.conceptType)}
+            label={concept.label}
+          />
+        ))}
       </CollaboratorsWrapper>
     </section>
   );


### PR DESCRIPTION
(I conflated the spec for Frequent collaborators and Related topics in the Figma file)

## What does this change?
If we show collaborators on a concept, there should only ever be a maximum of 4, but I got confused when looking through the Figma spec because it was close to Related topics where 12 is the maximum

## How to test
Visit a [person concept](http://localhost:3000/concepts/patspgf3#frequent-collaborators), check that there's only 4 frequent collaborators

## How can we measure success?
Meets design spec

## Have we considered potential risks?
n/a