### PR TITLE
Don't exclude topics on the frontend because this has already happened

### DIFF
--- a/content/webapp/contexts/ConceptPageContext/concept.config.tsx
+++ b/content/webapp/contexts/ConceptPageContext/concept.config.tsx
@@ -16,10 +16,8 @@ export type ConceptConfig = {
   worksBy: ConceptSection;
   worksAbout: ConceptSection;
   worksIn: ConceptSection;
-  collaborators: ConceptSection
   relatedTopics: ConceptSection;
   collaborators: ConceptSection;
-  relatedTopics: ConceptSection;
 };
 
 export const defaultConceptConfig: ConceptConfig = {

--- a/content/webapp/contexts/ConceptPageContext/concept.config.tsx
+++ b/content/webapp/contexts/ConceptPageContext/concept.config.tsx
@@ -1,7 +1,4 @@
-import {
-  Concept,
-  ConceptType,
-} from '@weco/content/services/wellcome/catalogue/types';
+import { Concept } from '@weco/content/services/wellcome/catalogue/types';
 
 type ConceptSection = {
   display: boolean;
@@ -22,7 +19,7 @@ export type ConceptConfig = {
   collaborators: ConceptSection & {
     maxCount?: number;
   };
-  relatedTopics: ConceptSection & { excludedTopics?: ConceptType[] };
+  relatedTopics: ConceptSection;
 };
 
 export const defaultConceptConfig: ConceptConfig = {
@@ -118,7 +115,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         },
         relatedTopics: {
           display: true,
-          excludedTopics: ['Person', 'Organisation', 'Agent'],
         },
       };
 
@@ -167,7 +163,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         },
         relatedTopics: {
           display: true,
-          excludedTopics: ['Person', 'Organisation', 'Agent'],
         },
       };
 
@@ -215,7 +210,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         },
         relatedTopics: {
           display: true,
-          excludedTopics: ['Person', 'Organisation', 'Agent'],
         },
       };
 
@@ -352,7 +346,6 @@ export function makeConceptConfig(concept: Concept): ConceptConfig {
         },
         relatedTopics: {
           display: true,
-          excludedTopics: ['Person', 'Organisation', 'Agent'],
         },
       };
 

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -6,7 +6,6 @@ import { dasherize } from '@weco/common/utils/grammar';
 import Button, { ButtonColors } from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
-import { useConceptPageContext } from '@weco/content/contexts/ConceptPageContext';
 import { RelatedConcept } from '@weco/content/services/wellcome/catalogue/types';
 
 const RelatedConceptsContainer = styled.div.attrs({
@@ -46,15 +45,9 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
   buttonColors,
   dataGtmTriggerName,
 }: Props) => {
-  const { config } = useConceptPageContext();
-
   if (!relatedConcepts || relatedConcepts.length === 0) {
     return null;
   }
-
-  const displayRelatedConcepts = relatedConcepts.filter(
-    c => !config.relatedTopics.excludedTopics?.includes(c.conceptType)
-  );
 
   return (
     <Space
@@ -67,7 +60,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
       )}
       <RelatedConceptsContainer>
         {labelType === 'inline' && <span>{label}</span>}
-        {displayRelatedConcepts.map((item, index) => (
+        {relatedConcepts.map((item, index) => (
           <RelatedConceptItem
             key={item.id}
             $isFullWidth={


### PR DESCRIPTION
## What does this change?
We were defining concepts to filter out from each concepts 'related topics' on the front end, but this has already been done further up the chain so isn't needed.

## How to test
Can't think of a thorough way to do it, but e.g. visit a [person concept](http://localhost:3000/concepts/patspgf3) and check that they don't have any 'person', 'agent', or 'organisation' related topics

## How can we measure success?
Less unnecessary front end code to maintain

## Have we considered potential risks?
n/a