### PR TITLE
Only use IIIF image location if we don't have an image service on the current canvas

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -233,6 +233,8 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const currentCanvas =
     transformedManifest?.canvases[queryParamToArrayIndex(canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
+  // We only want to use the IIIF image location if we don't have an image service on the current canvas
+  const shouldUseIifImageLocation = !currentCanvas?.imageServiceId;
   const urlTemplate =
     (iiifImageLocation && iiifImageTemplate(iiifImageLocation.url)) ||
     (mainImageService['@id'] && iiifImageTemplate(mainImageService['@id']));
@@ -333,7 +335,11 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         </Sidebar>
         <Topbar>
           <DelayVisibility>
-            <ViewerTopBar iiifImageLocation={iiifImageLocation} />
+            <ViewerTopBar
+              iiifImageLocation={
+                shouldUseIifImageLocation ? iiifImageLocation : undefined
+              }
+            />
           </DelayVisibility>
         </Topbar>
         <Main
@@ -366,7 +372,11 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         </Main>
         {showZoomed && isFullSupportBrowser && (
           <Zoom>
-            <ZoomedImage iiifImageLocation={iiifImageLocation} />
+            <ZoomedImage
+              iiifImageLocation={
+                shouldUseIifImageLocation ? iiifImageLocation : undefined
+              }
+            />
           </Zoom>
         )}
         {isFullSupportBrowser && (


### PR DESCRIPTION
## What does this change?
If we pass a `iiifImageLocation` to the `ZoomedImage` component, it will use that image to zoom. Otherwise it will try to use the image service on the current canvas. But we now have a [situation](https://wellcome.slack.com/archives/C8X9YKM5X/p1753864052307589) where a catalogue response contains a `iiifImageLocation` for a single image from a work as well as all the items for the work and the end result was the single image would always be the one that was zoomed.

This PR checks whether we have an image service available, and if so, stops the `iiifImageLocation` from being sent to the `ZoomedImage` component (and the viewer top bar that handles downloads, where the same problem would have been happening).

This feels like a bit of a sticking plaster that should probably be fixed better/higher up, but I haven't got the brain to do that now(/maybe ever again?)

## How to test
Visit [the work where the issue was reported (with `iiifImageLocation`)](http://localhost:3000/works/wuwth5sx/items), check zooming the images works, and downloading from the top bar works.

Visit a [work without a `iiifImageLocation`](http://localhost:3000/works/vr82xdrp/items?canvas=3) and check zoom/download still works as expected.

## How can we measure success?
Zoom works

## Have we considered potential risks?
The viewer code is confusing and I missed something/broke something else?