### PR TITLE
Concept Headings

### DIFF
--- a/content/webapp/views/pages/concepts/concept/concept.Collaborators.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Collaborators.tsx
@@ -39,7 +39,7 @@ const Collaborators: FunctionComponent<{
 
   return (
     <section data-id="frequent-collaborators">
-      <h2 className={font('intsb', 2)} id="frequent-collaborators">
+      <h2 className={font('wb', 2)} id="frequent-collaborators">
         {config.collaborators.label || 'Frequent collaborators'}
       </h2>
       <CollaboratorsWrapper>

--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -77,11 +77,7 @@ const ImageSection: FunctionComponent<Props> = ({
   }
 
   return (
-    <Space
-      $v={{ size: 'l', properties: ['padding-top'] }}
-      as="section"
-      data-id={`images-${type}`}
-    >
+    <Space $v={{ size: 'l', properties: ['padding-top'] }}>
       <SectionHeading id={`images-${type}`}>
         {getSectionTypeLabel(type, config, 'images')}
       </SectionHeading>
@@ -122,9 +118,13 @@ const ImagesResults: FunctionComponent<{
 
   return (
     <>
-      <ThemeImagesWrapper data-testid="images-section">
+      <ThemeImagesWrapper
+        as="section"
+        data-testid="images-section"
+        data-id="images"
+      >
         <Space $v={{ size: 'm', properties: ['padding-top'] }}>
-          <FromCollectionsHeading $color="white">
+          <FromCollectionsHeading $color="white" id="images">
             Images from the collections
           </FromCollectionsHeading>
         </Space>

--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -26,12 +26,14 @@ import {
   themeTabOrder,
   ThemeTabType,
 } from './concept.helpers';
+import { FromCollectionsHeading } from './concept.styles';
 
 const ThemeImagesWrapper = styled(Space).attrs({
   $v: { size: 'xl', properties: ['padding-bottom'] },
 })`
   background-color: ${props => props.theme.color('neutral.700')};
 `;
+
 const SectionHeading = styled(Space).attrs({
   as: 'h3',
   className: font('intsb', 3),
@@ -121,6 +123,11 @@ const ImagesResults: FunctionComponent<{
   return (
     <>
       <ThemeImagesWrapper data-testid="images-section">
+        <Space $v={{ size: 'm', properties: ['padding-top'] }}>
+          <FromCollectionsHeading $color="white">
+            Images from the collections
+          </FromCollectionsHeading>
+        </Space>
         {themeTabOrder.map(tabType => (
           <ImageSection
             key={tabType}

--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -34,7 +34,7 @@ const ThemeImagesWrapper = styled(Space).attrs({
 `;
 const SectionHeading = styled(Space).attrs({
   as: 'h3',
-  className: font('intsb', 2),
+  className: font('intsb', 3),
   $v: { size: 's', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('white')};

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -28,7 +28,7 @@ const RelatedConceptItem = styled.div.attrs<{ $isFullWidth: boolean }>({
 `;
 
 const SectionHeading = styled.h2.attrs({
-  className: font('intsb', 2),
+  className: font('wb', 2),
 })``;
 
 type Props = {

--- a/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
@@ -26,6 +26,8 @@ import {
   ThemeTabType,
 } from '@weco/content/views/pages/concepts/concept/concept.helpers';
 
+import { FromCollectionsHeading } from './concept.styles';
+
 const WorksCount = styled(Space).attrs({
   as: 'p',
   className: font('intr', 6),
@@ -93,9 +95,11 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
         as="section"
         data-id="works"
       >
-        <h2 id="works" className={font('intsb', 2)}>
-          Works
-        </h2>
+        <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <FromCollectionsHeading id="works" $color="black">
+            Works from the collections
+          </FromCollectionsHeading>
+        </Space>
         {tabs.length > 1 && (
           <Tabs
             label="Works tabs"

--- a/content/webapp/views/pages/concepts/concept/concept.styles.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.styles.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { font } from '@weco/common/utils/classnames';
 import { GridCell } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
-import { themeValues } from '@weco/common/views/themes/config';
+import { PaletteColor, themeValues } from '@weco/common/views/themes/config';
 
 export const MobileNavBackground = styled(Space).attrs({
   className: 'is-hidden-l is-hidden-xl',
@@ -12,6 +12,13 @@ export const MobileNavBackground = styled(Space).attrs({
   display: block;
   background-color: ${props =>
     props.theme.color(props.$isOnWhite ? 'white' : 'neutral.700')};
+`;
+
+export const FromCollectionsHeading = styled.h2.attrs({
+  className: font('wb', 2),
+})<{ $color: PaletteColor }>`
+  color: ${props => props.theme.color(props.$color)};
+  margin-bottom: 0;
 `;
 
 export const NavGridCell = styled(GridCell)<{

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -43,7 +43,6 @@ import CataloguePageLayout from '@weco/content/views/layouts/CataloguePageLayout
 import Collaborators from './concept.Collaborators';
 import Header from './concept.Header';
 import {
-  getThemeSectionHeading,
   SectionData,
   ThemePageSectionsData,
   themeTabOrder,
@@ -302,23 +301,19 @@ const ConceptPage: NextPage<Props> = ({
     const links: Link[] = [];
 
     // Add image sections
-    for (const section of themeTabOrder) {
-      const showSection = () => {
-        switch (section) {
-          case 'by':
-            return config.imagesBy.display;
-          case 'in':
-            return config.imagesIn.display;
-          case 'about':
-            return config.imagesAbout.display;
-        }
-      };
-      if (sectionsData[section].images?.totalResults && showSection()) {
-        links.push({
-          text: `Images ${getThemeSectionHeading(section, conceptResponse, true)}`,
-          url: `#images-${section}`,
-        });
-      }
+    const showImagesSection = () => {
+      return (
+        config.imagesAbout.display ||
+        config.imagesBy.display ||
+        config.imagesIn.display
+      );
+    };
+
+    if (showImagesSection()) {
+      links.push({
+        text: `Images from the collections`,
+        url: `#images`,
+      });
     }
 
     // Add works section
@@ -328,7 +323,7 @@ const ConceptPage: NextPage<Props> = ({
         config.worksIn.display ||
         config.worksAbout.display)
     ) {
-      links.push({ text: 'Works', url: '#works' });
+      links.push({ text: 'Works from the collections', url: '#works' });
     }
 
     // Add frequent collaborators

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -301,15 +301,12 @@ const ConceptPage: NextPage<Props> = ({
     const links: Link[] = [];
 
     // Add image sections
-    const showImagesSection = () => {
-      return (
+    const showImagesSection =
         config.imagesAbout.display ||
         config.imagesBy.display ||
         config.imagesIn.display
-      );
-    };
 
-    if (showImagesSection()) {
+    if (showImagesSection) {
       links.push({
         text: `Images from the collections`,
         url: `#images`,


### PR DESCRIPTION
## What does this change?
Adds an h2 section headings above images/works in line with designs, and update other h2s to be Wellcome Bold. Also changes side navigation to link to these (h2) sections (i.e. not the images sub-sections).

Note: the Figma has the heading in a lighter weight of Wellcome Bold which we don't have (yet) in production. @dana-saur has Said it's ok to use what we've currently got for now.

## How to test
Visit a concept page and check that 'Images from the collections' and 'Works from the collections' headings are above the images/works sections. Check the 'Frequent collaborators' and 'Related topics' headings are in Wellcome Bold, and that these are now the sections that are linked from side nav.

## How can we measure success?
Matches design spec

## Have we considered potential risks?
Can't think of any