### PR TITLE
Use scroll instead of scrollend on event listener as not supported by Safari

### DIFF
--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
@@ -63,11 +63,11 @@ const ScrollableNavigation: FunctionComponent<Props> = ({
 
     updateScrollButtons();
 
-    container.addEventListener('scrollend', updateScrollButtons);
+    container.addEventListener('scroll', updateScrollButtons);
     window.addEventListener('resize', updateScrollButtons);
 
     return () => {
-      container.removeEventListener('scrollend', updateScrollButtons);
+      container.removeEventListener('scroll', updateScrollButtons);
       window.removeEventListener('resize', updateScrollButtons);
     };
   }, []);


### PR DESCRIPTION
## What does this change?
[#12200](https://github.com/wellcomecollection/wellcomecollection.org/issues/12200)

Sorry, that one was a change of mine, so just reverting it now. I thought scrollend was nicer, but didn't check the support  and turns out [Safari doesn't support it](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event#browser_compatibility). Scroll [is supported everywhere](https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event#browser_compatibility).

## How to test

Run on all browsers and make sure it's fixed in Safari and not affected in the others

## How can we measure success?

Bug fixed in Saf

## Have we considered potential risks?
N/A if good in other browsers.