### PR TITLE
Alt landing page for Collections

### DIFF
--- a/common/data/hardcoded-ids.ts
+++ b/common/data/hardcoded-ids.ts
@@ -31,6 +31,7 @@ export const prismicPageIds = {
   bookingAndAttendingOurEvents: 'booking-and-attending-our-events',
   cafe: 'cafe',
   collections: 'collections',
+  newCollections: 'collections-landing', // TODO eventually rename collections when it switches over
   contactUs: 'contact-us',
   cookiePolicy: 'cookie-policy',
   dailyGuidedTours: 'daily-guided-tours-and-discussions',

--- a/common/views/layouts/PageLayout/index.tsx
+++ b/common/views/layouts/PageLayout/index.tsx
@@ -66,6 +66,7 @@ export type Props = PropsWithChildren<{
   apiToolbarLinks?: (ApiToolbarLink | undefined)[];
   skipToContentLinks?: SkipToContentLink[];
   clipOverflowX?: boolean; // See pageGridOffset
+  isNoIndex?: boolean;
 }>;
 
 const PageLayoutComponent: NextPage<Props> = ({
@@ -86,6 +87,7 @@ const PageLayoutComponent: NextPage<Props> = ({
   apiToolbarLinks = [],
   skipToContentLinks = [],
   clipOverflowX = false,
+  isNoIndex = false,
 }) => {
   const { apiToolbar, issuesBanner } = useToggles();
   const urlString = convertUrlToString(url);
@@ -214,6 +216,8 @@ const PageLayoutComponent: NextPage<Props> = ({
           name="viewport"
           content="width=device-width, initial-scale=1"
         />
+
+        {isNoIndex && <meta name="robots" content="noindex" />}
 
         {rssUrl && (
           <link

--- a/content/webapp/pages/collections/[uid].tsx
+++ b/content/webapp/pages/collections/[uid].tsx
@@ -1,5 +1,6 @@
 import { NextPage } from 'next';
 
+import { looksLikePrismicId } from '@weco/common/services/prismic';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -16,6 +17,17 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   Props
 > = async context => {
   const { uid } = context.query;
+
+  const isHiddenPage = uid
+    ? ['collections-landing', 'aKb_ahAAAB8AhtQC'].includes(
+        Array.isArray(uid) ? uid[0] : uid
+      )
+    : false;
+
+  if (isHiddenPage || !looksLikePrismicId(uid)) {
+    return { notFound: true };
+  }
+
   return page.getServerSideProps({
     ...context,
     query: { pageId: uid },

--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -1,6 +1,8 @@
 import { NextPage } from 'next';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
+import { getServerData } from '@weco/common/server-data';
+import { useToggles } from '@weco/common/server-data/Context';
 import {
   ContaineredLayout,
   gridSize12,
@@ -13,9 +15,14 @@ import {
 } from '@weco/common/views/pages/_app';
 import * as page from '@weco/content/pages/pages/[pageId]';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import CollectionsLandingPage from '@weco/content/views/pages/collections';
 
 const Page: NextPage<page.Props> = props => {
-  return (
+  const { collectionsLanding } = useToggles();
+
+  return collectionsLanding ? (
+    <CollectionsLandingPage {...props} />
+  ) : (
     <page.Page
       {...props}
       staticContent={
@@ -35,9 +42,17 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   Props
 > = async context => {
   setCacheControl(context.res);
+  const serverData = await getServerData(context);
+
+  const newCollectionsLanding = serverData.toggles.collectionsLanding.value;
+
   return page.getServerSideProps({
     ...context,
-    query: { pageId: prismicPageIds.collections },
+    query: {
+      pageId: newCollectionsLanding
+        ? prismicPageIds.newCollections
+        : prismicPageIds.collections,
+    },
     params: { siteSection: 'collections' },
   });
 };

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -1,0 +1,45 @@
+import { NextPage } from 'next';
+
+import { SiteSection } from '@weco/common/model/site-section';
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import PageHeader from '@weco/common/views/components/PageHeader';
+import { Container } from '@weco/common/views/components/styled/Container';
+import PageLayout from '@weco/common/views/layouts/PageLayout';
+import { Props as PagePageProps } from '@weco/content/views/pages/pages/page';
+
+const CollectionsLandingPage: NextPage<PagePageProps> = ({
+  page,
+  // siblings,
+  // children,
+  // ordersInParents,
+  // staticContent,
+  jsonLd,
+}) => {
+  return (
+    <PageLayout
+      title={page.title}
+      description={page.metadataDescription || page.promo?.caption || ''}
+      url={{
+        pathname: `${page?.siteSection ? '/' + page.siteSection : ''}/${page.uid}`,
+      }}
+      jsonLd={jsonLd}
+      openGraphType="website"
+      siteSection={page?.siteSection as SiteSection}
+      image={page.image}
+      apiToolbarLinks={[createPrismicLink(page.id)]}
+      isNoIndex // TODO remove when this becomes the page
+      hideNewsletterPromo
+    >
+      <PageHeader
+        title={page.title}
+        breadcrumbs={{ items: [] }} // TODO
+      />
+
+      <Container>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      </Container>
+    </PageLayout>
+  );
+};
+
+export default CollectionsLandingPage;


### PR DESCRIPTION
## What does this change?

#12214 

The new page [was created in Prismic](https://wellcomecollection.prismic.io/builder/pages/aKb_ahAAAB8AhtQC?s=published) and has a `delist` tag as to not get picked up by our All search.

I added the capacity to add the `noIndex` meta, which I think Lauren wanted us to have anyway so that could stay in. It's all manual at the moment though, it's not perfected.

Also manually done was the `isHiddenPage` const, which returns a 404 if a user is trying to access this page straight from its id/uid (`collections/collections-landing` would otherwise work).

So I think it's general the page SHOULD be hidden from all, but let me know if I've missed something!

Otherwise the PR is mostly about displaying and fetching alternative content should the user have the `collectionsLanding` toggle turned on.

The page itself is VERY WIP, a lot of TODOs and commented out code.


## How to test

Run locally, try to access the page without the toggle turned on - you shouldn't be able to.

Turn it on and go to `/collections`, you should see the alternative page.

## How can we measure success?

We have a space to start the work.

## Have we considered potential risks?
N/A if it's not indexed/findable, although even then it'd just be a bit confusing.
Mostly we want to ensure users can still see the CURRENT Collection page and aren't affected.