### PR TITLE
RelatedWorksCard hover style in Cardigan

### DIFF
--- a/cardigan/stories/components/Cards/RelatedWorksCard/RelatedWorksCard.stories.tsx
+++ b/cardigan/stories/components/Cards/RelatedWorksCard/RelatedWorksCard.stories.tsx
@@ -52,6 +52,7 @@ type Story = StoryObj<RelatedWorksCardStoryProps>;
 export const Basic: Story = {
   args: {
     work: workBasic,
+    variant: 'default',
   },
 
   name: 'RelatedWorksCard',

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Default.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Default.tsx
@@ -1,0 +1,94 @@
+import { FunctionComponent } from 'react';
+
+import { WorkLinkSource } from '@weco/common/data/segment-values';
+import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
+import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
+import LabelsList from '@weco/common/views/components/LabelsList';
+import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+import WorkLink from '@weco/content/views/components/WorkLink';
+import { ContentAPILinkedWork } from '@weco/content/views/pages/stories/story/tempMockData';
+
+import {
+  Card,
+  ImageWrapper,
+  LineClamp,
+  MetaContainer,
+  TextWrapper,
+  Title,
+} from './RelatedWorksCard.styles';
+
+export type Props = {
+  work: WorkBasic | ContentAPILinkedWork; // Supports both Catalogue and Content API works
+  source?: WorkLinkSource; // Optional source for Segment tracking
+  gtmData?: DataGtmProps;
+};
+
+const RelatedWorksCard: FunctionComponent<Props> = ({
+  work,
+  source,
+  gtmData,
+}) => {
+  const isCatalogueWork = 'notes' in work;
+
+  const thumbnailUrl = isCatalogueWork
+    ? work.thumbnail?.url
+    : work.thumbnailUrl;
+
+  const date = isCatalogueWork
+    ? work.productionDates.length > 0
+      ? work.productionDates[0]
+      : undefined
+    : work.date;
+
+  const labels = isCatalogueWork ? work.cardLabels : work.labels || [];
+
+  const mainContributor = isCatalogueWork
+    ? work.primaryContributorLabel
+    : work.mainContributor;
+
+  return (
+    <WorkLink
+      data-component="related-works-card"
+      id={work.id}
+      source={source || `works_search_result_${work.id}`}
+      passHref
+    >
+      <Card
+        {...(gtmData &&
+          dataGtmPropsToAttributes({
+            ...gtmData,
+            id: work.id,
+            trigger: 'related_card_result',
+          }))}
+      >
+        <TextWrapper>
+          <div>
+            <LabelsList labels={labels} defaultLabelColor="warmNeutral.300" />
+            <Title $linesToClamp={3}>{work.title}</Title>
+          </div>
+
+          <MetaContainer>
+            {mainContributor && (
+              <LineClamp $linesToClamp={1}>{mainContributor}</LineClamp>
+            )}
+            {date && <LineClamp $linesToClamp={1}>Date: {date}</LineClamp>}
+          </MetaContainer>
+        </TextWrapper>
+
+        {thumbnailUrl && (
+          <ImageWrapper>
+            <img
+              src={convertIiifImageUri(thumbnailUrl, 120)}
+              alt={work.title}
+              loading="lazy"
+              width="200"
+              height="200"
+            />
+          </ImageWrapper>
+        )}
+      </Card>
+    </WorkLink>
+  );
+};
+
+export default RelatedWorksCard;

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Hover.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Hover.tsx
@@ -65,6 +65,8 @@ const RelatedWorksCard: FunctionComponent<Props> = ({
               src={convertIiifImageUri(thumbnailUrl, 120)}
               alt={work.title}
               loading="lazy"
+              width="200"
+              height="200"
             />
           </ImageWrapper>
         )}

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Hover.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Hover.tsx
@@ -1,0 +1,88 @@
+import { FunctionComponent } from 'react';
+
+import { WorkLinkSource } from '@weco/common/data/segment-values';
+import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
+import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
+import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+import WorkLink from '@weco/content/views/components/WorkLink';
+import { ContentAPILinkedWork } from '@weco/content/views/pages/stories/story/tempMockData';
+
+import {
+  Card,
+  ImageWrapper,
+  LineClamp,
+  MetaContainer,
+  TextWrapper,
+  Title,
+} from './RelatedWorksCard.styles';
+
+type Props = {
+  work: WorkBasic | ContentAPILinkedWork; // Supports both Catalogue and Content API works
+  source?: WorkLinkSource; // Optional source for Segment tracking
+  gtmData?: DataGtmProps;
+};
+
+const RelatedWorksCard: FunctionComponent<Props> = ({
+  work,
+  source,
+  gtmData,
+}) => {
+  const isCatalogueWork = 'notes' in work;
+
+  const thumbnailUrl = isCatalogueWork
+    ? work.thumbnail?.url
+    : work.thumbnailUrl;
+
+  const date = isCatalogueWork
+    ? work.productionDates.length > 0
+      ? work.productionDates[0]
+      : undefined
+    : work.date;
+
+  const mainContributor = isCatalogueWork
+    ? work.primaryContributorLabel
+    : work.mainContributor;
+
+  return (
+    <WorkLink
+      data-component="related-works-card"
+      id={work.id}
+      source={source || `works_search_result_${work.id}`}
+      passHref
+    >
+      <Card
+        $isHover={true}
+        {...(gtmData &&
+          dataGtmPropsToAttributes({
+            ...gtmData,
+            id: work.id,
+            trigger: 'related_card_result',
+          }))}
+      >
+        {thumbnailUrl && (
+          <ImageWrapper $isHover={true}>
+            <img
+              src={convertIiifImageUri(thumbnailUrl, 120)}
+              alt={work.title}
+              loading="lazy"
+            />
+          </ImageWrapper>
+        )}
+        <TextWrapper>
+          <Title $isHover={true} $linesToClamp={1}>
+            {work.title}
+          </Title>
+
+          <MetaContainer>
+            {mainContributor && (
+              <LineClamp $linesToClamp={1}>{mainContributor}</LineClamp>
+            )}
+            {date && <LineClamp $linesToClamp={1}>Date: {date}</LineClamp>}
+          </MetaContainer>
+        </TextWrapper>
+      </Card>
+    </WorkLink>
+  );
+};
+
+export default RelatedWorksCard;

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
@@ -10,7 +10,7 @@ const clampLineStyles = css<{ $linesToClamp: number }>`
   -webkit-line-clamp: ${props => props.$linesToClamp};
 `;
 
-export const Card = styled.a`
+export const Card = styled.a<{ $isHover?: boolean }>`
   display: flex;
   padding: ${props => props.theme.spacingUnits['3']}px;
   background-color: ${props => props.theme.color('white')};
@@ -18,16 +18,24 @@ export const Card = styled.a`
   flex-wrap: wrap;
   text-decoration: none;
 
+  ${props =>
+    props.$isHover &&
+    `
+    height: 6rem;
+    width: 30rem;
+  `}
+
   ${props => props.theme.media('medium')`
     max-height: 10rem;
     flex-wrap: nowrap;
     justify-content: space-between;
   `}
 
-  ${props => props.theme.media('large')`
+  ${props =>
+    props.theme.media('large')(`
     max-height: unset;
-    height: 10rem;
-  `}
+    height: ${props.$isHover ? '6rem' : '10rem'};
+  `)}
 `;
 
 export const TextWrapper = styled.div`
@@ -60,9 +68,9 @@ export const TextWrapper = styled.div`
   }
 `;
 
-export const Title = styled.h2.attrs({
-  className: font('intb', 5),
-})<{ $linesToClamp: number }>`
+export const Title = styled.h2.attrs<{ $isHover?: boolean }>(props => ({
+  className: font(props.$isHover ? 'intr' : 'intb', 5),
+}))<{ $linesToClamp: number }>`
   ${clampLineStyles};
   margin-top: ${props => props.theme.spacingUnits['1']}px;
 
@@ -75,7 +83,7 @@ export const LineClamp = styled.div<{ $linesToClamp: number }>`
   ${clampLineStyles};
 `;
 
-export const ImageWrapper = styled.div`
+export const ImageWrapper = styled.div<{ $isHover?: boolean }>`
   width: 100%;
   max-height: 250px;
   order: -1;
@@ -93,8 +101,8 @@ export const ImageWrapper = styled.div`
 
     ${props =>
       props.theme.media('medium')(`
-      margin-left: ${props.theme.spacingUnits['3']}px;
-      margin-right: unset;
+      margin-left: ${props.$isHover ? '0' : props.theme.spacingUnits['3']}px;
+      margin-right: ${props.$isHover ? props.theme.spacingUnits['3'] + 'px' : 'unset'};
       width: unset;
       height: 100%;
 

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
@@ -22,7 +22,7 @@ export const Card = styled.a<{ $isHover?: boolean }>`
     props.$isHover &&
     `
     height: 6rem;
-    width: 30rem;
+    width: 22rem;
   `}
 
   ${props => props.theme.media('medium')`

--- a/content/webapp/views/components/RelatedWorksCard/index.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/index.tsx
@@ -1,94 +1,24 @@
 import { FunctionComponent } from 'react';
 
-import { WorkLinkSource } from '@weco/common/data/segment-values';
-import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
-import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
-import LabelsList from '@weco/common/views/components/LabelsList';
-import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
-import WorkLink from '@weco/content/views/components/WorkLink';
-import { ContentAPILinkedWork } from '@weco/content/views/pages/stories/story/tempMockData';
+import RelatedWorksCardDefault, {
+  Props as BaseProps,
+} from './RelatedWorksCard.Default';
+import RelatedWorksCardHover from './RelatedWorksCard.Hover';
 
-import {
-  Card,
-  ImageWrapper,
-  LineClamp,
-  MetaContainer,
-  TextWrapper,
-  Title,
-} from './RelatedWorksCard.styles';
-
-type Props = {
-  work: WorkBasic | ContentAPILinkedWork; // Supports both Catalogue and Content API works
-  source?: WorkLinkSource; // Optional source for Segment tracking
-  gtmData?: DataGtmProps;
+type Props = BaseProps & {
+  variant: 'default' | 'hover';
 };
 
-const RelatedWorksCard: FunctionComponent<Props> = ({
-  work,
-  source,
-  gtmData,
-}) => {
-  const isCatalogueWork = 'notes' in work;
+const RelatedWorksCard: FunctionComponent<Props> = props => {
+  const { variant } = props;
 
-  const thumbnailUrl = isCatalogueWork
-    ? work.thumbnail?.url
-    : work.thumbnailUrl;
+  if (variant === 'default') {
+    return <RelatedWorksCardDefault {...props} />;
+  }
 
-  const date = isCatalogueWork
-    ? work.productionDates.length > 0
-      ? work.productionDates[0]
-      : undefined
-    : work.date;
-
-  const labels = isCatalogueWork ? work.cardLabels : work.labels || [];
-
-  const mainContributor = isCatalogueWork
-    ? work.primaryContributorLabel
-    : work.mainContributor;
-
-  return (
-    <WorkLink
-      data-component="related-works-card"
-      id={work.id}
-      source={source || `works_search_result_${work.id}`}
-      passHref
-    >
-      <Card
-        {...(gtmData &&
-          dataGtmPropsToAttributes({
-            ...gtmData,
-            id: work.id,
-            trigger: 'related_card_result',
-          }))}
-      >
-        <TextWrapper>
-          <div>
-            <LabelsList labels={labels} defaultLabelColor="warmNeutral.300" />
-            <Title $linesToClamp={3}>{work.title}</Title>
-          </div>
-
-          <MetaContainer>
-            {mainContributor && (
-              <LineClamp $linesToClamp={1}>{mainContributor}</LineClamp>
-            )}
-            {date && <LineClamp $linesToClamp={1}>Date: {date}</LineClamp>}
-          </MetaContainer>
-        </TextWrapper>
-
-        {thumbnailUrl && (
-          <ImageWrapper>
-            <img
-              src={convertIiifImageUri(thumbnailUrl, 120)}
-              alt={work.title}
-              loading="lazy"
-              width="200"
-              height="200"
-            />
-          </ImageWrapper>
-        )}
-      </Card>
-    </WorkLink>
-  );
+  if (variant === 'hover') {
+    return <RelatedWorksCardHover {...props} />;
+  }
 };
 
 export default RelatedWorksCard;


### PR DESCRIPTION
For #12068 

## What does this change?
Creates a new 'hover' variant of the `RelatedWorksCard` and renders it in Cardigan

## How to test
Run Cardigan, look at the [RelatedWorksCard component](http://localhost:9001/?path=/story/components-cards-relatedworkscard--basic&args=work:Catalogue+API;seeOnDarkBackground:!true;variant:hover), check it matches design.

__TODO__
- [ ] The filter that adds rounded corners to the images is currently [only added in the app](https://github.com/wellcomecollection/wellcomecollection.org/blob/6c7c64cf0fc5861e914394baceff9c703d01424c/content/webapp/views/pages/works/work/RelatedWorks/index.tsx#L199), not in Cardigan (possible case for adding them in a React Portal that is part of the RelatedWorksCard component?)

## How can we measure success?
tracking

## Have we considered potential risks?
Needs more testing with e.g. different image aspect ratios once it's plugged into the real data
