### PR TITLE
Adjusted styles for Related cards

### DIFF
--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
@@ -34,12 +34,12 @@ export const Card = styled.a`
 export const TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   width: 100%;
   container-type: inline-size;
   container-name: text-wrapper;
 
   ${props => props.theme.media('medium')`
+    justify-content: space-between;
     padding-top: 0;
   `}
 
@@ -79,7 +79,7 @@ export const LineClamp = styled.div<{ $linesToClamp: number }>`
 
 export const ImageWrapper = styled.div`
   width: 100%;
-  max-height: 250px;
+  max-height: 160px;
   order: -1;
   margin-bottom: ${props => props.theme.spacingUnits['5']}px;
   display: flex;
@@ -88,7 +88,6 @@ export const ImageWrapper = styled.div`
     display: block;
     object-fit: contain;
     width: 100%;
-    max-width: 200px; /* The size of the IIIF thumbnails */
     margin-left: auto;
     margin-right: auto;
     filter: url('#border-radius-mask');

--- a/content/webapp/views/components/RelatedWorksCard/index.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/index.tsx
@@ -82,10 +82,9 @@ const RelatedWorksCard: FunctionComponent<Props> = ({ work, gtmData }) => {
         {thumbnailUrl && (
           <ImageWrapper>
             <img
-              src={convertIiifImageUri(thumbnailUrl, 120)}
+              src={convertIiifImageUri(thumbnailUrl, 250)}
               alt={work.title}
               loading="lazy"
-              width="200"
               height="200"
             />
           </ImageWrapper>


### PR DESCRIPTION
## What does this change?

#12129  ([this comment specifically](https://github.com/wellcomecollection/wellcomecollection.org/issues/12129#issuecomment-3228614832))

Adjusted as requested by Dana. We also changed the image size so they would have the same height across (prioritising max height over max width)

It does also affect the works in Work pages because it's the same component - but I check and we're happy to change across, the images are also less blurry now.

## How to test

Visit a couple stories with the component (e.g. https://www-dev.wellcomecollection.org/stories/YZJzrhEAACUARhC3) and resize window to check it looks good.

Visit works pages to see how if affected it: https://www-dev.wellcomecollection.org/works/a2239muq

## How can we measure success?

Ready to release?

## Have we considered potential risks?
N/A