### PR TITLE
Ge/fetch works when required

### DIFF
--- a/cardigan/stories/data/content.ts
+++ b/cardigan/stories/data/content.ts
@@ -270,6 +270,7 @@ export const article: TransformedPrismicArticle = {
   id: 'YLoCLhAAACEAfyuO',
   uid: 'a-dark-cloud',
   title: 'A dark cloud',
+  hasLinkedWorks: false,
   contributors: [
     {
       role: {
@@ -460,6 +461,7 @@ export const articleBasic: ArticleBasic = {
   title: article.title,
   datePublished: article.datePublished,
   labels: [],
+  hasLinkedWorks: false,
 };
 
 export const exhibitionBasic: ExhibitionBasic = {

--- a/content/webapp/services/prismic/transformers/article-series.test.ts
+++ b/content/webapp/services/prismic/transformers/article-series.test.ts
@@ -66,6 +66,7 @@ describe('sortSeriesItems', () => {
         type: 'articles',
         id: 'Y0-8rxEAAA1CBr3a',
         uid: 'how-can-we-prevent-violence',
+        hasLinkedWorks: false,
         title: 'How can we prevent violence?',
         series: [],
         datePublished: new Date('2022-10-27T09:00:00.000Z'),
@@ -75,6 +76,7 @@ describe('sortSeriesItems', () => {
         type: 'articles',
         id: 'Y0Uv0REAAImM14IP',
         uid: 'what-is-structural-violence',
+        hasLinkedWorks: false,
         series: [],
         title: 'What is structural violence?',
         datePublished: new Date('2022-10-20T09:00:00.000Z'),
@@ -83,6 +85,7 @@ describe('sortSeriesItems', () => {
       {
         type: 'articles',
         id: 'Yz1IdhEAABfUtA8u',
+        hasLinkedWorks: false,
         series: [],
         uid: 'why-do-victims-become-violent',
         title: 'Why do victims become violent?',

--- a/content/webapp/services/prismic/transformers/articles.ts
+++ b/content/webapp/services/prismic/transformers/articles.ts
@@ -13,6 +13,7 @@ import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 import { Article, ArticleBasic } from '@weco/content/types/articles';
 import { Format } from '@weco/content/types/format';
 import { Series } from '@weco/content/types/series';
+import { getWorksIdsFromDocumentBody } from '@weco/content/utils/extract-works-ids';
 import {
   calculateReadingTime,
   showReadingTime,
@@ -43,6 +44,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     datePublished,
     labels,
     color,
+    hasLinkedWorks,
   }) => ({
     type,
     id,
@@ -61,6 +63,7 @@ export function transformArticleToArticleBasic(article: Article): ArticleBasic {
     datePublished,
     labels,
     color,
+    hasLinkedWorks,
     // We only use the square crop of an image in the <ArticleCard> component,
     // so we can omit sending any other crops.
     image: image && {
@@ -109,6 +112,9 @@ export function transformArticle(
 
   const contributors = transformContributors(document);
 
+  const workIds = getWorksIdsFromDocumentBody(data.body);
+  const hasLinkedWorks = workIds.length > 0;
+
   // The content will be fetched client side later on
   const exploreMoreDocument =
     'exploreMoreDocument' in data &&
@@ -138,5 +144,6 @@ export function transformArticle(
         )
       : [],
     exploreMoreDocument,
+    hasLinkedWorks,
   };
 }

--- a/content/webapp/types/articles.test.ts
+++ b/content/webapp/types/articles.test.ts
@@ -8,6 +8,7 @@ describe('getPartNumberInSeries', () => {
       type: 'articles',
       id: 'Y_iu0RQAACYAwp8A',
       uid: 'cataloguing-audrey',
+      hasLinkedWorks: false,
       series: [
         {
           id: 'Y_OGkRQAACgAq4ui',
@@ -49,6 +50,7 @@ describe('getPartNumberInSeries', () => {
       type: 'articles',
       id: 'Y-0A1hQAACUAjrjg',
       uid: 'stones-for-healing',
+      hasLinkedWorks: false,
       series: [
         {
           id: 'WsSUrR8AAL3KGFPF',

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -24,6 +24,7 @@ export type ArticleBasic = {
   datePublished: Date;
   labels: Label[];
   color?: ColorSelection;
+  hasLinkedWorks: boolean;
 };
 
 export type Article = GenericContentFields & {
@@ -41,6 +42,7 @@ export type Article = GenericContentFields & {
     uid?: string;
     type: 'articles' | 'exhibitions';
   };
+  hasLinkedWorks: boolean;
 };
 
 /** Given an article in a serial, return its part number.

--- a/content/webapp/utils/extract-works-ids.test.ts
+++ b/content/webapp/utils/extract-works-ids.test.ts
@@ -1,0 +1,125 @@
+import { getWorksIdsFromDocumentBody } from '@weco/content/utils/extract-works-ids';
+
+describe('extract-works-ids', () => {
+  describe('getWorksIdsFromDocumentBody', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns empty array when no body is provided', () => {
+      expect(getWorksIdsFromDocumentBody(undefined)).toEqual([]);
+      expect(getWorksIdsFromDocumentBody([])).toEqual([]);
+    });
+
+    it('extracts work IDs from text slice with hyperlinks', () => {
+      const documentBody = [
+        {
+          slice_type: 'text',
+          primary: {
+            text: [
+              {
+                type: 'paragraph',
+                text: 'Check out this work',
+                spans: [
+                  {
+                    start: 10,
+                    end: 20,
+                    type: 'hyperlink',
+                    data: {
+                      link_type: 'Web',
+                      url: 'https://wellcomecollection.org/works/abc123def',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ] as unknown as Parameters<typeof getWorksIdsFromDocumentBody>[0];
+
+      const result = getWorksIdsFromDocumentBody(documentBody);
+      expect(result).toEqual(['abc123def']);
+    });
+
+    it('extracts work IDs from editorial image copyright', () => {
+      const documentBody = [
+        {
+          slice_type: 'editorialImage',
+          primary: {
+            image: {
+              copyright:
+                'Title | Author | Wellcome Collection | https://wellcomecollection.org/works/xyz789/items | CC-BY | |',
+            },
+            caption: [],
+          },
+        },
+      ] as unknown as Parameters<typeof getWorksIdsFromDocumentBody>[0];
+
+      const result = getWorksIdsFromDocumentBody(documentBody);
+      expect(result).toEqual(['xyz789']);
+    });
+
+    it('extracts work IDs from gifVideo tasl field', () => {
+      const documentBody = [
+        {
+          slice_type: 'gifVideo',
+          primary: {
+            tasl: 'Video title | Creator | Wellcome Collection | https://wellcomecollection.org/works/def456 | CC-BY | |',
+            caption: [],
+          },
+        },
+      ] as unknown as Parameters<typeof getWorksIdsFromDocumentBody>[0];
+
+      const result = getWorksIdsFromDocumentBody(documentBody);
+      expect(result).toEqual(['def456']);
+    });
+
+    it('ignores slices that cannot contain work links', () => {
+      const documentBody = [
+        {
+          slice_type: 'embed',
+          primary: {
+            embed: { url: 'https://example.com' },
+          },
+        },
+        {
+          slice_type: 'quote',
+          primary: {
+            text: [
+              {
+                type: 'paragraph',
+                text: 'This quote contains a work link',
+                spans: [],
+              },
+            ],
+          },
+        },
+        {
+          slice_type: 'audioPlayer',
+          primary: {
+            title: [
+              {
+                type: 'paragraph',
+                text: 'Audio with work link',
+                spans: [],
+              },
+            ],
+          },
+        },
+        {
+          slice_type: 'editorialImage',
+          primary: {
+            image: {
+              copyright:
+                'Title | Author | Wellcome Collection | https://wellcomecollection.org/works/should-be-found | CC-BY | |',
+            },
+            caption: [],
+          },
+        },
+      ] as unknown as Parameters<typeof getWorksIdsFromDocumentBody>[0];
+
+      const result = getWorksIdsFromDocumentBody(documentBody);
+      expect(result).toEqual(['should-be-found']);
+    });
+  });
+});

--- a/content/webapp/utils/extract-works-ids.test.ts
+++ b/content/webapp/utils/extract-works-ids.test.ts
@@ -6,11 +6,6 @@ describe('extract-works-ids', () => {
       jest.clearAllMocks();
     });
 
-    it('returns empty array when no body is provided', () => {
-      expect(getWorksIdsFromDocumentBody(undefined)).toEqual([]);
-      expect(getWorksIdsFromDocumentBody([])).toEqual([]);
-    });
-
     it('extracts work IDs from text slice with hyperlinks', () => {
       const documentBody = [
         {

--- a/content/webapp/utils/extract-works-ids.ts
+++ b/content/webapp/utils/extract-works-ids.ts
@@ -1,0 +1,164 @@
+import type * as prismic from '@prismicio/client';
+
+import {
+  EditorialImageGallerySlice,
+  GifVideoSlice,
+} from '@weco/common/prismicio-types';
+
+export type AddressableSlices =
+  | prismic.Content.ArticlesDocumentDataBodySlice
+  | prismic.Content.BooksDocumentDataBodySlice
+  | prismic.Content.EventsDocumentDataBodySlice
+  | prismic.Content.ExhibitionsDocumentDataBodySlice
+  | prismic.Content.ExhibitionHighlightToursDocumentDataSlicesSlice
+  | prismic.Content.ExhibitionTextsDocumentDataSlicesSlice
+  | prismic.Content.PagesDocumentDataBodySlice
+  | prismic.Content.ProjectsDocumentDataBodySlice
+  | prismic.Content.SeasonsDocumentDataBodySlice
+  | prismic.Content.VisualStoriesDocumentDataBodySlice;
+
+// Helper functions for extracting Wellcome Collection work IDs from Prismic slice content.
+// Searches for works URLs (https://wellcomecollection.org/works/[id]) in:
+// - Text slices: hyperlinks in 'text' rich text field
+// - Editorial image slices: hyperlinks in 'caption' rich text field, URLs in the image's copyright string
+// - Editorial image gallery slices: hyperlinks in each item's 'caption' rich text field, URLs in each item's image copyright string
+// - gifVideo slices: hyperlinks in 'caption' rich text field, URLs in the tasl string
+const worksUrlPattern = /^https:\/\/wellcomecollection\.org\/works\/([^/?#]+)/i;
+
+const extractWorksIdsFromRichTextField = ({
+  richTextField,
+}: {
+  richTextField: prismic.RichTextField;
+}): string[] => {
+  const worksIds: string[] = [];
+
+  richTextField.forEach(textElement => {
+    if ('text' in textElement && 'spans' in textElement) {
+      const spans = (textElement as { spans: unknown }).spans;
+      if (Array.isArray(spans)) {
+        const extractedIds = spans.reduce<string[]>((spanIds, span) => {
+          if (
+            span.type === 'hyperlink' &&
+            span.data?.link_type === 'Web' &&
+            span.data?.url
+          ) {
+            const match = span.data.url.match(worksUrlPattern);
+            if (match?.[1]) {
+              spanIds.push(match[1]);
+            }
+          }
+          return spanIds;
+        }, []);
+        worksIds.push(...extractedIds);
+      }
+    }
+  });
+
+  return worksIds;
+};
+
+const extractWorksIdsFromString = ({
+  text,
+}: {
+  text: string | null | undefined;
+}): string[] => {
+  const worksIds: string[] = [];
+
+  if (text && typeof text === 'string') {
+    const globalWorksUrlPattern =
+      /https:\/\/wellcomecollection\.org\/works\/([^/?#\s|]+)/gi;
+    const matches = text.matchAll(globalWorksUrlPattern);
+
+    for (const match of matches) {
+      if (match[1]) {
+        worksIds.push(match[1]);
+      }
+    }
+  }
+
+  return worksIds;
+};
+
+const extractWorksIdsFromGifVideoTasl = ({
+  slice,
+}: {
+  slice: GifVideoSlice;
+}): string[] => {
+  return extractWorksIdsFromString({
+    text: slice.primary.tasl,
+  });
+};
+
+const extractWorksIdsFromEditorialImageGallery = ({
+  slice,
+}: {
+  slice: EditorialImageGallerySlice;
+}): string[] => {
+  const worksIds: string[] = [];
+
+  slice.items.forEach(item => {
+    const copyrightIds = extractWorksIdsFromString({
+      text: item.image.copyright,
+    });
+    worksIds.push(...copyrightIds);
+
+    const captionIds = extractWorksIdsFromRichTextField({
+      richTextField: item.caption,
+    });
+    worksIds.push(...captionIds);
+  });
+
+  return worksIds;
+};
+
+const extractWorksIdsFromSlices = (slices: AddressableSlices[]): string[] => {
+  const worksIds = slices.flatMap(slice => {
+    switch (slice.slice_type) {
+      case 'text':
+        return extractWorksIdsFromRichTextField({
+          richTextField: slice.primary.text,
+        });
+      case 'editorialImage':
+        return [
+          ...extractWorksIdsFromString({
+            text: slice.primary.image.copyright,
+          }),
+          ...extractWorksIdsFromRichTextField({
+            richTextField: slice.primary.caption,
+          }),
+        ];
+      case 'editorialImageGallery':
+        return extractWorksIdsFromEditorialImageGallery({
+          slice,
+        });
+      case 'gifVideo':
+        return [
+          ...extractWorksIdsFromGifVideoTasl({ slice }),
+          ...extractWorksIdsFromRichTextField({
+            richTextField: slice.primary.caption,
+          }),
+        ];
+      default:
+        return [];
+    }
+  });
+
+  return worksIds;
+};
+
+export const getWorksIdsFromDocumentBody = (
+  documentBody: AddressableSlices[]
+): string[] => {
+  const supportedSliceTypes = [
+    'text',
+    'editorialImage',
+    'editorialImageGallery',
+    'gifVideo',
+  ];
+  if (!documentBody) return [];
+  const relevantSlices = documentBody.filter(slice =>
+    supportedSliceTypes.includes(slice.slice_type)
+  );
+
+  return extractWorksIdsFromSlices(relevantSlices);
+};

--- a/content/webapp/views/pages/stories/story/index.tsx
+++ b/content/webapp/views/pages/stories/story/index.tsx
@@ -89,7 +89,9 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
   }, []);
 
   useEffect(() => {
-    fetchLinkedWorks();
+    if (article.hasLinkedWorks) {
+      fetchLinkedWorks();
+    }
   }, [article.id]);
 
   const extraBreadcrumbs = [


### PR DESCRIPTION
## What does this change?

Only make calls to the content-api for linked works data if the article contains linked works

- Checks the body slices of articles for the presence of work ids
- Adds a hasLinkedWorks property to Articles
- Uses the hasLinkedWorks property to determine whether to make a request to the content-api

## How to test

- enable the 'Featured works in addressables' toggle
- view [a page with no linked works](https://www-dev.wellcomecollection.org/stories/abandoning-daydreams-of-a-life-without-diabetes) and use dev tools to see that no request is made to the content-api
- compare this to [the live page](https://wellcomecollection.org/stories/abandoning-daydreams-of-a-life-without-diabetes), which does make the request
- view [a page with linked works](https://www-dev.wellcomecollection.org/stories/how-the-slave-trades-medical-legacies-persist) and see that it does make a request to the content-api and the preview cards appear at the bottom of the page

## How can we measure success?

We don't make unnecesary requests

## Have we considered potential risks?

none really

## Questions

We're only making the calls to the content-api for articles, but other content types can have linkedWorks. Should we be doing this for all addressable types?
