### PR TITLE
WIP: Align landings

### DIFF
--- a/common/data/hardcoded-ids.ts
+++ b/common/data/hardcoded-ids.ts
@@ -64,10 +64,15 @@ export const getNameFromCollectionVenue = id => {
   }
 };
 
+// TODO: check if it works with their ID and not just their UID
+// TODO: only use this and not the page format? Or the other way around?
 export const sectionLevelPages = [
   prismicPageIds.visitUs,
+  prismicPageIds.whatsOn,
+  'stories',
   prismicPageIds.collections,
   prismicPageIds.getInvolved,
+  prismicPageIds.aboutUs,
 ];
 
 // The only series ("webcomic series") that uses the `webcomics` type.

--- a/common/views/components/PageHeader/PageHeader.Landing.tsx
+++ b/common/views/components/PageHeader/PageHeader.Landing.tsx
@@ -1,3 +1,4 @@
+import * as prismic from '@prismicio/client';
 import {
   ComponentProps,
   FunctionComponent,
@@ -6,7 +7,9 @@ import {
 } from 'react';
 
 import { font } from '@weco/common/utils/classnames';
+import ConditionalWrapper from '@weco/common/views/components//ConditionalWrapper';
 import AccessibilityProvision from '@weco/common/views/components/AccessibilityProvision';
+import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import {
   ContaineredLayout,
@@ -14,6 +17,7 @@ import {
   gridSize12,
 } from '@weco/common/views/components/Layout';
 import { Picture } from '@weco/common/views/components/Picture';
+import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import { WobblyBottom } from '@weco/common/views/components/WobblyEdge';
 
@@ -38,6 +42,8 @@ export type Props = {
   backgroundTexture?: string;
   SerialPartNumber?: ReactNode;
   isSlim?: boolean;
+  isLandingPage?: boolean;
+  introText?: prismic.RichTextField;
   includeAccessibilityProvision?: boolean;
 };
 
@@ -55,18 +61,50 @@ const LandingPageHeader: FunctionComponent<Props> = ({
   backgroundTexture,
   SerialPartNumber,
   isSlim,
+  isLandingPage,
+  introText,
   includeAccessibilityProvision,
 }) => {
-  return (
+  const hasIntroText = !!(introText && introText.length > 0);
+
+  return isLandingPage ? (
+    <Container $backgroundTexture={backgroundTexture}>
+      {Background}
+      <ContaineredLayout gridSizes={gridSize12()}>
+        <Space $v={{ size: 'l', properties: ['margin-top'] }}>
+          <ConditionalWrapper
+            condition={hasIntroText}
+            wrapper={children => (
+              <Space $v={{ size: 's', properties: ['margin-bottom'] }}>
+                {children}
+              </Space>
+            )}
+          >
+            <TitleWrapper $sectionLevelPage>{title}</TitleWrapper>
+          </ConditionalWrapper>
+
+          {hasIntroText && (
+            <Space
+              $v={{ size: 'xl', properties: ['margin-bottom'] }}
+              className={font('intr', 3)}
+              style={{ maxWidth: '960px' }}
+            >
+              <PrismicHtmlBlock
+                html={introText}
+                htmlSerializer={defaultSerializer}
+              />
+            </Space>
+          )}
+        </Space>
+      </ContaineredLayout>
+    </Container>
+  ) : (
     <>
       <Container $backgroundTexture={backgroundTexture}>
         {Background}
         <ContaineredLayout gridSizes={gridSize12()}>
           <Wrapper
-            $v={{
-              size: isSlim ? 'xs' : 'l',
-              properties: ['margin-bottom'],
-            }}
+            $v={{ size: isSlim ? 'xs' : 'l', properties: ['margin-bottom'] }}
           >
             <Space $v={{ size: 'l', properties: ['margin-top'] }}>
               {SerialPartNumber}
@@ -81,12 +119,7 @@ const LandingPageHeader: FunctionComponent<Props> = ({
                 {ContentTypeInfo}
               </Space>
             )}
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'end',
-              }}
-            >
+            <div style={{ display: 'flex', alignItems: 'end' }}>
               {amendedLabels && amendedLabels.labels.length > 0 && (
                 <LabelsList {...amendedLabels} />
               )}

--- a/common/views/components/PageHeader/index.tsx
+++ b/common/views/components/PageHeader/index.tsx
@@ -51,7 +51,7 @@ const PageHeader: FunctionComponent<Props> = (props: Props) => {
   if ('sectionLevelPage' in props)
     return (
       <LandingPageHeader
-        data-component="section-page-header"
+        data-component="landing-page-header"
         amendedLabels={amendedLabels}
         {...props}
       />

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -90,7 +90,7 @@ export type Props = {
   isDropCapped?: boolean;
   pageId: string;
   minWidth?: 10 | 8;
-  isLanding?: boolean;
+  isLandingPage?: boolean;
   sectionLevelPage?: boolean;
   staticContent?: ReactElement | null;
   comicPreviousNext?: ComicPreviousNextProps;
@@ -128,7 +128,7 @@ export type SliceZoneContext = {
   comicPreviousNext?: ComicPreviousNextProps;
   isShortFilm: boolean;
   pageId: string;
-  isLanding: boolean;
+  isLandingPage: boolean;
   isDropCapped: boolean;
   contentType?: 'short-film' | 'visual-story' | 'standalone-image-gallery';
 };
@@ -140,7 +140,7 @@ export const defaultContext: SliceZoneContext = {
   comicPreviousNext: undefined,
   isShortFilm: false,
   pageId: '',
-  isLanding: false,
+  isLandingPage: false,
   isDropCapped: false,
   contentType: undefined,
 };
@@ -153,7 +153,7 @@ const Body: FunctionComponent<Props> = ({
   isDropCapped,
   pageId,
   minWidth = 8,
-  isLanding = false,
+  isLandingPage = false,
   sectionLevelPage = false,
   staticContent = null,
   comicPreviousNext,
@@ -304,7 +304,7 @@ const Body: FunctionComponent<Props> = ({
       className={`content-type-${contentType}`}
       $splitBackground={isShortFilm}
     >
-      {introText && (
+      {!isLandingPage && introText && introText.length > 0 && (
         <ContaineredLayout gridSizes={gridSize8(!sectionLevelPage)}>
           <div className="body-text spaced-text">
             <Space
@@ -332,7 +332,7 @@ const Body: FunctionComponent<Props> = ({
         </SpacingComponent>
       )}
 
-      {isLanding && <LandingPageSections sections={sections} />}
+      {isLandingPage && <LandingPageSections sections={sections} />}
 
       <SliceZone
         slices={filteredUntransformedBody}
@@ -343,7 +343,7 @@ const Body: FunctionComponent<Props> = ({
           isVisualStory,
           comicPreviousNext,
           pageId,
-          isLanding,
+          isLandingPage,
           isDropCapped,
           contentType,
           isShortFilm,

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -49,9 +49,9 @@ const CollectionsLandingPage: NextPage<PagePageProps> = ({
       hideNewsletterPromo
     >
       <PageHeader
+        isLandingPage
         title={page.title}
-        breadcrumbs={{ items: [], noHomeLink: true }} // TODO
-        Background={<HeaderBackground />}
+        // Background={<HeaderBackground />}
       />
       {page.introText && (
         <ContaineredLayout gridSizes={gridSize8(false)}>

--- a/content/webapp/views/pages/pages/page/index.tsx
+++ b/content/webapp/views/pages/pages/page/index.tsx
@@ -63,13 +63,13 @@ export const PagePage: NextPage<Props> = ({
   jsonLd,
 }) => {
   const DateInfo = page.datePublished && <HTMLDate date={page.datePublished} />;
-  const isLanding = page.format && page.format.id === PageFormatIds.Landing;
+  const isLandingPage = page.format && page.format.id === PageFormatIds.Landing;
   const labels =
-    !isLanding && page.format?.title
+    !isLandingPage && page.format?.title
       ? makeLabels(page.format?.title)
       : undefined;
 
-  const backgroundTexture = isLanding
+  const backgroundTexture = isLandingPage
     ? landingHeaderBackgroundLs
     : headerBackgroundLs;
 
@@ -103,7 +103,7 @@ export const PagePage: NextPage<Props> = ({
   const sectionLevelPage = sectionLevelPages.includes(page.uid);
 
   function getBreadcrumbText(siteSection: string): string {
-    return isLanding
+    return isLandingPage
       ? '\u200b'
       : links.find(link => link.siteSection === siteSection)?.title ||
           siteSection;
@@ -140,13 +140,17 @@ export const PagePage: NextPage<Props> = ({
     featuredMedia && !sectionLevelPage ? (
       <HeaderBackground
         backgroundTexture={backgroundTexture}
-        hasWobblyEdge={!isLanding}
+        hasWobblyEdge={!isLandingPage}
       />
     ) : undefined;
 
   const Header = (
     <PageHeader
-      {...(sectionLevelPage && { sectionLevelPage: true })}
+      {...(sectionLevelPage && {
+        sectionLevelPage: true,
+        isLandingPage: true,
+        introText: page.introText,
+      })}
       {...(!sectionLevelPage && { breadcrumbs })}
       labels={labels}
       title={page.title}
@@ -234,7 +238,7 @@ export const PagePage: NextPage<Props> = ({
             introText={page.introText}
             onThisPage={page.onThisPage}
             showOnThisPage={page.showOnThisPage}
-            isLanding={isLanding}
+            isLandingPage={isLandingPage}
             sectionLevelPage={sectionLevelPage}
             staticContent={staticContent}
           />

--- a/content/webapp/views/pages/stories/index.tsx
+++ b/content/webapp/views/pages/stories/index.tsx
@@ -5,12 +5,10 @@ import { pageDescriptions } from '@weco/common/data/microcopy';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import {
   ContaineredLayout,
   gridSize12,
-  gridSize8,
 } from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
@@ -28,7 +26,6 @@ import { SeriesBasic } from '@weco/content/types/series';
 import { StoriesLanding } from '@weco/content/types/stories-landing';
 import CardGrid from '@weco/content/views/components/CardGrid';
 import FeaturedCard from '@weco/content/views/components/FeaturedCard';
-import FeaturedText from '@weco/content/views/components/FeaturedText';
 import SectionHeader from '@weco/content/views/components/SectionHeader';
 import StoryPromo from '@weco/content/views/components/StoryPromo';
 
@@ -102,20 +99,10 @@ const StoriesPage: NextPage<Props> = ({
         breadcrumbs={getBreadcrumbItems('stories')}
         title="Stories"
         isContentTypeInfoBeforeMedia={false}
-        sectionLevelPage={true}
+        sectionLevelPage
+        isLandingPage
+        introText={introText}
       />
-      {introText && (
-        <ContaineredLayout gridSizes={gridSize8(false)}>
-          <div className="body-text spaced-text">
-            <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
-              <FeaturedText
-                html={introText}
-                htmlSerializer={defaultSerializer}
-              />
-            </Space>
-          </div>
-        </ContaineredLayout>
-      )}
 
       <SpacingSection>
         <ArticlesContainer className="row--has-wobbly-background">


### PR DESCRIPTION
## What does this change?

As part of creating the new headers for the Collections landing I tried to align all landing pages header.

[See Slack conversation for details](https://wellcome.slack.com/archives/CUA669WHH/p1756732718798119?thread_ts=1756728426.908039&cid=CUA669WHH), I will table this for now as I'd also like to pick between either the coded list of landings and the Landing page format.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

