### PR TITLE
CL: Inside our collections

### DIFF
--- a/common/data/microcopy.tsx
+++ b/common/data/microcopy.tsx
@@ -19,6 +19,8 @@ export const pageDescriptions = {
     'Our words and pictures explore the connections between science, medicine, life and art. Dive into one no matter where in the world you are.',
   books:
     'We publish thought-provoking books exploring health and human experiences.',
+  collections:
+    'Over 1.1 million items exploring art, health, culture and what it means to be human',
   events:
     'Our events take place both online and in our building. Choose from an inspiring range of free talks, discussions and more.',
   exhibitionGuides:

--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -1,8 +1,9 @@
 import { NextPage } from 'next';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
+import { PagesDocument as RawPagesDocument } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
-import { useToggles } from '@weco/common/server-data/Context';
+import { serialiseProps } from '@weco/common/utils/json';
 import {
   ContaineredLayout,
   gridSize12,
@@ -14,13 +15,19 @@ import {
   ServerSidePropsOrAppError,
 } from '@weco/common/views/pages/_app';
 import * as page from '@weco/content/pages/pages/[pageId]';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { fetchPage } from '@weco/content/services/prismic/fetch/pages';
+import { getInsideOurCollectionsCards } from '@weco/content/services/prismic/transformers/collections-landing';
+import { transformPage } from '@weco/content/services/prismic/transformers/pages';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
-import CollectionsLandingPage from '@weco/content/views/pages/collections';
+import CollectionsLandingPage, {
+  Props as CollectionsLandingPageProps,
+} from '@weco/content/views/pages/collections';
 
-const Page: NextPage<page.Props> = props => {
-  const { collectionsLanding } = useToggles();
-
-  return collectionsLanding ? (
+const Page: NextPage<
+  page.Props | (CollectionsLandingPageProps & { hasNewPageToggle: true })
+> = props => {
+  return 'hasNewPageToggle' in props ? (
     <CollectionsLandingPage {...props} />
   ) : (
     <page.Page
@@ -36,7 +43,9 @@ const Page: NextPage<page.Props> = props => {
   );
 };
 
-type Props = ServerSideProps<page.Props>;
+type Props = ServerSideProps<
+  page.Props | (CollectionsLandingPageProps & { hasNewPageToggle: true })
+>;
 
 export const getServerSideProps: ServerSidePropsOrAppError<
   Props
@@ -44,7 +53,36 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
+  const client = createClient(context);
   const newCollectionsLanding = serverData.toggles.collectionsLanding.value;
+
+  if (newCollectionsLanding) {
+    const collectionsPagePromise = await fetchPage(
+      client,
+      prismicPageIds.newCollections
+    );
+    const collectionsPage = transformPage(
+      collectionsPagePromise as RawPagesDocument
+    );
+
+    const insideOurCollectionsCards =
+      getInsideOurCollectionsCards(collectionsPage);
+
+    return {
+      props: serialiseProps({
+        hasNewPageToggle: true,
+        pageMeta: {
+          id: collectionsPage.id,
+          image: collectionsPage.promo?.image,
+          description: collectionsPage.promo?.caption,
+        },
+        title: collectionsPage.title,
+        introText: collectionsPage.introText ?? [],
+        insideOurCollectionsCards,
+        serverData,
+      }),
+    };
+  }
 
   return page.getServerSideProps({
     ...context,

--- a/content/webapp/services/prismic/transformers/collections-landing.ts
+++ b/content/webapp/services/prismic/transformers/collections-landing.ts
@@ -1,0 +1,42 @@
+// This is temporary as I believe we'll be fetching everything we need from the Content API
+import linkResolver from '@weco/common/services/prismic/link-resolver';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
+import { transformContentListSlice } from '@weco/content/services/prismic/transformers/body';
+import { isContentList } from '@weco/content/types/body';
+import { MultiContent } from '@weco/content/types/multi-content';
+import { Page as PageType } from '@weco/content/types/pages';
+
+/** The Collections page in Prismic includes a content list which is used to pick
+ * items for the 'Inside our collections' promo section.
+ */
+
+export function getInsideOurCollectionsCards(
+  collectionsLanding: PageType
+): MultiContent[] {
+  const contentLists = collectionsLanding.untransformedBody
+    .filter(isContentList)
+    .map(transformContentListSlice);
+
+  return contentLists
+    .filter(slice => slice.value.title === 'Inside our collections')
+    .flatMap(slice => slice.value.items)
+    .map(item => {
+      return item.type === 'articles'
+        ? {
+            type: 'articles' as const,
+            id: item.id,
+            uid: item.uid,
+            url: linkResolver(item),
+            title: item.title,
+            image: item.promo?.image,
+            promo: item.promo,
+            description: item.promo?.caption,
+            series: item.series ?? [],
+            datePublished: item.datePublished,
+            labels: item.labels ?? [],
+            hasLinkedWorks: item.hasLinkedWorks ?? false,
+          }
+        : undefined;
+    })
+    .filter(isNotUndefined);
+}

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -1,39 +1,76 @@
+import * as prismic from '@prismicio/client';
 import { NextPage } from 'next';
 
-import { SiteSection } from '@weco/common/model/site-section';
+import { pageDescriptions } from '@weco/common/data/microcopy';
+import { ImageType } from '@weco/common/model/image';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader';
+import Space from '@weco/common/views/components/styled/Space';
 import PageLayout from '@weco/common/views/layouts/PageLayout';
-import { Props as PagePageProps } from '@weco/content/views/pages/pages/page';
+import { MultiContent } from '@weco/content/types/multi-content';
+import CardGrid from '@weco/content/views/components/CardGrid';
+import SectionHeader from '@weco/content/views/components/SectionHeader';
 
-const CollectionsLandingPage: NextPage<PagePageProps> = ({
-  page,
-  // siblings,
-  // children,
-  // ordersInParents,
-  // staticContent,
-  jsonLd,
+export type Props = {
+  pageMeta: {
+    id: string;
+    image?: ImageType;
+    description?: string;
+  };
+  title: string;
+  introText: prismic.RichTextField;
+  insideOurCollectionsCards: MultiContent[];
+  // jsonLd: JsonLdObj[]; ??
+};
+
+const CollectionsLandingPage: NextPage<Props> = ({
+  pageMeta,
+  title,
+  introText,
+  insideOurCollectionsCards,
 }) => {
   return (
     <PageLayout
-      title={page.title}
-      description={page.metadataDescription || page.promo?.caption || ''}
-      url={{
-        pathname: `${page?.siteSection ? '/' + page.siteSection : ''}/${page.uid}`,
-      }}
-      jsonLd={jsonLd}
+      title="Collections"
+      description={pageMeta.description || pageDescriptions.collections}
+      url={{ pathname: '/collections' }}
+      jsonLd={[]} // TODO?
       openGraphType="website"
-      siteSection={page?.siteSection as SiteSection}
-      image={page.image}
-      apiToolbarLinks={[createPrismicLink(page.id)]}
+      siteSection="collections"
+      image={pageMeta.image}
+      apiToolbarLinks={[createPrismicLink(pageMeta.id)]}
       isNoIndex // TODO remove when this becomes the page
       hideNewsletterPromo
     >
-      <PageHeader
-        variant="simpleLanding"
-        title={page.title}
-        introText={page.introText}
-      />
+      <PageHeader variant="simpleLanding" title={title} introText={introText} />
+
+      <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <SectionHeader title="Inside our collections" gridSize={gridSize12()} />
+        <ContaineredLayout gridSizes={gridSize12()}>
+          <p>
+            Explore stories inspired by the objects, manuscripts and archives in
+            our collection
+          </p>
+        </ContaineredLayout>
+
+        <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <CardGrid
+            items={insideOurCollectionsCards}
+            itemsPerRow={3}
+            itemsHaveTransparentBackground
+            links={[
+              {
+                text: 'Read all stories',
+                url: '/series/inside-our-collections',
+              },
+            ]}
+          />
+        </Space>
+      </Space>
     </PageLayout>
   );
 };


### PR DESCRIPTION
## What does this change?

#12219

- Tweaks the new collections landing page to get more curated content from the server queries (more like our What's On page - the other page that's half coded/half coming from Prismic)
- I hard coded the "Inside our collections" block, similarly to "Latest stories" on the homepage, with the actual cards coming from Prismic. I do not love it, it looks like the CardGrid needs to get adjusted when it's fed by Prismic as all the images have a different height?

<img width="1098" height="700" alt="Screenshot 2025-09-02 at 16 34 04" src="https://github.com/user-attachments/assets/d7535e31-39ee-46b4-9f76-46b98c6dc53e" />


I won't close the ticket when this gets deployed. I still want to:
- Fix the image ratio on the cards
- Add the format so it displays? Although it's not in the mockup so it's probably good without.
- Tidy up the helper; we won't be fetching from Content API but really from Prismic, so make it better and remove the comment saying otherwise.

As I'm leaving for a week and it's behind a toggle, I would rather we merge this than wait until my return to do the above.

## How to test

Run locally, ensure that Collections looks fine without the toggle
With the toggle on, it should
- Have valid meta data
- Have the Inside Our collections block

## How can we measure success?

It's recognisable and reusable

## Have we considered potential risks?
N/A