### PR TITLE
Add prop to allow ScrollButtons to optionally appear after content

### DIFF
--- a/cardigan/stories/components/CatalogueImageGallery/CatalogueImageGallery.stories.tsx
+++ b/cardigan/stories/components/CatalogueImageGallery/CatalogueImageGallery.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta = {
     variant: 'scrollable',
     label: 'Hello there, this is some text',
     imageCount: 10,
+    scrollButtonsAfter: false,
   },
   argTypes: {
     imageCount: {
@@ -22,6 +23,10 @@ const meta: Meta = {
     variant: {
       control: 'select',
       options: ['scrollable', 'justified'],
+    },
+    scrollButtonsAfter: {
+      control: 'boolean',
+      if: { arg: 'variant', eq: 'scrollable' },
     },
     images: {
       table: {

--- a/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.tsx
+++ b/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.tsx
@@ -12,16 +12,23 @@ const IMAGE_HEIGHT = 200;
 export type Props = {
   images: Image[];
   label?: string;
+  scrollButtonsAfter?: boolean;
 };
 
 const CatalogueImageGalleryScrollable: FunctionComponent<Props> = ({
   images,
   label,
+  scrollButtonsAfter,
 }: Props) => {
   const [, setExpandedImage] = useExpandedImage(images);
 
   return (
-    <ScrollContainer label={label} hasDarkBackground hasLeftOffset>
+    <ScrollContainer
+      label={label}
+      hasDarkBackground
+      hasLeftOffset
+      scrollButtonsAfter={scrollButtonsAfter}
+    >
       {images.map((image, index) => (
         <li key={image.id} style={{ maxWidth: '90vw' }}>
           <Space $h={{ size: 'm', properties: ['margin-right'] }}>

--- a/content/webapp/views/components/CatalogueImageGallery/index.tsx
+++ b/content/webapp/views/components/CatalogueImageGallery/index.tsx
@@ -9,7 +9,10 @@ import CatalogueImageGalleryScrollable, {
 
 type Props =
   | (CatalogueImageGalleryJustifiedProps & { variant: 'justified' })
-  | (CatalogueImageGalleryScrollableProps & { variant: 'scrollable' });
+  | (CatalogueImageGalleryScrollableProps & {
+      variant: 'scrollable';
+      scrollButtonsAfter?: boolean;
+    });
 
 const CatalogueImageGallery: FunctionComponent<Props> = props => {
   const { variant } = props;

--- a/content/webapp/views/components/ScrollContainer/index.tsx
+++ b/content/webapp/views/components/ScrollContainer/index.tsx
@@ -12,10 +12,11 @@ import ScrollableNavigation from './ScrollContainer.Navigation';
 
 const ScrollButtonsContainer = styled(Space).attrs({
   $v: { size: 'm', properties: ['margin-bottom'] },
-})`
+})<{ $hasLabel?: boolean }>`
   display: flex;
-  justify-content: space-between;
+  justify-content: ${props => (props.$hasLabel ? 'space-between' : 'flex-end')};
   gap: ${props => props.theme.spacingUnits['3']}px;
+  align-items: center;
 `;
 
 const Label = styled(Space).attrs({
@@ -37,6 +38,7 @@ type Props = PropsWithChildren<{
   hasDarkBackground?: boolean;
   gridSizes?: SizeMap;
   hasLeftOffset?: boolean;
+  scrollButtonsAfter?: boolean;
 }>;
 
 const ScrollContainer: FunctionComponent<Props> = ({
@@ -44,34 +46,37 @@ const ScrollContainer: FunctionComponent<Props> = ({
   hasDarkBackground,
   gridSizes,
   hasLeftOffset,
+  scrollButtonsAfter = false,
   children,
 }) => {
   const scrollContainerRef = useRef<HTMLUListElement>(null);
 
+  const scrollButtons = (
+    <ConditionalWrapper
+      condition={!!gridSizes}
+      wrapper={children => (
+        <ContaineredLayout gridSizes={gridSizes as SizeMap}>
+          {children}
+        </ContaineredLayout>
+      )}
+    >
+      <ScrollButtonsContainer $hasLabel={!!label}>
+        {label && <Label $hasDarkBackground={hasDarkBackground}>{label}</Label>}
+
+        <ScrollableNavigation
+          containerRef={scrollContainerRef}
+          hasDarkBackground={hasDarkBackground}
+          hasLeftOffset={hasLeftOffset}
+        />
+      </ScrollButtonsContainer>
+    </ConditionalWrapper>
+  );
+
   return (
     <div data-component="scroll-container">
-      <ConditionalWrapper
-        condition={!!gridSizes}
-        wrapper={children => (
-          <ContaineredLayout gridSizes={gridSizes as SizeMap}>
-            {children}
-          </ContaineredLayout>
-        )}
-      >
-        <ScrollButtonsContainer>
-          {label && (
-            <Label $hasDarkBackground={hasDarkBackground}>{label}</Label>
-          )}
-
-          <ScrollableNavigation
-            containerRef={scrollContainerRef}
-            hasDarkBackground={hasDarkBackground}
-            hasLeftOffset={hasLeftOffset}
-          />
-        </ScrollButtonsContainer>
-      </ConditionalWrapper>
-
+      {!scrollButtonsAfter && scrollButtons}
       <ContentContainer ref={scrollContainerRef}>{children}</ContentContainer>
+      {scrollButtonsAfter && scrollButtons}
     </div>
   );
 };


### PR DESCRIPTION
For #12239 

## What does this change?
It adds a prop to allow the pagination controls for the ScrollContainer to appear above or below the scrolling content

__above__
<img width="1064" height="300" alt="image" src="https://github.com/user-attachments/assets/0b0d466c-bd5b-405c-b14d-33a69d8f0daa" />

__below__
<img width="1076" height="329" alt="image" src="https://github.com/user-attachments/assets/c31b3db5-4f93-4e4e-a2b9-231463a25ffb" />


## How to test
View the [CatalogueImageGallery story in Cardigan](http://localhost:9001/?path=/story/components-catalogueimagegallery--basic) and check the `scrollButtonsAfter` toggle does what you'd expect

## How can we measure success?
We can reuse the component

## Have we considered potential risks?
Can't think of any

