### PR TITLE
Move Grid into Container so grid sizes are realistic in Cardigan

### DIFF
--- a/cardigan/.storybook/preview.js
+++ b/cardigan/.storybook/preview.js
@@ -4,6 +4,7 @@ import { ContextDecorator } from '@weco/cardigan/config/decorators';
 import { AppContextProvider } from '@weco/common/contexts/AppContext';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import GlobalSvgDefinitions from '@weco/common/views/components/GlobalSvgDefinitions';
+import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import theme from '@weco/common/views/themes/default';
 
@@ -18,11 +19,13 @@ export const decorators = [
           <ConditionalWrapper
             condition={context?.parameters?.gridSizes}
             wrapper={children => (
-              <Grid>
-                <GridCell $sizeMap={context.parameters.gridSizes}>
-                  {children}
-                </GridCell>
-              </Grid>
+              <Container>
+                <Grid>
+                  <GridCell $sizeMap={context.parameters.gridSizes}>
+                    {children}
+                  </GridCell>
+                </Grid>
+              </Container>
             )}
           >
             <Story {...context} />


### PR DESCRIPTION
## What does this change?
Puts the `Grid` inside a `Container` when it is used in Cardigan, so that the grid can't continue growing wider than the max-width of the site. This ensures stories that use `gridSizes` will give a more accurate depiction of the size of the component contained within.

