### PR TITLE
Types of materials

### DIFF
--- a/content/webapp/hooks/useCollectionStats.ts
+++ b/content/webapp/hooks/useCollectionStats.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+import {
+  CollectionStats,
+  createDefaultCollectionStats,
+  fetchCollectionStats,
+} from '@weco/content/services/wellcome/catalogue/workTypeAggregations';
+
+export type UseCollectionStatsReturn = {
+  data: CollectionStats;
+  loading: boolean;
+  error: string | null;
+};
+
+/**
+ * Provides collection stats from work type aggregations and images
+ */
+export function useCollectionStats(): UseCollectionStatsReturn {
+  const [data, setData] = useState<CollectionStats>(
+    createDefaultCollectionStats()
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const stats = await fetchCollectionStats();
+
+        if (isMounted) {
+          setData(stats);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : 'An unknown error occurred while fetching collection statistics'
+          );
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/content/webapp/services/wellcome/catalogue/workTypeAggregations.test.ts
+++ b/content/webapp/services/wellcome/catalogue/workTypeAggregations.test.ts
@@ -1,0 +1,218 @@
+import { WellcomeAggregation } from '@weco/content/services/wellcome';
+
+import {
+  createDefaultCollectionStats,
+  fetchImagesCount,
+  fetchWorksAggregations,
+  transformWorkTypeAggregations,
+} from './workTypeAggregations';
+
+// Mock types for test responses
+type MockResponse = {
+  ok: boolean;
+  json: jest.Mock;
+  statusText?: string;
+};
+
+// Mock fetch globally
+global.fetch = jest.fn();
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+describe('workTypeAggregations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('transformWorkTypeAggregations', () => {
+    it('should transform work type aggregations correctly', () => {
+      const mockAggregation = {
+        buckets: [
+          {
+            data: { id: 'a', label: 'Books' },
+            count: 100000,
+            type: 'AggregationBucket' as const,
+          },
+          {
+            data: { id: 'd', label: 'Journals' },
+            count: 2000,
+            type: 'AggregationBucket' as const,
+          },
+          {
+            data: {
+              id: 'h',
+              label: 'Archives and manuscripts',
+            },
+            count: 15000,
+            type: 'AggregationBucket' as const,
+          },
+          {
+            data: { id: 'g', label: 'Videos' },
+            count: 1000,
+            type: 'AggregationBucket' as const,
+          },
+          {
+            data: { id: 'l', label: 'Ephemera' },
+            count: 3000,
+            type: 'AggregationBucket' as const,
+          },
+        ],
+        type: 'Aggregation' as const,
+      } as WellcomeAggregation;
+
+      const collectionStats = createDefaultCollectionStats();
+      const result = transformWorkTypeAggregations(
+        mockAggregation,
+        collectionStats
+      );
+
+      expect(result).toEqual({
+        booksAndJournals: {
+          id: 'books-journals',
+          label: 'Books and Journals',
+          count: 102000, // 100000 + 2000
+        },
+        archivesAndManuscripts: {
+          id: 'archives-manuscripts',
+          label: 'Archives and manuscripts',
+          count: 15000,
+        },
+        audioAndVideo: {
+          id: 'audio-video',
+          label: 'Audio and video',
+          count: 1000,
+        },
+        ephemera: {
+          id: 'ephemera',
+          label: 'Ephemera',
+          count: 3000,
+        },
+        images: {
+          id: 'images',
+          label: 'Images',
+          count: 0,
+        },
+      });
+    });
+
+    it('should handle empty aggregations', () => {
+      const mockAggregation = {
+        buckets: [],
+        type: 'Aggregation' as const,
+      };
+
+      const collectionStats = createDefaultCollectionStats();
+      const result = transformWorkTypeAggregations(
+        mockAggregation,
+        collectionStats
+      );
+
+      expect(result).toEqual({
+        booksAndJournals: {
+          id: 'books-journals',
+          label: 'Books and Journals',
+          count: 0,
+        },
+        archivesAndManuscripts: {
+          id: 'archives-manuscripts',
+          label: 'Archives and manuscripts',
+          count: 0,
+        },
+        audioAndVideo: {
+          id: 'audio-video',
+          label: 'Audio and video',
+          count: 0,
+        },
+        ephemera: {
+          id: 'ephemera',
+          label: 'Ephemera',
+          count: 0,
+        },
+        images: {
+          id: 'images',
+          label: 'Images',
+          count: 0,
+        },
+      });
+    });
+  });
+
+  describe('fetchImagesCount', () => {
+    it('should fetch images count successfully', async () => {
+      const mockResponse: MockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          totalResults: 3800000,
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await fetchImagesCount();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.wellcomecollection.org/catalogue/v2/images?pageSize=1'
+      );
+      expect(result).toBe(3800000);
+    });
+
+    it('should return fallback count on API error', async () => {
+      const mockResponse: MockResponse = {
+        ok: false,
+        statusText: 'Internal Server Error',
+        json: jest.fn(),
+      };
+      mockFetch.mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await fetchImagesCount();
+
+      expect(result).toBe(120000);
+    });
+
+    it('should return fallback count on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const result = await fetchImagesCount();
+
+      expect(result).toBe(120000);
+    });
+  });
+
+  describe('fetchWorksAggregations', () => {
+    it('should fetch collection stats successfully', async () => {
+      const mockWorksResponse: MockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          aggregations: {
+            workType: {
+              buckets: [
+                { data: { id: 'a', label: 'Books' }, count: 1000000 },
+                { data: { id: 'd', label: 'Journals' }, count: 20000 },
+              ],
+            },
+          },
+        }),
+      };
+
+      mockFetch.mockResolvedValueOnce(mockWorksResponse as unknown as Response);
+
+      const result = await fetchWorksAggregations();
+
+      expect(result).toBeTruthy();
+      expect(result?.buckets).toHaveLength(2);
+      expect(result?.buckets[0].data.id).toBe('a');
+      expect(result?.buckets[0].count).toBe(1000000);
+    });
+
+    it('should return null on API error', async () => {
+      const mockResponse: MockResponse = {
+        ok: false,
+        statusText: 'Internal Server Error',
+        json: jest.fn(),
+      };
+      mockFetch.mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await fetchWorksAggregations();
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/content/webapp/services/wellcome/catalogue/workTypeAggregations.ts
+++ b/content/webapp/services/wellcome/catalogue/workTypeAggregations.ts
@@ -1,0 +1,163 @@
+import { WellcomeAggregation } from '@weco/content/services/wellcome';
+
+export type WorkTypeStats = {
+  id: string;
+  label: string;
+  count: number | null;
+};
+
+export type CollectionStats = {
+  booksAndJournals: WorkTypeStats;
+  images: WorkTypeStats;
+  archivesAndManuscripts: WorkTypeStats;
+  audioAndVideo: WorkTypeStats;
+  ephemera: WorkTypeStats;
+};
+
+// Mapping catalogue work type IDs to grouped categories
+const WORK_TYPE_MAPPINGS = {
+  a: 'booksAndJournals', // Books
+  d: 'booksAndJournals', // Journals
+
+  h: 'archivesAndManuscripts', // Archives and manuscripts
+  b: 'archivesAndManuscripts', // Manuscripts
+  hdig: 'archivesAndManuscripts', // Born-digital archives
+
+  g: 'audioAndVideo', // Videos
+  i: 'audioAndVideo', // Audio
+  n: 'audioAndVideo', // Film
+  c: 'audioAndVideo', // Music
+
+  l: 'ephemera', // Ephemera
+} as const;
+
+export function createDefaultCollectionStats(): CollectionStats {
+  return {
+    booksAndJournals: {
+      id: 'books-journals',
+      label: 'Books and Journals',
+      count: null,
+    },
+    images: { id: 'images', label: 'Images', count: null },
+    archivesAndManuscripts: {
+      id: 'archives-manuscripts',
+      label: 'Archives and manuscripts',
+      count: null,
+    },
+    audioAndVideo: { id: 'audio-video', label: 'Audio and video', count: null },
+    ephemera: { id: 'ephemera', label: 'Ephemera', count: null },
+  };
+}
+
+/**
+ * Transforms workType aggregations from the catalogue API into grouped collection statistics
+ */
+export function transformWorkTypeAggregations(
+  workTypeAggregation: WellcomeAggregation,
+  collectionStats: CollectionStats
+): CollectionStats {
+  // Initialize counts to 0 for aggregation (we're processing real data)
+  collectionStats.booksAndJournals.count = 0;
+  collectionStats.archivesAndManuscripts.count = 0;
+  collectionStats.audioAndVideo.count = 0;
+  collectionStats.ephemera.count = 0;
+  collectionStats.images.count = 0;
+
+  // Sum up counts for each category
+  workTypeAggregation.buckets.forEach(bucket => {
+    const workTypeId = bucket.data.id;
+    const category =
+      WORK_TYPE_MAPPINGS[workTypeId as keyof typeof WORK_TYPE_MAPPINGS];
+
+    if (category) {
+      const currentCount = collectionStats[category].count || 0;
+      collectionStats[category].count = currentCount + bucket.count;
+    }
+  });
+
+  return collectionStats;
+}
+
+export async function fetchWorksAggregations(): Promise<WellcomeAggregation | null> {
+  try {
+    const response = await fetch(
+      'https://api.wellcomecollection.org/catalogue/v2/works?pageSize=1&aggregations=workType'
+    );
+
+    if (!response.ok) {
+      console.error(
+        'Failed to fetch work type aggregations:',
+        response.statusText
+      );
+      return null;
+    }
+
+    const worksData = await response.json();
+
+    if (!worksData.aggregations?.workType) {
+      console.error('No workType aggregations found in response');
+      return null;
+    }
+
+    return worksData.aggregations.workType;
+  } catch (error) {
+    console.error('Error fetching work type aggregations:', error);
+    return null;
+  }
+}
+
+export async function fetchImagesCount(): Promise<number> {
+  const fallbackCount = 120000; // Fallback estimate if API fails
+  try {
+    const response = await fetch(
+      'https://api.wellcomecollection.org/catalogue/v2/images?pageSize=1'
+    );
+
+    if (!response.ok) {
+      console.error('Failed to fetch images count:', response.statusText);
+      return fallbackCount;
+    }
+
+    const data = await response.json();
+    return data.totalResults || fallbackCount;
+  } catch (error) {
+    console.error('Error fetching images count:', error);
+    return fallbackCount;
+  }
+}
+
+export async function fetchCollectionStats(): Promise<CollectionStats> {
+  const collectionStats = createDefaultCollectionStats();
+
+  try {
+    const [worksResult, imagesResult] = await Promise.allSettled([
+      fetchWorksAggregations(),
+      fetchImagesCount(),
+    ]);
+
+    if (worksResult.status === 'fulfilled' && worksResult.value !== null) {
+      const worksAggregation = worksResult.value;
+      transformWorkTypeAggregations(worksAggregation, collectionStats);
+    } else {
+      console.error(
+        'Failed to fetch work type aggregations, using default counts'
+      );
+    }
+
+    // Only update images count if works data is available
+    // It would be odd to show just the images count
+    if (worksResult.status === 'fulfilled' && worksResult.value !== null) {
+      // Works succeeded, so show images count (fetchImagesCount already handles fallback)
+      if (imagesResult.status === 'fulfilled') {
+        collectionStats.images.count = imagesResult.value;
+      }
+    }
+    // If works failed, images.count stays null (no number displayed)
+
+    return collectionStats;
+  } catch (error) {
+    console.error('Error fetching collection statistics:', error);
+    // If error occurs, show labels with no counts
+    return collectionStats;
+  }
+}

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -34,7 +34,7 @@ const CollectionsLandingPage: NextPage<Props> = ({
   introText,
   insideOurCollectionsCards,
 }) => {
-  const { data: collectionStats, loading, error } = useCollectionStats();
+  const { data: collectionStats, loading } = useCollectionStats();
 
   return (
     <PageLayout
@@ -76,11 +76,12 @@ const CollectionsLandingPage: NextPage<Props> = ({
       </Space>
 
       <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
-        <SectionHeader title="Types of materials" gridSize={gridSize12()} />
+        <SectionHeader
+          title="Types of materials in the collections"
+          gridSize={gridSize12()}
+        />
         <ContaineredLayout gridSizes={gridSize12()}>
-          {error && <p>Error loading collection statistics: {error}</p>}
           <div>
-            <h3>Types of materials in the collections</h3>
             <ul>
               <li>
                 {(loading ||

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -11,6 +11,7 @@ import {
 import PageHeader from '@weco/common/views/components/PageHeader';
 import Space from '@weco/common/views/components/styled/Space';
 import PageLayout from '@weco/common/views/layouts/PageLayout';
+import { useCollectionStats } from '@weco/content/hooks/useCollectionStats';
 import { MultiContent } from '@weco/content/types/multi-content';
 import CardGrid from '@weco/content/views/components/CardGrid';
 import SectionHeader from '@weco/content/views/components/SectionHeader';
@@ -33,6 +34,8 @@ const CollectionsLandingPage: NextPage<Props> = ({
   introText,
   insideOurCollectionsCards,
 }) => {
+  const { data: collectionStats, loading, error } = useCollectionStats();
+
   return (
     <PageLayout
       title="Collections"
@@ -70,6 +73,82 @@ const CollectionsLandingPage: NextPage<Props> = ({
             ]}
           />
         </Space>
+      </Space>
+
+      <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
+        <SectionHeader title="Types of materials" gridSize={gridSize12()} />
+        <ContaineredLayout gridSizes={gridSize12()}>
+          {error && <p>Error loading collection statistics: {error}</p>}
+          <div>
+            <h3>Types of materials in the collections</h3>
+            <ul>
+              <li>
+                {(loading ||
+                  collectionStats.booksAndJournals.count !== null) && (
+                  <div>
+                    <strong>
+                      {loading
+                        ? '...'
+                        : collectionStats.booksAndJournals.count!.toLocaleString()}
+                    </strong>
+                  </div>
+                )}
+                <div>{collectionStats.booksAndJournals.label}</div>
+              </li>
+              <li>
+                {(loading || collectionStats.images.count !== null) && (
+                  <div>
+                    <strong>
+                      {loading
+                        ? '...'
+                        : collectionStats.images.count === 120000
+                          ? '120,000+'
+                          : collectionStats.images.count!.toLocaleString()}
+                    </strong>
+                  </div>
+                )}
+                <div>{collectionStats.images.label}</div>
+              </li>
+              <li>
+                {(loading ||
+                  collectionStats.archivesAndManuscripts.count !== null) && (
+                  <div>
+                    <strong>
+                      {loading
+                        ? '...'
+                        : collectionStats.archivesAndManuscripts.count!.toLocaleString()}
+                    </strong>
+                  </div>
+                )}
+                <div>{collectionStats.archivesAndManuscripts.label}</div>
+              </li>
+              <li>
+                {(loading || collectionStats.audioAndVideo.count !== null) && (
+                  <div>
+                    <strong>
+                      {loading
+                        ? '...'
+                        : collectionStats.audioAndVideo.count!.toLocaleString()}
+                    </strong>
+                  </div>
+                )}
+                <div>{collectionStats.audioAndVideo.label}</div>
+              </li>
+              <li>
+                {(loading || collectionStats.ephemera.count !== null) && (
+                  <div>
+                    <strong>
+                      {loading
+                        ? '...'
+                        : collectionStats.ephemera.count!.toLocaleString()}
+                    </strong>
+                  </div>
+                )}
+                <div>{collectionStats.ephemera.label}</div>
+              </li>
+            </ul>
+          </div>
+        </ContaineredLayout>
       </Space>
     </PageLayout>
   );


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/wellcomecollection.org/issues/12220

This PR fetches the collections data and displays the number of things we have in each grouping on the collections landing page. **N.B. Making a component to display the data with proper styling etc. is to come in another PR.**

- Makes 2 clientside calls to the catalogue api to retrieve the data we need to display the counts in each grouping (1 for images, 1 for the rest of the groups, e.g. Books and Journals)
- The component will display the groups initially and then once the data is retrieved will update with the counts for each.
- If the images request fails we fall back to an estimate for this one.
- If both requests or the work type aggregations request fails, then we don't display any counts. Having just the images would be odd. (We could fall back to estimates for all the groups...thoughts?)

Both requests successful:
<img width="546" height="415" alt="Screenshot 2025-09-09 at 13 54 19" src="https://github.com/user-attachments/assets/a6481893-f401-4a56-a8e7-128031368ec5" />

Image request fails:
<img width="515" height="412" alt="Screenshot 2025-09-09 at 13 54 05" src="https://github.com/user-attachments/assets/1570187f-70d8-4fcd-8ed3-995d36be95cd" />

Works aggregations or both requests fail:
<img width="493" height="271" alt="Screenshot 2025-09-09 at 13 54 44" src="https://github.com/user-attachments/assets/357ea561-dcc6-49ce-ac87-f0a8cafc7b64" />

## How to test
- enable the collectionsLanding toggle
- visit [Collections Landing page](https://www-dev.wellcomecollection.org/collections)
- scroll to the bottom of the page and see the types of things we have with the counts displayed above them

## How can we measure success?

We're half way to fulfilling [the issue](https://github.com/wellcomecollection/wellcomecollection.org/issues/12220)

## Have we considered potential risks?

This is behind a toggle, so none really
Adding the counts as a client side enhancement, mitigates performance issues

