### PR TITLE
Move YellowBox above title

### DIFF
--- a/content/webapp/views/components/SectionHeader/index.tsx
+++ b/content/webapp/views/components/SectionHeader/index.tsx
@@ -12,7 +12,7 @@ import { SizeMap } from '@weco/common/views/components/styled/Grid';
 const YellowBox = styled.div`
   display: block;
   width: 60px;
-  height: 18px;
+  height: 16px;
   background: ${props => props.theme.color('yellow')};
 
   ${props => props.theme.media('medium')`
@@ -21,7 +21,6 @@ const YellowBox = styled.div`
 
   ${props => props.theme.media('large')`
     width: 64px;
-    height: 19px;
   `}
 `;
 

--- a/content/webapp/views/components/SectionHeader/index.tsx
+++ b/content/webapp/views/components/SectionHeader/index.tsx
@@ -8,10 +8,9 @@ import {
   gridSize12,
 } from '@weco/common/views/components/Layout';
 import { SizeMap } from '@weco/common/views/components/styled/Grid';
-import Space from '@weco/common/views/components/styled/Space';
 
 const YellowBox = styled.div`
-  display: inline-block;
+  display: block;
   width: 60px;
   height: 18px;
   background: ${props => props.theme.color('yellow')};
@@ -26,13 +25,7 @@ const YellowBox = styled.div`
   `}
 `;
 
-const TitleWrapper = styled(Space).attrs({
-  $h: { size: 's', properties: ['margin-left'] },
-})`
-  display: inline;
-`;
-
-const Title = styled.span`
+const Title = styled.h2`
   .bg-dark & {
     color: ${props => props.theme.color('white')};
   }
@@ -54,10 +47,10 @@ const SectionHeader: FunctionComponent<Props> = ({ title, gridSize }) => {
           </ContaineredLayout>
         )}
       >
-        <YellowBox />
-        <TitleWrapper as="h2">
+        <div>
+          <YellowBox />
           <Title>{title}</Title>
-        </TitleWrapper>
+        </div>
       </ConditionalWrapper>
     </div>
   );


### PR DESCRIPTION
For #12242 

## What does this change?
Moves the Yellow bar of the `SectionHeader` above the title, instead of running it alongside.

## How to test
- View [the component in Cardigan](http://localhost:9001/?path=/story/components-sectionheader--basic&args=title:Browse%20by%20theme) and check it matches the design

## How can we measure success?
Easier to read

## Have we considered potential risks?
Can't think of any