### PR TITLE
Search box 2

### DIFF
--- a/common/views/components/Buttons/Buttons.Solid.tsx
+++ b/common/views/components/Buttons/Buttons.Solid.tsx
@@ -66,6 +66,7 @@ const Button: ForwardRefRenderFunction<HTMLButtonElement, ButtonSolidProps> = (
       $isPill={isPill}
       $hasIcon={!!icon}
       $isIconAfter={isIconAfter}
+      $isNewSearchBar={isNewSearchBar}
     >
       <BaseButtonInner
         $isNewSearchBar={isNewSearchBar}

--- a/common/views/components/Buttons/Buttons.styles.tsx
+++ b/common/views/components/Buttons/Buttons.styles.tsx
@@ -71,7 +71,7 @@ export const BasicButton = styled.button.attrs<{
 // Default to medium button
 const getPadding = (size: ButtonSize = 'medium', isNewSearchBar?: boolean) => {
   if (isNewSearchBar) {
-    return '13px 14px';
+    return '13px 16px';
   }
   switch (size) {
     case 'small':

--- a/common/views/components/SearchBar/index.tsx
+++ b/common/views/components/SearchBar/index.tsx
@@ -7,12 +7,9 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
-import { useToggles } from '@weco/common/server-data/Context';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import TextInput from '@weco/common/views/components/TextInput';
 import { themeValues } from '@weco/common/views/themes/config';
-
-import SearchBarNew from './new';
 
 const Container = styled.div`
   display: flex;
@@ -43,7 +40,6 @@ type Props = {
   form: string;
   inputRef?: RefObject<HTMLInputElement | null>;
   location: ValidLocations;
-  showTypewriter?: boolean;
 };
 
 export type ValidLocations = 'header' | 'search' | 'page';
@@ -55,22 +51,10 @@ const SearchBar: FunctionComponent<Props> = ({
   form,
   inputRef,
   location,
-  showTypewriter,
 }) => {
-  const { newSearchBar } = useToggles();
   const defaultInputRef = useRef<HTMLInputElement>(null);
 
-  return newSearchBar ? (
-    <SearchBarNew
-      inputValue={inputValue}
-      setInputValue={setInputValue}
-      placeholder={placeholder}
-      form={form}
-      inputRef={inputRef}
-      location={location}
-      showTypewriter={showTypewriter}
-    />
-  ) : (
+  return (
     <Container data-component="search-bar" className="is-hidden-print">
       <SearchInputWrapper>
         <TextInput
@@ -91,7 +75,7 @@ const SearchBar: FunctionComponent<Props> = ({
           text="Search"
           type={ButtonTypes.submit}
           form={form}
-          colors={themeValues.buttonColors.yellowYellowBlack}
+          colors={themeValues.buttonColors.greenGreenWhite}
         />
       </SearchButtonWrapper>
     </Container>

--- a/common/views/components/SearchBar/index.tsx
+++ b/common/views/components/SearchBar/index.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
+import { useToggles } from '@weco/common/server-data/Context';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import TextInput from '@weco/common/views/components/TextInput';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -53,6 +54,11 @@ const SearchBar: FunctionComponent<Props> = ({
   location,
 }) => {
   const defaultInputRef = useRef<HTMLInputElement>(null);
+  const { collectionsLanding } = useToggles();
+
+  const buttonColors = collectionsLanding
+    ? themeValues.buttonColors.greenGreenWhite
+    : themeValues.buttonColors.yellowYellowBlack;
 
   return (
     <Container data-component="search-bar" className="is-hidden-print">
@@ -75,7 +81,7 @@ const SearchBar: FunctionComponent<Props> = ({
           text="Search"
           type={ButtonTypes.submit}
           form={form}
-          colors={themeValues.buttonColors.greenGreenWhite}
+          colors={buttonColors}
         />
       </SearchButtonWrapper>
     </Container>

--- a/common/views/components/SearchBar/new.tsx
+++ b/common/views/components/SearchBar/new.tsx
@@ -12,7 +12,6 @@ import Typed from 'typed.js';
 import { search } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
-import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import TextInput from '@weco/common/views/components/TextInput';
 import { themeValues } from '@weco/common/views/themes/config';
 import { visuallyHiddenStyles } from '@weco/common/views/themes/utility-classes';
@@ -113,7 +112,6 @@ type Props = {
   form: string;
   inputRef?: RefObject<HTMLInputElement | null>;
   location: ValidLocations;
-  showTypewriter?: boolean;
 };
 
 export type ValidLocations = 'header' | 'search' | 'page';
@@ -125,7 +123,6 @@ const SearchBar: FunctionComponent<Props> = ({
   form,
   inputRef,
   location,
-  showTypewriter,
 }) => {
   const defaultInputRef = useRef<HTMLInputElement>(null);
   const typewriterRef = useRef<HTMLDivElement>(null);
@@ -175,39 +172,35 @@ const SearchBar: FunctionComponent<Props> = ({
   }, [typewriterRef.current]);
 
   return (
-    <Grid>
-      <GridCell $sizeMap={{ s: [12], m: [10], l: [10], xl: [10] }}>
-        <Container data-component="search-bar" className="is-hidden-print">
-          <SearchInputWrapper>
-            {showTypewriter && <Typewriter ref={typewriterRef} />}
-            <TextInput
-              id={`${location}-searchbar`}
-              label={placeholder}
-              name="query"
-              type="search"
-              value={inputValue}
-              setValue={setInputValue}
-              ref={inputRef || defaultInputRef}
-              form={form}
-              hasClearButton
-              isNewSearchBar={true}
-              placeholder=" " // This empty placeholder is required for the :placeholder-shown CSS selector to work
-            />
-          </SearchInputWrapper>
-          <SearchButtonWrapper>
-            <Button
-              variant="ButtonSolid"
-              text="Search"
-              type={ButtonTypes.submit}
-              form={form}
-              colors={themeValues.buttonColors.greenGreenWhite}
-              icon={search}
-              isNewSearchBar={true}
-            />
-          </SearchButtonWrapper>
-        </Container>
-      </GridCell>
-    </Grid>
+    <Container data-component="search-bar" className="is-hidden-print">
+      <SearchInputWrapper>
+        <Typewriter ref={typewriterRef} />
+        <TextInput
+          id={`${location}-searchbar`}
+          label={placeholder}
+          name="query"
+          type="search"
+          value={inputValue}
+          setValue={setInputValue}
+          ref={inputRef || defaultInputRef}
+          form={form}
+          hasClearButton
+          isNewSearchBar={true}
+          placeholder=" " // This empty placeholder is required for the :placeholder-shown CSS selector to work
+        />
+      </SearchInputWrapper>
+      <SearchButtonWrapper>
+        <Button
+          variant="ButtonSolid"
+          text="Search"
+          type={ButtonTypes.submit}
+          form={form}
+          colors={themeValues.buttonColors.greenGreenWhite}
+          icon={search}
+          isNewSearchBar={true}
+        />
+      </SearchButtonWrapper>
+    </Container>
   );
 };
 

--- a/common/views/components/SearchBar/new.tsx
+++ b/common/views/components/SearchBar/new.tsx
@@ -146,22 +146,23 @@ const SearchBar: FunctionComponent<Props> = ({
           'Vaccines',
           'Easter',
         ],
-        typeSpeed: 100,
-        fadeOut: true,
+        typeSpeed: 50,
         fadeOutDelay: 0,
         fadeOutClass: '', // prevent fade completely
         shuffle: true,
         loop: true,
         showCursor: false,
         onStringTyped: async (_, self) => {
-          // There isn't an option to delay between strings, so we implement it here
+          // There isn't an option to delay between strings, so we implement it
           // https://github.com/mattboldt/typed.js/issues/617
           const delay = (ms: number) =>
             new Promise(resolve => setTimeout(resolve, ms));
 
           self.stop();
           await delay(3000);
-          self.destroy();
+          // @ts-expect-error - accessing private method
+          // https://mattboldt.github.io/typed.js/docs/class/src/typed.js~Typed.html
+          self.initFadeOut();
           await delay(1000);
           self.start();
         },

--- a/common/views/components/SearchBar/new.tsx
+++ b/common/views/components/SearchBar/new.tsx
@@ -145,15 +145,26 @@ const SearchBar: FunctionComponent<Props> = ({
           'Oil paintings',
           'Vaccines',
           'Easter',
-        ]
-          .map(value => ({ value, sort: Math.random() }))
-          .sort((a, b) => a.sort - b.sort)
-          .map(({ value }) => value),
+        ],
         typeSpeed: 100,
-        backSpeed: 25,
-        backDelay: 2000,
+        fadeOut: true,
+        fadeOutDelay: 0,
+        fadeOutClass: '', // prevent fade completely
+        shuffle: true,
         loop: true,
         showCursor: false,
+        onStringTyped: async (_, self) => {
+          // There isn't an option to delay between strings, so we implement it here
+          // https://github.com/mattboldt/typed.js/issues/617
+          const delay = (ms: number) =>
+            new Promise(resolve => setTimeout(resolve, ms));
+
+          self.stop();
+          await delay(3000);
+          self.destroy();
+          await delay(1000);
+          self.start();
+        },
       });
 
       return () => {

--- a/common/views/components/SearchBar/new.tsx
+++ b/common/views/components/SearchBar/new.tsx
@@ -23,7 +23,7 @@ const Container = styled.div`
 `;
 
 const Typewriter = styled.div.attrs({
-  className: font('intr', 2),
+  className: font('intr', 3),
   'aria-hidden': 'true',
 })`
   position: absolute;

--- a/common/views/components/SearchForm/index.tsx
+++ b/common/views/components/SearchForm/index.tsx
@@ -27,12 +27,10 @@ const SearchForm = ({
   searchCategory = 'overview',
   location = 'header',
   inputRef = undefined,
-  showTypewriter = false,
 }: {
   searchCategory?: SearchCategory;
   location?: ValidLocations;
   inputRef?: RefObject<HTMLInputElement | null> | undefined;
-  showTypewriter?: boolean;
 }): ReactElement => {
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
@@ -69,7 +67,6 @@ const SearchForm = ({
         placeholder={searchLabelText[searchCategory]}
         inputRef={inputRef}
         location={location}
-        showTypewriter={showTypewriter}
       />
     </form>
   );

--- a/common/views/components/TextInput/TextInput.Clear.tsx
+++ b/common/views/components/TextInput/TextInput.Clear.tsx
@@ -10,6 +10,7 @@ const Button = styled.button`
   top: 50%;
   transform: translateY(-50%);
   padding: 0;
+  display: flex;
 `;
 
 type Props = {

--- a/common/views/components/TextInput/index.tsx
+++ b/common/views/components/TextInput/index.tsx
@@ -29,7 +29,7 @@ type TextInputWrapProps = {
   $isNewSearchBar?: boolean;
 };
 export const TextInputWrap = styled(Space).attrs<TextInputWrapProps>(props => ({
-  className: font('intr', props.$isNewSearchBar ? 2 : 4),
+  className: font('intr', props.$isNewSearchBar ? 3 : 4),
   $v: { size: 's', properties: ['margin-top'] },
 }))<TextInputWrapProps>`
   display: flex;
@@ -70,7 +70,8 @@ export const TextInputWrap = styled(Space).attrs<TextInputWrapProps>(props => ({
   overflow: hidden;
 
   &:hover {
-    border-color: ${props => props.theme.color('black')};
+    border-color: ${props =>
+      !props.$isNewSearchBar && props.theme.color('black')};
   }
 
   ${props =>

--- a/common/views/components/TextInput/index.tsx
+++ b/common/views/components/TextInput/index.tsx
@@ -35,7 +35,10 @@ export const TextInputWrap = styled(Space).attrs<TextInputWrapProps>(props => ({
   display: flex;
   position: relative;
   border-width: ${props => (props.$isNewSearchBar ? '4px' : '1px')};
-  border-style: solid;
+  ${props =>
+    props.$isNewSearchBar
+      ? `border-bottom-style: solid;`
+      : `border-style: solid;`}
   border-color: ${props =>
     props.$status
       ? props.$status === 'error'
@@ -59,11 +62,6 @@ export const TextInputWrap = styled(Space).attrs<TextInputWrapProps>(props => ({
       `
       box-shadow: 0 0 0 6px ${props.theme.color('focus.yellow')};
       outline:  3px solid ${props.theme.color('black')};
-    `}
-    ${props =>
-      props.$isNewSearchBar &&
-      `
-      border-color: ${props.theme.color('black')};
     `}
   }
 

--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -35,11 +35,7 @@ const Page: NextPage<
       staticContent={
         <ContaineredLayout gridSizes={gridSize12()}>
           <SpacingSection>
-            <SearchForm
-              searchCategory="works"
-              location="page"
-              showTypewriter={true}
-            />
+            <SearchForm searchCategory="works" location="page" />
           </SpacingSection>
         </ContaineredLayout>
       }

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -1,15 +1,19 @@
 import * as prismic from '@prismicio/client';
 import { NextPage } from 'next';
+import { useState } from 'react';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { ImageType } from '@weco/common/model/image';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import {
   ContaineredLayout,
+  gridSize10,
   gridSize12,
 } from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader';
+import SearchBar from '@weco/common/views/components/SearchBar/new';
 import Space from '@weco/common/views/components/styled/Space';
+import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import PageLayout from '@weco/common/views/layouts/PageLayout';
 import { useCollectionStats } from '@weco/content/hooks/useCollectionStats';
 import { MultiContent } from '@weco/content/types/multi-content';
@@ -35,6 +39,14 @@ const CollectionsLandingPage: NextPage<Props> = ({
   insideOurCollectionsCards,
 }) => {
   const { data: collectionStats } = useCollectionStats();
+  const [searchValue, setSearchValue] = useState('');
+
+  const handleSearch = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (searchValue.trim()) {
+      window.location.href = `/search/works?query=${encodeURIComponent(searchValue.trim())}`;
+    }
+  };
 
   return (
     <PageLayout
@@ -50,6 +62,20 @@ const CollectionsLandingPage: NextPage<Props> = ({
       hideNewsletterPromo
     >
       <PageHeader variant="simpleLanding" title={title} introText={introText} />
+
+      <SpacingSection>
+        <ContaineredLayout gridSizes={gridSize10(false)}>
+          <form id="collections-search" onSubmit={handleSearch}>
+            <SearchBar
+              inputValue={searchValue}
+              setInputValue={setSearchValue}
+              placeholder="Search our collections"
+              form="collections-search"
+              location="page"
+            />
+          </form>
+        </ContaineredLayout>
+      </SpacingSection>
 
       <Space $v={{ size: 'l', properties: ['margin-bottom'] }}>
         <SectionHeader title="Inside our collections" gridSize={gridSize12()} />


### PR DESCRIPTION
## What does this change?
QA amends to the searchbox after discussion with @dana-saur

<img width="1326" height="897" alt="image" src="https://github.com/user-attachments/assets/93d009b2-3f51-4a4e-ad1e-27b8ed13e128" />

It will now _only_ appear on the new collections landing page, and only with the bottom border. If you have the `collectionsLanding` toggle on, this will also change the colour of the existing search bar button to green with white text for a degree of consistency.

The other changes to the component from the initial PR are:

- clear input button has better vertical alignment
- the box no longer changes border colour to black on hover
- the button horizontal padding is 16px (a prop not being passed through previously prevented this from happening)
- the font sizes of the typewriter and input text have gone down a size
- the typewriter behaviours have been tweaked according to [those suggested](https://github.com/wellcomecollection/wellcomecollection.org/issues/12215#issuecomment-3293000336)

## How to test
Look at the new collections landing page (with the `collectionsLanding` toggle on). Does the search bar match the designs (ignoring the fact it doesn't have the 'W' background, which will be added in a separate piece of work).

## How can we measure success?
New UI

## Have we considered potential risks?
Less now we've limited where we're showing the component