### PR TITLE
Removes border on active

### DIFF
--- a/content/webapp/views/components/SelectableTags/index.tsx
+++ b/content/webapp/views/components/SelectableTags/index.tsx
@@ -23,9 +23,7 @@ const TagsWrapper = styled.div`
 `;
 
 const StyledInput = styled.label<
-  AnimatedUnderlineProps & {
-    $isSelected: boolean;
-  }
+  AnimatedUnderlineProps & { $isSelected: boolean }
 >`
   ${AnimatedUnderlineCSS}
 
@@ -57,7 +55,8 @@ const InputField = styled.input`
     outline: ${props => props.theme.highContrastOutlineFix};
   }
 
-  &:focus ~ ${StyledInput}:not(:focus-visible ~ ${StyledInput}) {
+  &:focus ~ ${StyledInput}:not(:focus-visible ~ ${StyledInput}),
+  &:active ~ ${StyledInput} {
     box-shadow: none;
   }
 `;


### PR DESCRIPTION
## What does this change?

Addresses [Dana's comment here](https://github.com/wellcomecollection/wellcomecollection.org/issues/12241#issuecomment-3312477472)

Removes yellow outline on click 

## How to test

Should still be there on focus/keyboard nav

## Have we considered potential risks?
a11y concerns? This is how our other inputs behave though (e.g. CheckboxRadio)