### PR TITLE
Use container queries for font sizes behind new toggle

### DIFF
--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -151,8 +151,8 @@ const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
   ${row}
   ${inlineFonts}
   ${fonts}
-  ${makeFontSizeClasses()}
-  ${makeFontSizeOverrideClasses()}
+  ${props => makeFontSizeClasses(props.toggles?.containerQueryFont?.value)}
+  ${props => makeFontSizeOverrideClasses(props.toggles?.containerQueryFont?.value)}
   ${typography}
 `;
 

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -77,10 +77,11 @@ const fontFamilies = {
   },
 };
 
-const fontSizeMixin = size => {
+const fontSizeMixin = (size: number, useContainerQueries = false) => {
   return breakpointNames
     .map(name => {
-      return `@media (min-width: ${themeValues.sizes[name]}px) {
+      const queryType = useContainerQueries ? '@container' : '@media';
+      return `${queryType} (min-width: ${themeValues.sizes[name]}px) {
       font-size: ${fontSizesAtBreakpoints[name][size]}rem;
     }`;
     })
@@ -145,13 +146,17 @@ export const typography = css<GlobalStyleProps>`
 
   body {
     ${fontFamilyMixin('intr', true)}
-    ${fontSizeMixin(4)}
+    ${props => fontSizeMixin(4, props.toggles?.containerQueryFont?.value)}
     line-height: 1.5;
     color: ${themeValues.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
     -o-font-smoothing: antialiased;
+    ${props =>
+      props.toggles?.containerQueryFont?.value
+        ? 'container-type: inline-size;'
+        : ''}
   }
 
   h1,
@@ -243,12 +248,12 @@ export const typography = css<GlobalStyleProps>`
 
     h1 {
       ${fontFamilyMixin('wb', true)}
-      ${fontSizeMixin(1)}
+      ${props => fontSizeMixin(1, props.toggles?.containerQueryFont?.value)}
     }
 
     h2 {
       ${fontFamilyMixin('wb', true)}
-      ${fontSizeMixin(2)}
+      ${props => fontSizeMixin(2, props.toggles?.containerQueryFont?.value)}
     }
 
     /* Visual stories have their own h2 styling that involves more space and a border above */
@@ -265,7 +270,7 @@ export const typography = css<GlobalStyleProps>`
 
     h3 {
       ${fontFamilyMixin('intb', true)}
-      ${fontSizeMixin(3)}
+      ${props => fontSizeMixin(3, props.toggles?.containerQueryFont?.value)}
     }
 
     *::selection {
@@ -362,10 +367,11 @@ export const typography = css<GlobalStyleProps>`
   }
 `;
 
-export function makeFontSizeClasses(): string {
+export function makeFontSizeClasses(useContainerQueries = false): string {
+  const queryType = useContainerQueries ? '@container' : '@media';
   return breakpointNames
     .map(bp => {
-      return `@media (min-width: ${themeValues.sizes[bp]}px) {
+      return `${queryType} (min-width: ${themeValues.sizes[bp]}px) {
       ${Object.entries(fontSizesAtBreakpoints[bp])
         .map(([key, value]) => {
           return `.font-size-${key} {font-size: ${value}rem}`;
@@ -384,7 +390,10 @@ function overridesAtBreakpoint(bp: string) {
     .join(' ');
 }
 
-export function makeFontSizeOverrideClasses(): string {
+export function makeFontSizeOverrideClasses(
+  useContainerQueries = false
+): string {
+  const queryType = useContainerQueries ? '@container' : '@media';
   return breakpointNames
     .map(bp => {
       const minMax =
@@ -395,13 +404,13 @@ export function makeFontSizeOverrideClasses(): string {
             : ['large'];
 
       if (minMax.length === 2) {
-        return `@media (min-width: ${
+        return `${queryType} (min-width: ${
           themeValues.sizes[minMax[0]]
         }px) and (max-width: ${themeValues.sizes[minMax[1]]}px) {
         ${overridesAtBreakpoint(bp)}
       }`;
       } else {
-        return `@media (min-width: ${themeValues.sizes[minMax[0]]}px) {
+        return `${queryType} (min-width: ${themeValues.sizes[minMax[0]]}px) {
         ${overridesAtBreakpoint(bp)}
       }`;
       }

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -152,6 +152,14 @@ const toggles = {
         'Enables the concepts search tab and functionality in the search interface',
       type: 'experimental',
     },
+    {
+      id: 'containerQueryFont',
+      title: 'Container query font sizing',
+      initialValue: false,
+      description:
+        'Use container queries instead of media queries for responsive typography. Provides better containment for typography sizing in components.',
+      type: 'experimental',
+    },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth


### PR DESCRIPTION
Implements container query-based typography as an alternative to media queries.

## Changes
- Added `containerQueryFont` experimental toggle
- When toggle is enabled, uses `@container` anywhere we currently use `@media` for typography classes

## Benefits
- Better containment for typography sizing in components
- More predictable responsive behaviour in complex layouts
- Foundation for component-based responsive design

## Testing
Turn on the containerQueryFont toggle and look at the site. The most pronounced change is that the font sizing across cards is more consistent on small and large screens. Effectively, this means that the titles and descriptions in cards are slightly smaller than they currently are at larger viewport widths.

An example of where this approach would be beneficial is with the FeaturedCards at the top of some landing pages. when the page gets smaller, the card layout changes in such a way that there is _more_ room for the text, which the `@media` query is unable to deal with (without overrides).

I don't think the change in this PR is enough on its own to improve the typography across the site, but I think the rationale is sound. I think the type scale as it stands has been created to be quite conservative in changes across breakpoints, because we didn't know how much space was going to be available for it within its containing component. But we could afford to be more bold with the scale if we were to base it on container-width rather than viewport-width.

I'm not sure if we want to get it into prod. On the one hand I don't think it could hurt since it's all behind a toggle, but I'm not sure it would exemplify much to non-devs (who are capable of viewing it locally), and I don't think it would end up staying there in this form, so perhaps not worth it?
