### PR TITLE
Improve typographic layout for headings and body copy

### DIFF
--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -152,6 +152,7 @@ export const typography = css<GlobalStyleProps>`
     -webkit-font-smoothing: antialiased;
     -moz-font-smoothing: antialiased;
     -o-font-smoothing: antialiased;
+    text-wrap-style: pretty;
   }
 
   h1,
@@ -162,6 +163,7 @@ export const typography = css<GlobalStyleProps>`
   h6 {
     font-size: 1em;
     margin: 0 0 0.6em;
+    text-wrap-style: balance;
   }
 
   /*


### PR DESCRIPTION
## What does this change?
Adds the `text-wrap-style` property to body text and headings – [`balance`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap-style#balance) for headings, and [`pretty`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap-style#pretty) for the body.

@dana-saur These are relatively new css properties that aim to improve typographic elements on the web. I _think_ you'd probably be in favour of implementing them, but let me know if you're not.

__before__
<img width="1268" height="744" alt="Screenshot 2025-09-24 at 10 59 43" src="https://github.com/user-attachments/assets/d1ce4bd7-37a7-4c1c-9d4d-89ce8476af86" />


__after__
<img width="1278" height="758" alt="Screenshot 2025-09-24 at 10 59 33" src="https://github.com/user-attachments/assets/2920c7f7-31bb-4ce3-8d44-4fc7667aa023" />

`balance` is available across our entire browser support list. `pretty` is in all apart from Firefox (where body copy will continue to appear as it currently does).

## How to test
Visit the site – check that headings appear 'balanced' (i.e. line lengths fairly similar where possible), and body copy is 'pretty' (i.e. orphans should be avoided if possible).

## How can we measure success?
Typography appears more pleasing/considered

## Have we considered potential risks?
The browser has to do more computation to lay out text with these constraints, so I suppose there is a chance that our performance metrics _might_ be impacted. I'd be surprised if it was significant, but we should keep an eye on it just in case cc @mankeetn 
