### PR TITLE
Collections 'browse by type' tweaks

### DIFF
--- a/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
+++ b/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
@@ -229,7 +229,6 @@ const WorkTypeItem: React.FC<WorkTypeItemProps> = ({
       const startCount = stats.fallbackCount;
       const endCount = stats.count;
       const duration = 2000;
-      const staggerDelay = animationIndex * 750;
 
       if (prefersReducedMotion) {
         setDisplayCount(endCount);
@@ -259,17 +258,15 @@ const WorkTypeItem: React.FC<WorkTypeItemProps> = ({
           requestAnimationFrame(animate);
         };
 
-        setTimeout(startAnimation, staggerDelay);
+        startAnimation();
       }
     } else if (stats.count !== null) {
       if (prefersReducedMotion) {
         setDisplayCount(stats.count);
         setShowPlus(false);
       } else {
-        setTimeout(() => {
-          setDisplayCount(stats.count!);
-          setShowPlus(false);
-        }, animationIndex * 750);
+        setDisplayCount(stats.count!);
+        setShowPlus(false);
       }
     }
   }, [isInView, stats.count, stats.fallbackCount, animationIndex]);

--- a/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
+++ b/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
@@ -148,7 +148,7 @@ const StyledLink = styled(NextLink)<{ $tiltIndex?: number }>`
             : '-2deg'}
       )
       scale(1.1);
-    filter: drop-shadow(4px 4px 2px rgba(0, 0, 0, 0.25));
+    filter: drop-shadow(4px 4px 2px #00000040);
   }
 
   @container work-types-list (min-width: ${containerBreakpoint}) {

--- a/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
+++ b/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
@@ -234,11 +234,9 @@ const WorkTypeItem: FunctionComponent<WorkTypeItemProps> = ({
       return;
     }
 
-    // Pure JS animation using requestAnimationFrame. We don't rely on any CSS
-    // custom properties so the counter effect remains visible across
-    // environments. Duration and easing exponent chosen to slow near the end.
+    // Duration and easing exponent chosen to slow near the end.
     const startCount = initialCount;
-    const duration = 5000; // ms - slower, as requested
+    const duration = 5000;
 
     let rafId: number | null = null;
     let startTime: number | null = null;
@@ -358,9 +356,6 @@ const WorkTypesList: React.FC<WorkTypesListProps> = ({
   },
 }) => {
   const [startAnimations, setStartAnimations] = useState(false);
-
-  // Observe number elements directly so animations start when the numbers
-  // scroll into view. Store elements in a Set to avoid duplicates.
   const numberEls = useRef<Set<Element>>(new Set());
   const observerRef = useRef<IntersectionObserver | null>(null);
 

--- a/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
+++ b/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
@@ -16,7 +16,8 @@ import { WorkTypeStats } from '@weco/content/services/wellcome/catalogue/workTyp
 import { toSearchImagesLink } from '@weco/content/views/components/SearchPagesLink/Images';
 import { toSearchWorksLink } from '@weco/content/views/components/SearchPagesLink/Works';
 
-const containerBreakpoint = '620px';
+const smallContainerBreakpoint = '620px';
+const largeContainerBreakpoint = '960px';
 
 const StyledImage = styled(Image)<{ $tiltIndex: number }>`
   width: 80px;
@@ -28,7 +29,13 @@ const StyledImage = styled(Image)<{ $tiltIndex: number }>`
     transform 0.2s ease-out,
     filter 0.2s ease-out;
 
-  @container work-types-list (min-width: ${containerBreakpoint}) {
+  @container work-types-list (min-width: ${smallContainerBreakpoint}) {
+    width: 100%;
+    height: auto;
+    max-width: 100px;
+  }
+
+  @container work-types-list (min-width: ${largeContainerBreakpoint}) {
     width: 100%;
     height: auto;
     max-width: 120px;
@@ -60,7 +67,7 @@ const StyledList = styled.ul`
   }
 
   /* Large container: single row layout */
-  @container work-types-list (min-width: ${containerBreakpoint}) {
+  @container work-types-list (min-width: ${smallContainerBreakpoint}) {
     flex-wrap: nowrap;
     justify-content: space-between;
     min-width: 0;
@@ -92,7 +99,7 @@ const IconContainer = styled(Space).attrs({
   max-width: 80px;
   flex-shrink: 0;
 
-  @container work-types-list (min-width: ${containerBreakpoint}) {
+  @container work-types-list (min-width: ${smallContainerBreakpoint}) {
     min-height: 120px;
     max-width: 100%;
     flex-shrink: 1;
@@ -104,7 +111,7 @@ const TextContainer = styled.div`
   align-items: center;
   flex-grow: 1;
 
-  @container work-types-list (min-width: ${containerBreakpoint}) {
+  @container work-types-list (min-width: ${smallContainerBreakpoint}) {
     align-items: center;
   }
 `;
@@ -114,7 +121,7 @@ const CountDisplayContainer = styled.div`
   justify-content: center;
   align-items: center;
 
-  @container work-types-list (min-width: ${containerBreakpoint}) {
+  @container work-types-list (min-width: ${smallContainerBreakpoint}) {
     justify-content: center;
     min-width: 100px;
   }
@@ -150,7 +157,7 @@ const StyledLink = styled(NextLink)<{ $tiltIndex?: number }>`
     filter: drop-shadow(4px 4px 2px #00000040);
   }
 
-  @container work-types-list (min-width: ${containerBreakpoint}) {
+  @container work-types-list (min-width: ${smallContainerBreakpoint}) {
     flex-direction: column;
     text-align: center;
     gap: 0;


### PR DESCRIPTION
## What does this change?

Tweaks to the browse by type component following feedback from @dana-saur 

  - don't stagger the animations for each type
  - change length of animations
  - just tick up the last few digits
  - scale the icons down on tablet

## How to test

- enable the 'collectionsLanding' toggle
- scroll to the browse by type component and check it does the above

## How can we measure success?

@dana-saur is happy with the changes

## Have we considered potential risks?

none really
