### PR TITLE
Reuse formDataAsUrlQuery and linkResolver in collections search

### DIFF
--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -1,11 +1,14 @@
 import * as prismic from '@prismicio/client';
 import { SliceZone } from '@prismicio/react';
 import { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import styled from 'styled-components';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { ImageType } from '@weco/common/model/image';
+import { formDataAsUrlQuery } from '@weco/common/utils/forms';
+import { linkResolver } from '@weco/common/utils/search';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import {
   ContaineredLayout,
@@ -52,14 +55,18 @@ const CollectionsLandingPage: NextPage<Props> = ({
   insideOurCollectionsCards,
   fullWidthBanners,
 }) => {
+  const router = useRouter();
   const { data: collectionStats } = useCollectionStats();
   const [searchValue, setSearchValue] = useState('');
 
-  const handleSearch = (event: React.FormEvent) => {
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (searchValue.trim()) {
-      window.location.href = `/search/works?query=${encodeURIComponent(searchValue.trim())}`;
-    }
+    const formValues = formDataAsUrlQuery(event.currentTarget);
+    const link = linkResolver({
+      params: formValues,
+      pathname: '/search/works',
+    });
+    return router.push(link.href);
   };
 
   return (


### PR DESCRIPTION
## What does this change?

The search box was checking that there was at least _something_ entered. Instead of just removing that check I updated it to match the behaviour of the existing SearchForm:

- Import formDataAsUrlQuery and linkResolver utilities
- Update handleSearch to use shared URL construction logic
- Replace manual URL encoding with consistent search form pattern
- Use router.push for client-side navigation

We'll need to have done this by the time we add the 'available online' checkbox, so makes sense to do it now.

## How to test

Check the form submits without any input text

## How can we measure success?

Consistent with current behaviour

## Have we considered potential risks?

Can't think of any