### PR TITLE
Remove double breakpoints

### DIFF
--- a/content/webapp/utils/breakpoints.ts
+++ b/content/webapp/utils/breakpoints.ts
@@ -1,6 +1,0 @@
-export const breakpoints = {
-  small: '0',
-  medium: '600px',
-  large: '960px',
-  xlarge: '1338px',
-};

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -5,10 +5,10 @@ import { FeaturedMedia } from '@weco/common/views/components/PageHeader';
 import Picture from '@weco/common/views/components/Picture';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed';
+import { themeValues } from '@weco/common/views/themes/config';
 import { transformEmbedSlice } from '@weco/content/services/prismic/transformers/body';
 import { isVideoEmbed } from '@weco/content/types/body';
 import { GenericContentFields } from '@weco/content/types/generic-content-fields';
-import { breakpoints } from '@weco/content/utils/breakpoints';
 import ImageWithTasl from '@weco/content/views/components/ImageWithTasl';
 
 export function getFeaturedMedia(
@@ -74,7 +74,7 @@ export function getHeroPicture(
     widescreenImage && (
       <Picture
         images={[
-          { ...widescreenImage, minWidth: breakpoints.medium },
+          { ...widescreenImage, minWidth: `${themeValues.sizes.medium}px` },
           squareImage,
         ]}
         isFull={true}


### PR DESCRIPTION
## What does this change?

Remove a util file that's used once that declares breakpoints, which we also have as `sizes` in our theme. 
Replaced the one place where it was used to the equivalent value (medium size is also 600)

## How to test

Do the Hero images still look fine?

## How can we measure success?

No double declaration of breakpoints

## Have we considered potential risks?
N/A
