### PR TITLE
Toggles: Remove double `conceptSearch` and unused `newSearchBar`

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -136,14 +136,6 @@ const toggles = {
       description: `Displays the new Collections landing page as it's being built.`,
       type: 'experimental',
     },
-    {
-      id: 'newSearchBar',
-      title: 'Use the new search bar style',
-      initialValue: false,
-      description:
-        'Displays the new search bar created as part of the Collections landing page update',
-      type: 'experimental',
-    },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth


### PR DESCRIPTION
## What does this change?

Realised conceptSearch was showing like three times on the toggles dashboard 😅 So removed one, it's already been deployed.

Removed newSearchBar as not needed anymore
