### PR TITLE
Add checkbox to collections search

### DIFF
--- a/common/views/components/SearchForm/index.tsx
+++ b/common/views/components/SearchForm/index.tsx
@@ -4,9 +4,11 @@ import { ReactElement, RefObject, useEffect, useState } from 'react';
 import { searchLabelText } from '@weco/common/data/microcopy';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { getQueryPropertyValue, linkResolver } from '@weco/common/utils/search';
+import CheckboxRadio from '@weco/common/views/components/CheckboxRadio';
 import SearchBar, {
   ValidLocations,
 } from '@weco/common/views/components/SearchBar';
+import Space from '@weco/common/views/components/styled/Space';
 
 type SearchCategory = 'overview' | 'works';
 
@@ -20,24 +22,30 @@ function formAction(searchCategory: SearchCategory) {
       return '/search';
   }
 }
+
+type Props = {
+  searchCategory?: SearchCategory;
+  location?: ValidLocations;
+  inputRef?: RefObject<HTMLInputElement | null> | undefined;
+  isNew?: boolean;
+  hasAvailableOnlineOnly?: boolean;
+};
+
 // This search form is used in the Header and also at the top of /collections and /works/{id} pages
 // If it's at the top of /collections or /works/{id} we want to show '/search/works'
 // otherwise we default to '/search'
 const SearchForm = ({
   searchCategory = 'overview',
   location = 'header',
-  inputRef = undefined,
-  isNew = false,
-}: {
-  searchCategory?: SearchCategory;
-  location?: ValidLocations;
-  inputRef?: RefObject<HTMLInputElement | null> | undefined;
-  isNew?: boolean;
-}): ReactElement => {
+  inputRef,
+  isNew,
+  hasAvailableOnlineOnly,
+}: Props): ReactElement => {
   const router = useRouter();
   const routerQuery = getQueryPropertyValue(router?.query?.query);
   const initialValue = routerQuery || '';
   const [inputValue, setInputValue] = useState(initialValue);
+  const [checkboxIsSelected, setCheckboxIsSelected] = useState(false);
 
   useEffect(() => {
     setInputValue(location === 'header' ? '' : initialValue);
@@ -52,11 +60,14 @@ const SearchForm = ({
 
     return router.push(link.href);
   };
+
+  const formId = `search-form-${searchCategory}`;
+
   return (
     <form
       data-component="search-form"
       action={formAction(searchCategory)}
-      id={`search-form-${searchCategory}`}
+      id={formId}
       onSubmit={event => {
         event.preventDefault();
         updateUrl(event.currentTarget);
@@ -66,11 +77,26 @@ const SearchForm = ({
         variant={isNew ? 'new' : 'default'}
         inputValue={inputValue}
         setInputValue={setInputValue}
-        form={`search-form-${searchCategory}`}
+        form={formId}
         placeholder={searchLabelText[searchCategory]}
         inputRef={inputRef}
         location={location}
       />
+
+      {hasAvailableOnlineOnly && (
+        <Space $v={{ size: 'm', properties: ['margin-top'] }}>
+          <CheckboxRadio
+            id="isAvailableOnlineOnly"
+            type="checkbox"
+            text="Available online only"
+            value="online"
+            name="availabilities"
+            checked={checkboxIsSelected}
+            onChange={() => setCheckboxIsSelected(!checkboxIsSelected)}
+            form={formId}
+          />
+        </Space>
+      )}
     </form>
   );
 };

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -94,11 +94,7 @@ const CollectionsLandingPage: NextPage<Props> = ({
           <WShape
             variant="edge-1"
             color="accent.lightBlue"
-            styles={{
-              display: 'block',
-              bottom: '-1px',
-              position: 'relative',
-            }}
+            styles={{ display: 'block', bottom: '-1px', position: 'relative' }}
           />
         </WShapeContainer>
       </ContaineredLayout>
@@ -108,7 +104,12 @@ const CollectionsLandingPage: NextPage<Props> = ({
           <Space
             $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <SearchForm searchCategory="works" location="page" isNew={true} />
+            <SearchForm
+              searchCategory="works"
+              location="page"
+              isNew
+              hasAvailableOnlineOnly
+            />
           </Space>
         </ContaineredLayout>
 


### PR DESCRIPTION
## What does this change?

#12290 

I wasn't sure where to add it but I think it belongs in `SearchForm`, to ensure it uses the same ID. `SearchForm` is used elsewhere but mostly for works (as well as the header search). Shout if we think it'd be better off elsewhere!

## How to test

Test the search bar with and without the checkbox being selected, see if the results make sense.

## How can we measure success?

More search control

## Have we considered potential risks?
N/A
