### PR TITLE
Remove `featuredWorksInAddressables` toggle conditions

### DIFF
--- a/content/webapp/views/components/ContentPage/index.tsx
+++ b/content/webapp/views/components/ContentPage/index.tsx
@@ -68,7 +68,7 @@ const ContentPage = ({
   showStaticLinkedWorks,
   contentApiType,
 }: Props): ReactElement => {
-  const { featuredWorksInAddressables, stagingApi } = useToggles();
+  const { stagingApi } = useToggles();
 
   const [linkedWorks, setLinkedWorks] = useState<ContentApiLinkedWork[]>([]);
 
@@ -138,21 +138,16 @@ const ContentPage = ({
               ))}
             </SpacingSection>
           )}
-          {featuredWorksInAddressables &&
-            linkedWorks &&
-            linkedWorks.length > 0 && (
-              <HoverLinkedWorks linkedWorks={linkedWorks} />
-            )}
-          {featuredWorksInAddressables &&
-            showStaticLinkedWorks &&
-            linkedWorks &&
-            linkedWorks.length > 0 && (
-              <LinkedWorks
-                linkedWorks={linkedWorks}
-                gridSizes={gridSize8()}
-                parentId={id}
-              />
-            )}
+          {linkedWorks && linkedWorks.length > 0 && (
+            <HoverLinkedWorks linkedWorks={linkedWorks} />
+          )}
+          {showStaticLinkedWorks && linkedWorks && linkedWorks.length > 0 && (
+            <LinkedWorks
+              linkedWorks={linkedWorks}
+              gridSizes={gridSize8()}
+              parentId={id}
+            />
+          )}
           {!hideContributors && contributors && contributors.length > 0 && (
             <SpacingSection>
               <ContaineredLayout gridSizes={gridSize8()}>

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -122,14 +122,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'featuredWorksInAddressables',
-      title: 'Featured works in addressables',
-      initialValue: false,
-      description:
-        'Adds features in displaying featured works in the Content part of the website',
-      type: 'experimental',
-    },
-    {
       id: 'collectionsLanding',
       title: 'Collections landing alternative page',
       initialValue: false,


### PR DESCRIPTION
## What does this change?

#12336 

Quick work, this one! Removed the toggle and its condition (dashboard will be updated upon merge)

## How to test

Run locally and ensure featured works still show in incognito mode. (e.g https://www-dev.wellcomecollection.org/stories/YZJzrhEAACUARhC3)

## How can we measure success?

One less toggle, work made official = success

## Have we considered potential risks?
N/A