### PR TITLE
Use wc_ prefix for consistency. Remove unnecessary values

### DIFF
--- a/common/hooks/useScrollTracking.ts
+++ b/common/hooks/useScrollTracking.ts
@@ -38,9 +38,7 @@ export function useScrollTracking() {
 
           window.dataLayer?.push({
             event: 'wc_scroll_depth',
-            scroll_depth_threshold: value,
-            scroll_depth_units: 'percent',
-            scroll_direction: 'vertical',
+            wc_scroll_depth_threshold: value,
           });
         }
       });


### PR DESCRIPTION
## What does this change?

Adds a `wc_` prefix to the scroll depth threshold for consistency with the event name. Also, we know that it's a percent, and we're not measuring horizontal scroll, so I've removed those (static) values from what we're pushing to the dataLayer

## How to test

Turn on the GA Debugger extension and check the event and value have the wc_ prefix, and that no other data is sent

## How can we measure success?

We'll know which values we're dealing with in GTM (where we have a bit of a proliferation of scroll depth data currently)

## Have we considered potential risks?

Can't think of any