### PR TITLE
Browse by theme scrolling

### DIFF
--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
@@ -39,12 +39,14 @@ type Props = {
   containerRef: RefObject<HTMLElement | null>;
   hasDarkBackground?: boolean;
   hasLeftOffset?: boolean;
+  customScrollDistance?: number;
 };
 
 const ScrollableNavigation: FunctionComponent<Props> = ({
   containerRef,
   hasDarkBackground,
   hasLeftOffset,
+  customScrollDistance,
 }: Props) => {
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -76,6 +78,22 @@ const ScrollableNavigation: FunctionComponent<Props> = ({
     const container = containerRef.current;
     if (!container) return;
 
+    // use customScrollDistance for scrolling, when available
+    if (customScrollDistance) {
+      const currScrollLeft = Math.round(container.scrollLeft);
+      const newScrollLeft =
+        direction === 'right'
+          ? currScrollLeft + customScrollDistance
+          : currScrollLeft - customScrollDistance;
+
+      container.scrollTo({
+        left: Math.max(0, newScrollLeft), // Ensure we don't scroll past the beginning
+        behavior: 'smooth',
+      });
+      return;
+    }
+
+    // Logic for when customScrollDistance is not available
     // Math.round is required because Chrome Android does not round numbers,
     // and this causes the scroll to not work correctly.
     const currScrollLeft = Math.round(container.scrollLeft);

--- a/content/webapp/views/components/ScrollContainer/index.tsx
+++ b/content/webapp/views/components/ScrollContainer/index.tsx
@@ -39,6 +39,7 @@ type Props = PropsWithChildren<{
   gridSizes?: SizeMap;
   hasLeftOffset?: boolean;
   scrollButtonsAfter?: boolean;
+  customScrollDistance?: number;
 }>;
 
 const ScrollContainer: FunctionComponent<Props> = ({
@@ -47,6 +48,7 @@ const ScrollContainer: FunctionComponent<Props> = ({
   gridSizes,
   hasLeftOffset,
   scrollButtonsAfter = false,
+  customScrollDistance,
   children,
 }) => {
   const scrollContainerRef = useRef<HTMLUListElement>(null);
@@ -67,6 +69,7 @@ const ScrollContainer: FunctionComponent<Props> = ({
           containerRef={scrollContainerRef}
           hasDarkBackground={hasDarkBackground}
           hasLeftOffset={hasLeftOffset}
+          customScrollDistance={customScrollDistance}
         />
       </ScrollButtonsContainer>
     </ConditionalWrapper>

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -151,7 +151,11 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
           />
         </Space>
       </ContaineredLayout>
-      <ScrollContainer scrollButtonsAfter={true} gridSizes={gridSizes}>
+      <ScrollContainer
+        scrollButtonsAfter={true}
+        gridSizes={gridSizes}
+        customScrollDistance={424} // 400px card width + 24px gap
+      >
         <Shim $gridValues={gridValues}></Shim>
         {displayedConcepts.map(concept => (
           <ListItem key={concept.id}>

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -22,7 +22,59 @@ import type { ThemeConfig } from './themeBlockCategories';
 type BrowseByThemeProps = {
   themeConfig: ThemeConfig;
   initialConcepts: Concept[];
+  gridSizes: SizeMap;
 };
+
+const Shim = styled.li<{ $gridValues: number[] }>`
+  display: none;
+
+  --container-padding: ${props => props.theme.containerPadding.small}px;
+  --number-of-columns: ${props => (12 - props.$gridValues[0]) / 2};
+  --gap-value: ${props => props.theme.gutter.small}px;
+  --container-width: calc(100% - (var(--container-padding) * 2));
+  --container-width-without-gaps: calc(
+    (var(--container-width) - (var(--gap-value) * 11))
+  );
+  min-width: calc(
+    var(--container-padding) +
+      (
+        var(--number-of-columns) *
+          ((var(--container-width-without-gaps) / 12) + var(--gap-value))
+      )
+  );
+
+  ${props =>
+    props.theme.media('medium')(`
+      display: block;
+      --container-padding: ${props.theme.containerPadding.medium}px;
+      --number-of-columns: ${(12 - props.$gridValues[1]) / 2};
+      --gap-value: ${props.theme.gutter.medium}px;
+  `)}
+
+  ${props =>
+    props.theme.media('large')(`
+      --container-padding: ${props.theme.containerPadding.large}px;
+      --number-of-columns: ${(12 - props.$gridValues[2]) / 2};
+      --gap-value: ${props.theme.gutter.large}px;
+  `)}
+
+  ${props =>
+    props.theme.media('xlarge')(`
+      --container-padding: ${props.theme.containerPadding.xlarge}px;
+      --container-width: calc(${props.theme.sizes.xlarge}px - (var(--container-padding) * 2));
+      --left-margin-width: calc((100% - ${props.theme.sizes.xlarge}px) / 2);
+      --number-of-columns: ${(12 - props.$gridValues[3]) / 2};
+      --gap-value: ${props.theme.gutter.xlarge}px;
+
+      min-width: calc(
+        var(--left-margin-width) + var(--container-padding) +
+          (
+            var(--number-of-columns) *
+              ((var(--container-width-without-gaps) / 12) + var(--gap-value))
+          )
+      );
+  `)}
+`;
 
 const ListItem = styled.li`
   --gap: ${themeValues.gutter.medium}px;
@@ -50,6 +102,7 @@ const Theme: FunctionComponent<{ concept: Concept }> = ({ concept }) => {
 const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
   themeConfig,
   initialConcepts,
+  gridSizes,
 }) => {
   const { fetchConcepts, setCache } = useThemeConcepts(
     initialConcepts,
@@ -82,19 +135,24 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
     label: category.label,
   }));
 
+  const gridValues = Object.values(gridSizes).map(v => v[0]);
+
   return (
     <Space
       $v={{ size: 'm', properties: ['margin-top'] }}
       data-component="BrowseByThemes"
     >
-      <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
-        <SelectableTags
-          tags={tagData}
-          isMultiSelect={false}
-          onChange={handleCategoryChange}
-        />
-      </Space>
-      <ScrollContainer scrollButtonsAfter={true}>
+      <ContaineredLayout gridSizes={gridSize12()}>
+        <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
+          <SelectableTags
+            tags={tagData}
+            isMultiSelect={false}
+            onChange={handleCategoryChange}
+          />
+        </Space>
+      </ContaineredLayout>
+      <ScrollContainer scrollButtonsAfter={true} gridSizes={gridSizes}>
+        <Shim $gridValues={gridValues}></Shim>
         {displayedConcepts.map(concept => (
           <ListItem key={concept.id}>
             <Theme concept={concept} />

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -1,6 +1,11 @@
 import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
+import { SizeMap } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
 import ThemePromo from '@weco/common/views/components/ThemePromo';
 import { themeValues } from '@weco/common/views/themes/config';

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -123,12 +123,11 @@ const CollectionsLandingPage: NextPage<Props> = ({
         $isDefaultVariant={true}
       >
         <SectionHeader title="Browse by theme" gridSize={gridSize12()} />
-        <ContaineredLayout gridSizes={gridSize12()}>
-          <BrowseByThemes
-            themeConfig={themeBlockCategories}
-            initialConcepts={featuredConcepts}
-          />
-        </ContaineredLayout>
+        <BrowseByThemes
+          themeConfig={themeBlockCategories}
+          initialConcepts={featuredConcepts}
+          gridSizes={gridSize12()}
+        />
       </MainBackground>
 
       {fullWidthBanners?.[0] && (


### PR DESCRIPTION
## What does this change?

This addresses the last comment in #12271, "The slider behaviour should be the same as Related works in stories (so fully to the edge of the browser on the right, then it scrolls past the left edge)."

- allows the browse by theme section to be full width
- adds a shim to left align the theme section
- allows the scrollContainer.Navigation component to take an optional customScrollDistance value
- uses the customScrollDistance for the browse by theme section - this ensures the scrolling always moves the appropriate amount

## How to test

- visit the collections landing page with the collectionsLanding toggle enabled
-  Try using the Browse by theme component

## How can we measure success?

It behaves as expected

## Have we considered potential risks?

None I can think of

