### PR TITLE
Add GTM tracking to ThemePromo cards

### DIFF
--- a/common/views/components/ThemePromo/index.tsx
+++ b/common/views/components/ThemePromo/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import { Image } from '@weco/content/services/wellcome/catalogue/types';
@@ -110,6 +111,7 @@ export type ThemePromoProps = {
   title: string;
   description?: string;
   url: string;
+  dataGtmProps?: DataGtmProps;
 };
 
 const ThemePromo: FunctionComponent<ThemePromoProps> = ({
@@ -117,6 +119,7 @@ const ThemePromo: FunctionComponent<ThemePromoProps> = ({
   title,
   description,
   url,
+  dataGtmProps,
 }) => {
   const imageCount = images.filter(Boolean).length;
   const isSingleImage = imageCount === 1;
@@ -135,7 +138,11 @@ const ThemePromo: FunctionComponent<ThemePromoProps> = ({
   });
 
   return (
-    <CardWrapper data-component="theme-promo" href={url}>
+    <CardWrapper
+      data-component="theme-promo"
+      href={url}
+      {...dataGtmPropsToAttributes(dataGtmProps)}
+    >
       <CompositeGrid $isSingleImage={isSingleImage}>
         {slots.map((slot, index) => (
           <ImageContainer

--- a/content/webapp/views/components/SelectableTags/index.tsx
+++ b/content/webapp/views/components/SelectableTags/index.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import AnimatedUnderlineCSS, {
   AnimatedUnderlineProps,
 } from '@weco/common/views/components/styled/AnimatedUnderline';
@@ -105,7 +106,7 @@ export const SelectableTags: FunctionComponent<SelectableTagsProps> = ({
   return (
     <div data-component="selectable-tags">
       <TagsWrapper className={font('intm', 5)}>
-        {tags.map(tag => {
+        {tags.map((tag, index) => {
           const isSelected = selected.includes(tag.id);
           return (
             <div key={tag.id}>
@@ -116,6 +117,11 @@ export const SelectableTags: FunctionComponent<SelectableTagsProps> = ({
                   value={tag.id}
                   checked={isSelected}
                   onChange={() => handleTagClick(tag.id)}
+                  {...dataGtmPropsToAttributes({
+                    trigger: 'selectable_tag',
+                    'position-in-list': String(index + 1),
+                    label: tag.id,
+                  })}
                   {...(tag.controls && { 'aria-controls': tag.controls })}
                 />
               ) : (
@@ -126,6 +132,11 @@ export const SelectableTags: FunctionComponent<SelectableTagsProps> = ({
                   value={tag.id}
                   checked={isSelected}
                   onChange={() => handleTagClick(tag.id)}
+                  {...dataGtmPropsToAttributes({
+                    trigger: 'selectable_tag',
+                    'position-in-list': String(index + 1),
+                    label: tag.id,
+                  })}
                   {...(tag.controls && { 'aria-controls': tag.controls })}
                 />
               )}

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -27,7 +27,12 @@ const ListItem = styled.li`
   margin-right: var(--gap);
 `;
 
-const Theme: FunctionComponent<{ concept: Concept }> = ({ concept }) => {
+const Theme: FunctionComponent<{
+  concept: Concept;
+  categoryLabel: string;
+  categoryPosition: number;
+  positionInList: number;
+}> = ({ concept, categoryLabel, categoryPosition, positionInList }) => {
   const linkProps = toConceptLink({ conceptId: concept.id });
   const images = useConceptImageUrls(concept);
   const url = linkProps.href.pathname;
@@ -38,6 +43,13 @@ const Theme: FunctionComponent<{ concept: Concept }> = ({ concept }) => {
       title={title}
       description={concept.description?.text}
       url={url}
+      dataGtmProps={{
+        trigger: 'theme_promo_card',
+        'category-label': categoryLabel,
+        'category-position-in-list': String(categoryPosition),
+        id: concept.id,
+        'position-in-list': String(positionInList),
+      }}
     />
   ) : null;
 };
@@ -53,11 +65,17 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
 
   const [displayedConcepts, setDisplayedConcepts] =
     useState<Concept[]>(initialConcepts);
+  const [selectedCategoryLabel, setSelectedCategoryLabel] = useState<string>(
+    themeConfig.categories[0]?.label || ''
+  );
 
   // Set the cache with the first category and display it
   useEffect(() => {
     const firstLabel = themeConfig.categories[0]?.label;
-    if (firstLabel) setCache(firstLabel, initialConcepts);
+    if (firstLabel) {
+      setCache(firstLabel, initialConcepts);
+      setSelectedCategoryLabel(firstLabel);
+    }
     setDisplayedConcepts(initialConcepts);
   }, [initialConcepts, themeConfig.categories, setCache]);
 
@@ -67,6 +85,7 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
       cat => cat.label === selectedCategoryId
     );
     if (category) {
+      setSelectedCategoryLabel(category.label);
       const result = await fetchConcepts(category);
       setDisplayedConcepts(result);
     }
@@ -76,6 +95,11 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
     id: category.label,
     label: category.label,
   }));
+
+  const selectedCategoryPosition =
+    themeConfig.categories.findIndex(
+      cat => cat.label === selectedCategoryLabel
+    ) + 1;
 
   return (
     <Space
@@ -90,9 +114,14 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
         />
       </Space>
       <ScrollContainer scrollButtonsAfter={true}>
-        {displayedConcepts.map(concept => (
+        {displayedConcepts.map((concept, index) => (
           <ListItem key={concept.id}>
-            <Theme concept={concept} />
+            <Theme
+              concept={concept}
+              categoryLabel={selectedCategoryLabel}
+              categoryPosition={selectedCategoryPosition}
+              positionInList={index + 1}
+            />
           </ListItem>
         ))}
       </ScrollContainer>


### PR DESCRIPTION
Adds click tracking to ThemePromo cards on the /collections page.

## Changes
- ThemePromo cards now track clicks with the following GTM attributes:
  - `data-gtm-trigger`: 'theme_promo_card'
  - `data-gtm-category-label`: Name of the selected pill/category
  - `data-gtm-category-position-in-list`: Position of the category (1-indexed)
  - `data-gtm-id`: Concept ID of the card
  - `data-gtm-position-in-list`: Position of the card within the list (1-indexed)
  
- SelectableTags now track pill selections with position and label

## Implementation
- Added `dataGtmProps` parameter to ThemePromo component
- Updated BrowseByThemes to track selected category state and pass tracking data
- Used `dataGtmPropsToAttributes` utility to convert props to data attributes