### PR TITLE
Collections a11y qa

### DIFF
--- a/common/views/components/SearchBar/SearchBar.New.tsx
+++ b/common/views/components/SearchBar/SearchBar.New.tsx
@@ -36,6 +36,10 @@ const Typewriter = styled.div.attrs({
   overflow: hidden;
   text-wrap: nowrap;
   text-overflow: ellipsis;
+
+  @media (prefers-reduced-motion: reduce) {
+    display: none;
+  }
 `;
 
 const SearchInputWrapper = styled.div`

--- a/common/views/components/SearchBar/SearchBar.New.tsx
+++ b/common/views/components/SearchBar/SearchBar.New.tsx
@@ -31,7 +31,7 @@ const Typewriter = styled.div.attrs({
   transform: translateY(-50%);
   left: 20px;
   z-index: 1;
-  color: ${props => props.theme.color('neutral.500')};
+  color: ${props => props.theme.color('neutral.600')};
   width: calc(100% - 32px);
   overflow: hidden;
   text-wrap: nowrap;

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
@@ -118,7 +118,8 @@ const ScrollableNavigation: FunctionComponent<Props> = ({
         onClick={() => scrollByChildImageWidth('left')}
       >
         <Icon icon={arrowSmall} rotate={180} />
-        Prev
+        <span aria-hidden="true">Prev</span>
+        <span className="visually-hidden">Previous</span>
       </ScrollButton>
 
       <ScrollButton

--- a/content/webapp/views/components/SelectableTags/index.tsx
+++ b/content/webapp/views/components/SelectableTags/index.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
+import { toHtmlId } from '@weco/common/utils/grammar';
 import AnimatedUnderlineCSS, {
   AnimatedUnderlineProps,
 } from '@weco/common/views/components/styled/AnimatedUnderline';
@@ -111,7 +112,7 @@ export const SelectableTags: FunctionComponent<SelectableTagsProps> = ({
             <div key={tag.id}>
               {isMultiSelect ? (
                 <InputField
-                  id={tag.id}
+                  id={toHtmlId(tag.id)}
                   type="checkbox"
                   value={tag.id}
                   checked={isSelected}
@@ -120,7 +121,7 @@ export const SelectableTags: FunctionComponent<SelectableTagsProps> = ({
                 />
               ) : (
                 <InputField
-                  id={tag.id}
+                  id={toHtmlId(tag.id)}
                   type="radio"
                   name="selectable-tags"
                   value={tag.id}
@@ -132,7 +133,7 @@ export const SelectableTags: FunctionComponent<SelectableTagsProps> = ({
               <StyledInput
                 as="label"
                 key={tag.id}
-                htmlFor={tag.id}
+                htmlFor={toHtmlId(tag.id)}
                 $isSelected={!!isSelected}
                 $lineColor={isSelected ? 'white' : 'black'}
                 $lineThickness={1.4}

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -86,7 +86,7 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
       $v={{ size: 'm', properties: ['margin-top'] }}
       data-component="BrowseByThemes"
     >
-      <div className="visually-hidden" aria-live="polite" aria-atomic="true">
+      <div className="visually-hidden" aria-live="polite">
         {announcement}
       </div>
       <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -53,6 +53,7 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
 
   const [displayedConcepts, setDisplayedConcepts] =
     useState<Concept[]>(initialConcepts);
+  const [announcement, setAnnouncement] = useState('');
 
   // Set the cache with the first category and display it
   useEffect(() => {
@@ -69,6 +70,9 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
     if (category) {
       const result = await fetchConcepts(category);
       setDisplayedConcepts(result);
+      setAnnouncement(
+        `Showing ${result.length} ${category.label.toLowerCase()} ${result.length === 1 ? 'theme' : 'themes'}`
+      );
     }
   };
 
@@ -82,6 +86,9 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
       $v={{ size: 'm', properties: ['margin-top'] }}
       data-component="BrowseByThemes"
     >
+      <div className="visually-hidden" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </div>
       <Space $v={{ size: 'm', properties: ['margin-bottom'] }}>
         <SelectableTags
           tags={tagData}


### PR DESCRIPTION
## What does this change?

Addresses various a11y issues arising from #12350 (I hadn't intended to do this, but in testing theories about why certain things weren't working it made more sense to put the end result in a PR).

## How to test
- Check screenreader announces number of ThemePromos (and the topic) when the theme radio button selection changes
- Check the contrast of the Typewriter is WCAG AA compliant
- Check NVDA announces 'people and organisations' when it is the selected radio button
- Check the 'prev' button is announced as 'previous' by screenreaders

## How can we measure success?

Site is more accessible than before

## Have we considered potential risks?

Can't think of any
