### PR TITLE
Update label copy for SearchBar.New

### DIFF
--- a/common/views/components/SearchForm/index.tsx
+++ b/common/views/components/SearchForm/index.tsx
@@ -78,7 +78,11 @@ const SearchForm = ({
         inputValue={inputValue}
         setInputValue={setInputValue}
         form={formId}
-        placeholder={searchLabelText[searchCategory]}
+        placeholder={
+          isNew
+            ? 'Search for books, artworks, images, videos, archives and more'
+            : searchLabelText[searchCategory]
+        }
         inputRef={inputRef}
         location={location}
       />


### PR DESCRIPTION
## What does this change?
Matches the SearchBar label to the design per [QA comment](https://github.com/wellcomecollection/wellcomecollection.org/issues/12341#issuecomment-3386208284)

<img width="1163" height="204" alt="image" src="https://github.com/user-attachments/assets/6cc5d627-710f-4aaf-8f8a-dca2a8b7d351" />

## How to test
- Visit /collections
- Check the label says 'Search for books, artworks, images, videos, archives and more'

## How can we measure success?
UI matches designs

## Have we considered potential risks?
This bypasses the microcopy file for now, but it didn't feel necessary to turn `searchLabelText` into a function that accepted the `isNew` value in order to return the different copy.

