### PR TITLE
Add 404 should the page not be fetched properly

### DIFF
--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -102,45 +102,50 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       client,
       prismicPageIds.newCollections
     );
-    const collectionsPage = transformPage(
-      collectionsPagePromise as RawPagesDocument
-    );
 
-    const insideOurCollectionsCards =
-      getInsideOurCollectionsCards(collectionsPage);
+    if (isNotUndefined(collectionsPagePromise)) {
+      const collectionsPage = transformPage(
+        collectionsPagePromise as RawPagesDocument
+      );
 
-    // Fetch featured concepts for the theme block
-    const featuredConcepts = await fetchFeaturedConcepts();
+      const insideOurCollectionsCards =
+        getInsideOurCollectionsCards(collectionsPage);
 
-    const bannerOne = collectionsPage.untransformedBody.find(
-      slice => slice.slice_type === 'fullWidthBanner'
-    );
+      // Fetch featured concepts for the theme block
+      const featuredConcepts = await fetchFeaturedConcepts();
 
-    const bannerTwo = collectionsPage.untransformedBody.find(
-      slice =>
-        slice.slice_type === 'fullWidthBanner' && slice.id !== bannerOne?.id
-    );
+      const bannerOne = collectionsPage.untransformedBody.find(
+        slice => slice.slice_type === 'fullWidthBanner'
+      );
 
-    const fullWidthBanners = [bannerOne, bannerTwo]
-      .filter(isNotUndefined)
-      .filter(isFullWidthBanner);
+      const bannerTwo = collectionsPage.untransformedBody.find(
+        slice =>
+          slice.slice_type === 'fullWidthBanner' && slice.id !== bannerOne?.id
+      );
 
-    return {
-      props: serialiseProps({
-        hasNewPageToggle: true,
-        pageMeta: {
-          id: collectionsPage.id,
-          image: collectionsPage.promo?.image,
-          description: collectionsPage.promo?.caption,
-        },
-        title: collectionsPage.title,
-        introText: collectionsPage.introText ?? [],
-        insideOurCollectionsCards,
-        featuredConcepts,
-        fullWidthBanners,
-        serverData,
-      }),
-    };
+      const fullWidthBanners = [bannerOne, bannerTwo]
+        .filter(isNotUndefined)
+        .filter(isFullWidthBanner);
+
+      return {
+        props: serialiseProps({
+          hasNewPageToggle: true,
+          pageMeta: {
+            id: collectionsPage.id,
+            image: collectionsPage.promo?.image,
+            description: collectionsPage.promo?.caption,
+          },
+          title: collectionsPage.title,
+          introText: collectionsPage.introText ?? [],
+          insideOurCollectionsCards,
+          featuredConcepts,
+          fullWidthBanners,
+          serverData,
+        }),
+      };
+    } else {
+      return { notFound: true };
+    }
   }
 
   return page.getServerSideProps({


### PR DESCRIPTION
## What does this change?

Adds a check (as we have in our other pages) before trying to return data as to whether or not the Prismic fetch was successful.

## How to test

Change the fetch so it fails (e.g. change the id of the page) and see if it returns a 404. 
I wasn't sure about the type of error we should send as it's unlikely to be a 404 (although it could be if the page was accidentally deleted), but it's what we have everywhere else. TBF if/when Prismic fails, we have a banner we put up site-wide to explain site-wide failures.

## How can we measure success?

A bit clearer when failing

## Have we considered potential risks?
N/A 