### PR TITLE
Move typewriter proportional to bottom of input

### DIFF
--- a/common/views/components/SearchBar/SearchBar.New.tsx
+++ b/common/views/components/SearchBar/SearchBar.New.tsx
@@ -27,8 +27,7 @@ const Typewriter = styled.div.attrs({
 })`
   position: absolute;
   pointer-events: none;
-  top: calc(50% + 12px);
-  transform: translateY(-50%);
+  bottom: 18px;
   left: 20px;
   z-index: 1;
   color: ${props => props.theme.color('neutral.600')};
@@ -36,6 +35,10 @@ const Typewriter = styled.div.attrs({
   overflow: hidden;
   text-wrap: nowrap;
   text-overflow: ellipsis;
+
+  ${props => props.theme.media('medium')`
+    bottom: 22px;
+  `}
 
   @media (prefers-reduced-motion: reduce) {
     display: none;


### PR DESCRIPTION
For [this part](https://github.com/dana-saur) of the Collections QA (#12341)


## What does this change?

Using a percentage from the top doesn't account for the fact the label can break onto two lines which then changes the amount the text is shifted down. The bottom of the element is consistent.

## How to test

View the input with typewriter visible on a large screen and a small screen. On the small screen make sure that the label breaks onto two lines. Make sure the typewriter text remains vertically centred in the input throughout.

## How can we measure success?
Looks like designs

## Have we considered potential risks?
Can't think of any. It would be nicer to be able to position the typewriter relative to the input rather than the input + label, but that would be a larger piece of work while this will do fine for now
