### PR TITLE
Update typewriter to animate once per time in viewport

### DIFF
--- a/common/views/components/SearchBar/SearchBar.New.tsx
+++ b/common/views/components/SearchBar/SearchBar.New.tsx
@@ -207,39 +207,22 @@ const SearchBar: FunctionComponent<Props> = ({
         ];
 
       const element = typewriterRef.current;
-      const isFirstAnimation = animationTrigger === 0;
 
       // Reset opacity before starting animation
       element.style.opacity = '1';
       element.style.transition = '';
 
-      let typed: Typed;
-      let initTimeout: NodeJS.Timeout;
-
-      const initTyped = () => {
-        typed = new Typed(element, {
-          strings: [selectedString],
-          startDelay: 1000,
-          typeSpeed: 50,
-          shuffle: false,
-          loop: false,
-          showCursor: false,
-        });
-      };
-
-      if (isFirstAnimation) {
-        // First animation: start immediately with its own startDelay
-        initTyped();
-      } else {
-        // Subsequent animations: wait 1 second before initialising Typed
-        initTimeout = setTimeout(initTyped, 1000);
-      }
+      const typed = new Typed(element, {
+        strings: [selectedString],
+        startDelay: 1000,
+        typeSpeed: 50,
+        shuffle: false,
+        loop: false,
+        showCursor: false,
+      });
 
       return () => {
-        clearTimeout(initTimeout);
-        if (typed) {
-          typed.destroy();
-        }
+        typed.destroy();
       };
     }
   }, [animationTrigger]);


### PR DESCRIPTION
For #12357
## What does this change?

Stops the typewriter animation after one string, then plays a different animated string after the search bar has first gone out then back into the viewport.

https://github.com/user-attachments/assets/c04a5bea-15a7-4449-89c9-dc46fde073f3


- [x] @dana-saur to confirm fading out/hiding of the animation after it has run is what we want



## How to test
Visit /collections and check that that's what happens


## How can we measure success?
WCAG compliant

## Have we considered potential risks?
Can't think of any
