### PR TITLE
Remove `relatedContentOnWorks` toggle

### DIFF
--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { useToggles } from '@weco/common/server-data/Context';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Divider from '@weco/common/views/components/Divider';
 import SearchForm from '@weco/common/views/components/SearchForm';
@@ -58,7 +57,6 @@ export const WorkPage: NextPage<Props> = ({
   apiUrl,
   transformedManifest,
 }) => {
-  const { relatedContentOnWorks } = useToggles();
   const { userIsStaffWithRestricted } = useUserContext();
   const isArchive = !!(
     work.parts.length ||
@@ -195,7 +193,7 @@ export const WorkPage: NextPage<Props> = ({
         )}
 
         {/* If the work has no subjects, it's not worth adding this component */}
-        {relatedContentOnWorks && hasAtLeastOneSubject(work.subjects) && (
+        {hasAtLeastOneSubject(work.subjects) && (
           <RelatedWorks
             workId={work.id}
             subjects={work.subjects}

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -115,13 +115,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'relatedContentOnWorks',
-      title: 'Related content on works',
-      initialValue: false,
-      description: 'Shows related content on works pages',
-      type: 'experimental',
-    },
-    {
       id: 'collectionsLanding',
       title: 'Collections landing alternative page',
       initialValue: false,


### PR DESCRIPTION
## What does this change?
[#12387](https://github.com/wellcomecollection/wellcomecollection.org/issues/12387)
Pretty easy change, here.

I'll deploy the changes to dash once this is in prod.

## How to test

Do they still show on [a works page](www-dev.wellcomecollection.org/works/a2239muq) in incognito mode? 

## How can we measure success?

One less toggle

## Have we considered potential risks?
N/A