### PR TITLE
Don't track 100% scroll

### DIFF
--- a/common/hooks/useScrollTracking.ts
+++ b/common/hooks/useScrollTracking.ts
@@ -11,7 +11,6 @@ export function useScrollTracking() {
       tracked50: false,
       tracked75: false,
       tracked90: false,
-      tracked100: false,
     };
 
     const handleScroll = () => {
@@ -29,7 +28,6 @@ export function useScrollTracking() {
         { value: 50, key: 'tracked50' as const },
         { value: 75, key: 'tracked75' as const },
         { value: 90, key: 'tracked90' as const },
-        { value: 100, key: 'tracked100' as const },
       ];
 
       thresholds.forEach(({ value, key }) => {
@@ -59,7 +57,6 @@ export function useScrollTracking() {
         tracked50: false,
         tracked75: false,
         tracked90: false,
-        tracked100: false,
       };
     };
 


### PR DESCRIPTION
For #12141

## What does this change?

Doesn't push a 100% page scrolled event into the `dataLayer` because it isn't required. I've removed the `wc_scroll_depth_100` GTM tag and trigger as well.

## How to test

Turn on GA Analytics Debugger browser extension. Check that 25, 50, 75, and 90 still fire but 100 doesn't.

## How can we measure success?

Mankeet's happy

## Have we considered potential risks?

Can't think of any
