### PR TITLE
Use active service when available

### DIFF
--- a/content/webapp/services/iiif/transformers/manifest.ts
+++ b/content/webapp/services/iiif/transformers/manifest.ts
@@ -1,4 +1,4 @@
-import { Collection, Manifest } from '@iiif/presentation-3';
+import { AuthAccessService2, Collection, Manifest } from '@iiif/presentation-3';
 
 import { TransformedManifest } from '@weco/content/types/manifest';
 import {
@@ -61,7 +61,9 @@ export function transformManifest(
     getExternalAuthAccessService(authAccessServices); // equivalent of restrictedService
   const activeAccessService = getActiveAuthAccessService(authAccessServices); // equivalent of clickThroughService
   const v2TokenService = getV2TokenService(
-    externalAccessService || externalAccessService
+    (activeAccessService || externalAccessService) as
+      | AuthAccessService2
+      | undefined
   ); // equivalent of tokenService
 
   // We should default to using the v2 services (TODO work in progress).


### PR DESCRIPTION
## What does this change?

For [#12382](https://github.com/wellcomecollection/wellcomecollection.org/issues/12382)

We should be trying to use the active service (used for clickthrough) then the external service (used for restricted). There was a mistake in the code where we were trying to use the external service both times for v2 services so we weren't seeing the clickthrough modal.

## How to test

- turn on the Auth IIIF V2 toggle
- [visit an item that should display a modal](https://www-dev.wellcomecollection.org/works/fa7pymra/items)
- check the modal is displayed and the clickthrough functionality works
- N.B. when using v1 services a cookie called dlcs-token-2 will be set, when using v2 services a cookie called dlcs-auth2-2 will be set - you should be seeing the latter

## How can we measure success?
We can turn on the V2 toggle for everyone
(then when we're happy we can remove all the v1 code)

## Have we considered potential risks?

We break something else. I've checked [various restricted items](https://github.com/wellcomecollection/wellcomecollection.org/wiki/Examples-of-things-from-the-collections#restricted-access) and all seems ok

