### PR TITLE
Add gtm attribute to know if form submission is result of filter change

### DIFF
--- a/content/webapp/views/pages/search/events/index.tsx
+++ b/content/webapp/views/pages/search/events/index.tsx
@@ -59,13 +59,18 @@ const EventsSearchPage: NextPage<Props> = withSearchLayout(
                 searchFormId={SEARCH_PAGES_FORM_ID}
                 changeHandler={() => {
                   const form = document.getElementById(SEARCH_PAGES_FORM_ID);
-                  form &&
+                  if (form) {
+                    // Set data attribute to indicate this is a filter change, not a query change
+                    form.dataset.gtmIsFilterChange = 'true';
                     form.dispatchEvent(
                       new window.Event('submit', {
                         cancelable: true,
                         bubbles: true,
                       })
                     );
+                    // Remove the attribute after dispatch
+                    delete form.dataset.gtmIsFilterChange;
+                  }
                 }}
                 filters={filters}
                 hasNoResults={hasNoResults}

--- a/content/webapp/views/pages/search/images/index.tsx
+++ b/content/webapp/views/pages/search/images/index.tsx
@@ -129,13 +129,18 @@ const ImagesSearchPage: NextPage<Props> = withSearchLayout(
                 searchFormId={SEARCH_PAGES_FORM_ID}
                 changeHandler={() => {
                   const form = document.getElementById(SEARCH_PAGES_FORM_ID);
-                  form &&
+                  if (form) {
+                    // Set data attribute to indicate this is a filter change, not a query change
+                    form.dataset.gtmIsFilterChange = 'true';
                     form.dispatchEvent(
                       new window.Event('submit', {
                         cancelable: true,
                         bubbles: true,
                       })
                     );
+                    // Remove the attribute after dispatch
+                    delete form.dataset.gtmIsFilterChange;
+                  }
                 }}
                 filters={filters}
                 hasNoResults={hasNoResults}

--- a/content/webapp/views/pages/search/stories/index.tsx
+++ b/content/webapp/views/pages/search/stories/index.tsx
@@ -93,13 +93,18 @@ const StoriesSearchPage: NextPage<Props> = withSearchLayout(
                 searchFormId={SEARCH_PAGES_FORM_ID}
                 changeHandler={() => {
                   const form = document.getElementById(SEARCH_PAGES_FORM_ID);
-                  form &&
+                  if (form) {
+                    // Set data attribute to indicate this is a filter change, not a query change
+                    form.dataset.gtmIsFilterChange = 'true';
                     form.dispatchEvent(
                       new window.Event('submit', {
                         cancelable: true,
                         bubbles: true,
                       })
                     );
+                    // Remove the attribute after dispatch
+                    delete form.dataset.gtmIsFilterChange;
+                  }
                 }}
                 filters={filters}
                 hasNoResults={hasNoResults}

--- a/content/webapp/views/pages/search/works.tsx/index.tsx
+++ b/content/webapp/views/pages/search/works.tsx/index.tsx
@@ -114,13 +114,18 @@ const WorksSearchPage: NextPage<Props> = withSearchLayout(
                     changeHandler={() => {
                       const form =
                         document.getElementById(SEARCH_PAGES_FORM_ID);
-                      form &&
+                      if (form) {
+                        // Set data attribute to indicate this is a filter change, not a query change
+                        form.dataset.gtmIsFilterChange = 'true';
                         form.dispatchEvent(
                           new window.Event('submit', {
                             cancelable: true,
                             bubbles: true,
                           })
                         );
+                        // Remove the attribute after dispatch
+                        delete form.dataset.gtmIsFilterChange;
+                      }
                     }}
                     filters={filters}
                     hasNoResults={hasNoResults}


### PR DESCRIPTION
For #12430

## What does this change?

We previously listened for click events on the search button to try to get the user's query. This was good in that it wouldn't fire when the filters changed, but bad because it was always out by one. Now we've updated the GTM trigger to fire on form submit events, but that means it _will_ fire even as a result of filter changes which we don't want. This PR adds a `data-gtm-is-filter-change` attribute at the appropriate times so that we can filter out forms with that attribute in GTM.

## How to test

- Preview the current changes in GTM
- Go to the [search page locally](http://localhost:3000/search/works)
- Search for something, and check that the `internal_site_search_page` event fires in the GA tab, with whatever you searched for sent along as a `query` `event.parameter`
- Filter the search using any of the drop-downs and check that another `internal_site_search_page` event isn't sent

## How can we measure success?

We can measure stuff in GTM/GA

## Have we considered potential risks?

More GTM-specific code in the repo but it's gtm-namespaced so I think it's ok
