### PR TITLE
Make the auth-modal heading an h1

### DIFF
--- a/content/webapp/views/pages/works/work/items.tsx
+++ b/content/webapp/views/pages/works/work/items.tsx
@@ -260,7 +260,10 @@ const WorkItemPage: NextPage<Props> = ({
       >
         <div className={font('intr', 5)}>
           {modalContent?.label && (
-            <h2 className={font('intb', 4)}>{modalContent?.label}</h2>
+            // When this modal is displayed, the rest of the page is hidden and we need to make
+            // sure there is an appropriate h1 available to assistive technologies
+            // https://github.com/wellcomecollection/wellcomecollection.org/issues/7545
+            <h1 className={font('intb', 4)}>{modalContent?.label}</h1>
           )}
           {modalContent?.description && (
             <div


### PR DESCRIPTION
For #7545 

## What does this change?
Changes the heading level in the `auth-modal` from an h2 to an h1. I started by (I think) overcomplicating it and checking for the presence of an h1 with JS, but think

1. Because this is a specific instance of a modal that will _always_ hide the other page content, we can be confident that it always needs to be an h1 here
2. Even if 1. weren't true, the check would run on mount, but if the h1 is added to the DOM after this component mounts it wouldn't be detected, so probably wouldn't have been a bullet-proof strategy anyhow

## How to test
- Visit an item page with a content advisory notice e.g. http://localhost:3000/works/fa7pymra/items
- Check that 'Content advisory' is the h1, and that there aren't any other h1s rendered in the dev-tools elements tab

## How can we measure success?
Fewer a11y bugs

## Have we considered potential risks?
If we update the part of the page that _is_ visible when this advisory notice is visible (not this component) to render an h1 in the future then we'll have two h1s on the page. I think this is unlikely
