### PR TITLE
Only include tab/tabpanel-specific attributes if there are tabs present

### DIFF
--- a/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
@@ -107,9 +107,11 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
           data-testid="works-section"
         >
           <div
-            role="tabpanel"
-            id={`tabpanel-${selectedTab}`}
-            aria-labelledby={`tab-${selectedTab}`}
+            {...(tabs.length > 1 && {
+              role: 'tabpanel',
+              id: `tabpanel-${selectedTab}`,
+              'aria-labelledby': `tab-${selectedTab}`,
+            })}
           >
             <WorksCount>
               {pluralize(activePanel.works.totalResults, 'work')}


### PR DESCRIPTION
For #10598 

## What does this change?

Conditionally adds the tab/tabpanel attributes if the tabs are actually rendering (`tabs.length > 1`).

## How to test

- Visit a [concept that doesn't have tabs](http://localhost:3000/concepts/bxmsz6xt) in the 'Works from the collections' section. Check the `role="tabpanel"` and other associated attributes aren't rendered
- Visit a [concept that has tabs](http://localhost:3000/concepts/fmydsuw2). Check the tabpanel attributes are present.

## How can we measure success?

Improved accessibility

## Have we considered potential risks?

Can't think of any

