### PR TITLE
Map l to md instead of lg

### DIFF
--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -305,7 +305,7 @@ const designSystemSpacing: Record<SpaceSize, ResponsiveSpaceValue> = {
   xs: designSystemTheme.spacing.responsive['space.2xs'],
   s: designSystemTheme.spacing.responsive['space.xs'],
   m: designSystemTheme.spacing.responsive['space.sm'],
-  l: designSystemTheme.spacing.responsive['space.lg'],
+  l: designSystemTheme.spacing.responsive['space.md'],
   xl: designSystemTheme.spacing.responsive['space.xl'],
 };
 


### PR DESCRIPTION
## What does this change?

@dana-saur noticed that there was extra space coming from somewhere. Looking at the mappings that I'd put in from our existing values to the design system values, the `l` was incorrectly mapped to `L` from the design system. It should have been mapped to `md` ([notion table](https://www.notion.so/wellcometrust/07-How-existing-tokens-map-to-new-values-and-names-17e6687658a18058bd57c3805d079635)).

Spacing Values Comparison (Updated)

| Size | Breakpoint | Old Value | Design System Value | Notes |
|------|------------|-----------|-------------------|-------|
| **xs** | small | 4px | 0.25rem (4px) | Identical |
| **xs** | medium | 4px | 0.25rem (4px) | Identical |
| **xs** | large | 4px | 0.25rem (4px) | Identical |
| **s** | small | 6px | 0.375rem (6px) | Identical |
| **s** | medium | 6px | 0.5rem (8px) | +2px difference |
| **s** | large | 8px | 0.5rem (8px) | Identical |
| **m** | small | 8px | 0.5rem (8px) | Identical |
| **m** | medium | 12px | 0.75rem (12px) | Identical |
| **m** | large | 16px | 1rem (16px) | Identical |
| **l** | small | 16px | 1rem (16px) | Identical |
| **l** | medium | 24px | 1.5rem (24px) | Identical |
| **l** | large | 32px | 2rem (32px) | Identical |
| **xl** | small | 30px | 2rem (32px) | +2px difference |
| **xl** | medium | 46px | 3rem (48px) | +2px difference |
| **xl** | large | 64px | 4rem (64px) | Identical |

Much better. With the updated mappings (`l → space.md` and `xl → space.xl`), the values are very close. The only differences are:
- **s** at medium: 6px → 8px (+2px)
- **xl** at small: 30px → 32px (+2px)
- **xl** at medium: 46px → 48px (+2px)

All other sizes match exactly.

## How to test

For Dana to QA behind toggle

## How can we measure success?

Site looks closer to how it did previously

## Have we considered potential risks?

Behind a toggle so all good
