### PR TITLE
Make distinction between selected/unseleceted tab after removing intm behind toggle

### DIFF
--- a/content/webapp/views/components/Tabs/Tabs.Navigate.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.Navigate.tsx
@@ -2,6 +2,7 @@ import Link, { LinkProps } from 'next/link';
 import { FunctionComponent } from 'react';
 
 import { IconSvg } from '@weco/common/icons';
+import { useToggles } from '@weco/common/server-data/Context';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -35,12 +36,19 @@ const TabsNavigate: FunctionComponent<Props> = ({
   currentSection,
   isWhite,
 }: Props) => {
+  const { designSystemFonts } = useToggles();
+
   return (
     <TabsContainer aria-label={label}>
       {items.map(item => {
         const isSelected = currentSection === item.id;
         return (
-          <Tab key={item.id} $selected={isSelected} $hideBorder={hideBorder}>
+          <Tab
+            key={item.id}
+            $selected={isSelected}
+            $hideBorder={hideBorder}
+            $designSystemFonts={designSystemFonts}
+          >
             <Link
               scroll={false}
               href={typeof item.url === 'string' ? item.url : item.url.href}

--- a/content/webapp/views/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.Switch.tsx
@@ -9,6 +9,7 @@ import {
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { IconSvg } from '@weco/common/icons';
+import { useToggles } from '@weco/common/server-data/Context';
 import { toSnakeCase } from '@weco/common/utils/grammar';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Icon from '@weco/common/views/components/Icon';
@@ -51,6 +52,7 @@ const TabsSwitch: FunctionComponent<Props> = ({
   isWhite,
 }: Props) => {
   const { isEnhanced } = useAppContext();
+  const { designSystemFonts } = useToggles();
   const tabListRef = useRef<HTMLDivElement>(null);
 
   function focusTabAtIndex(index: number): void {
@@ -114,6 +116,7 @@ const TabsSwitch: FunctionComponent<Props> = ({
             $selected={isSelected}
             $isWhite={isWhite}
             $hideBorder={hideBorder}
+            $designSystemFonts={designSystemFonts}
             onClick={e => {
               if (!(item.id === selectedTab)) {
                 (e.target as HTMLButtonElement).scrollIntoView({

--- a/content/webapp/views/components/Tabs/Tabs.styles.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.styles.tsx
@@ -46,10 +46,13 @@ type NavItemProps = {
   $selected: boolean;
   $isWhite?: boolean;
   $hideBorder?: boolean;
+  $designSystemFonts?: boolean;
 };
 
-export const Tab = styled.div.attrs<{ $selected?: boolean }>(props => ({
-  className: font(props.$selected ? 'intsb' : 'intm', 5),
+export const Tab = styled.div.attrs<NavItemProps>(props => ({
+  className: props.$designSystemFonts
+    ? font(props.$selected ? 'intsb' : 'intr', 5)
+    : font(props.$selected ? 'intsb' : 'intm', 5),
 }))<NavItemProps>`
   padding: 0;
   margin: 0;


### PR DESCRIPTION
For #12318 

## What does this change?

The selected and unselected tab weights were semi-bold and medium respectively. We're removing medium with the design system changes, so in order to keep the distinction this PR makes the unselected tab regular instead.


## How to test

- Turn on the [fonts toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=designSystemFonts)
- Visit a page with tabs (e.g. [what's on](http://localhost:3000/whats-on))
- Check the selected/unselected font weights are semi-bold/regular respectively

## How can we measure success?

Better UI

## Have we considered potential risks?

Can't think of any
