### PR TITLE
Use line-height values from design system behind toggle

### DIFF
--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -189,7 +189,10 @@ export const typography = css<GlobalStyleProps>`
   body {
     ${fontFamilyMixin('intr', true)}
     ${fontSizeMixin(4)}
-    line-height: 1.5;
+    line-height: ${props =>
+      props.toggles?.designSystemFonts?.value
+        ? designSystemTheme['line-height'].lg
+        : '1.5'};
     color: ${props => props.theme.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
@@ -207,6 +210,10 @@ export const typography = css<GlobalStyleProps>`
     font-size: 1em;
     margin: 0 0 0.6em;
     text-wrap-style: balance;
+    line-height: ${props =>
+      props.toggles?.designSystemFonts?.value
+        ? designSystemTheme['line-height'].md
+        : undefined};
   }
 
   /*
@@ -283,7 +290,9 @@ export const typography = css<GlobalStyleProps>`
   }
 
   .body-text {
-    line-height: 1.6;
+    /* if we're using the design system, the value we want (1.5) is already set on body */
+    line-height: ${props =>
+      props.toggles?.designSystemFonts?.value ? undefined : '1.6'};
     letter-spacing: 0.0044em;
 
     h1 {


### PR DESCRIPTION
For #12318 

## What does this change?

Uses the `line-height` values from the design system behind the `designSystemFonts` toggle. I only changed the heading and body values. There are other line-height declarations in the codebase, but I believe that they are for the most part set in order to accomplish bits of UI alignment that shouldn't be considered as part of a system.

All body copy is now `1.5` (previously `1.6`) and all headings are now `1.3` (previously `1.5` inherited from `body`).

## How to test

- Turn on the [design system font sizes toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=designSystemFontSizes)
- Check page headings have a line-height of `1.3`
- Check body copy has a line-height of `1.5`

## How can we measure success?

We're using the design system

## Have we considered potential risks?

Can't think of any
