### PR TITLE
Use font() to ensure we're not getting browser default weights for headings

### DIFF
--- a/content/webapp/views/components/ContentSearchResult/index.tsx
+++ b/content/webapp/views/components/ContentSearchResult/index.tsx
@@ -28,6 +28,7 @@ const Type = styled(Space).attrs({
 const Title = styled(Space).attrs({
   as: 'h2',
   $v: { size: 's', properties: ['margin-bottom'] },
+  className: font('intb', 4),
 })`
   ${Link}:hover & {
     text-decoration: underline;

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/index.tsx
@@ -41,6 +41,7 @@ import {
   Page,
   PrevNext,
   StickyPlayer,
+  Title,
 } from './stop.styles';
 
 export type Props = {
@@ -135,9 +136,9 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
             <HeaderInner>
               <div>
                 <span>{exhibitionTitle}</span>
-                <h1 style={{ marginBottom: '0' }}>
+                <Title>
                   Stop {stopNumber}/{allStops.length}: {currentStop.title}
-                </h1>
+                </Title>
               </div>
               <span>
                 <NextLink href={`${guideTypeUrl}#${currentStop.number}`}>

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/stop.styles.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/stop.styles.tsx
@@ -29,6 +29,12 @@ export const Header = styled.header.attrs({
   z-index: 1;
 `;
 
+export const Title = styled.h1.attrs({
+  className: font('intb', 5),
+})`
+  margin-bottom: 0;
+`;
+
 export const HeaderInner = styled(Space).attrs({
   $v: {
     size: 's',


### PR DESCRIPTION
For #12318

## What does this change?

We weren't using our `font` helper for a couple of headings and previously the browser added default bold styling to them (which was what we wanted). Now we want things that have been bold to render as semi-bold, we need to explicitly use the correct font with the helper. I've used `intb` since we still want it to render as bold when the `designSytemFonts` toggle is off, but when it is on that value is remapped to semibold.  

## How to test

- Turn on the designSystemFonts toggle
- Check the headings for [a guide stop page](http://localhost:3000/guides/exhibitions/thirst-in-search-of-freshwater/audio-without-descriptions/2) and the headings of the `ContentSearchResult`s on the [All search page](http://localhost:3000/search?query=test). They should be semi-bold

## How can we measure success?

Consistent font-weights

## Have we considered potential risks?

Can't think of any
