### PR TITLE
Remove specific sticky nav link active/focus styles 

### DIFF
--- a/common/views/components/styled/AnimatedUnderline.tsx
+++ b/common/views/components/styled/AnimatedUnderline.tsx
@@ -12,14 +12,6 @@ const AnimatedUnderlineCSS = css<AnimatedUnderlineProps>`
 
   position: relative;
 
-  &:focus-visible,
-  &:focus,
-  &:target,
-  &:active {
-    box-shadow: ${props => props.theme.focusBoxShadow};
-    outline: ${props => props.theme.highContrastOutlineFix};
-  }
-
   & > span {
     background-image: linear-gradient(
       0deg,


### PR DESCRIPTION
## What does this change?
The sticky nav `AnimatedLink`s have specific `:active`, `:focus` etc. styles set. These are a bit heavy-handed showing a border when you're clicking on a link. We set our desired link styling higher up in the cascade allowing active/focused links to receive a border if the user navigated to them using a keyboard (`:focus-visible`)

## How to test
- Go to a [concept](http://localhost:3000/concepts/dhu46v23)
- Click on the sticky nav and check there isn't a border visible
- Navigate to the sticky nav using the keyboard and check the border is visible


## How can we measure success?

Consistent/appropriate link styling

## Have we considered potential risks?

Can't think of any
