### PR TITLE
Pass designSystemFonts value to fontFamilyMixin everywhere it's used

### DIFF
--- a/common/views/components/StackingTable/index.tsx
+++ b/common/views/components/StackingTable/index.tsx
@@ -117,7 +117,12 @@ const StyledTd = styled(Space).attrs<TdProps>(props => ({
       white-space: nowrap;
       content: ${props =>
         props.$cellContent ? `'${props.$cellContent}'` : ''};
-      ${fontFamilyMixin('intb', true)}
+      ${props =>
+        fontFamilyMixin(
+          'intb',
+          true,
+          props.theme.toggles?.designSystemFonts?.value
+        )}
     }
   }
 `;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -127,7 +127,12 @@ export const fontFamilyMixin = (
   useDesignSystem?: boolean
 ): string => {
   if (useDesignSystem) {
-    return `font-family: ${fontFamilies[family].designSystem}`;
+    // Assign explicit font-weight to match re-mapping in note below
+    const fontWeight =
+      family === 'intb' || family === 'intsb' || family === 'intm'
+        ? `font-weight: ${designSystemTheme.font.weight.semibold};`
+        : '';
+    return `font-family: ${fontFamilies[family].designSystem}; ${fontWeight}`;
   }
   return `font-family: ${fontFamilies[family][isFull ? 'full' : 'base']}`;
 };
@@ -195,7 +200,8 @@ export const typography = css<GlobalStyleProps>`
   }
 
   body {
-    ${fontFamilyMixin('intr', true)}
+    ${props =>
+      fontFamilyMixin('intr', true, props.toggles?.designSystemFonts?.value)}
     ${fontSizeMixin(4)}
     line-height: ${props =>
       props.toggles?.designSystemFonts?.value
@@ -304,12 +310,14 @@ export const typography = css<GlobalStyleProps>`
     letter-spacing: 0.0044em;
 
     h1 {
-      ${fontFamilyMixin('wb', true)}
+      ${props =>
+        fontFamilyMixin('wb', true, props.toggles?.designSystemFonts?.value)}
       ${fontSizeMixin(1)}
     }
 
     h2 {
-      ${fontFamilyMixin('wb', true)}
+      ${props =>
+        fontFamilyMixin('wb', true, props.toggles?.designSystemFonts?.value)}
       ${fontSizeMixin(2)}
     }
 
@@ -326,7 +334,8 @@ export const typography = css<GlobalStyleProps>`
     }
 
     h3 {
-      ${fontFamilyMixin('intb', true)}
+      ${props =>
+        fontFamilyMixin('intb', true, props.toggles?.designSystemFonts?.value)}
       ${fontSizeMixin(3)}
     }
 
@@ -371,12 +380,14 @@ export const typography = css<GlobalStyleProps>`
 
     strong,
     b {
-      ${fontFamilyMixin('intb', true)};
+      ${props =>
+        fontFamilyMixin('intb', true, props.toggles?.designSystemFonts?.value)};
     }
   }
 
   .drop-cap {
-    ${fontFamilyMixin('wb', true)}
+    ${props =>
+      fontFamilyMixin('wb', true, props.toggles?.designSystemFonts?.value)}
     font-size: 3em;
     color: ${props => props.theme.color('black')};
     float: left;
@@ -408,7 +419,8 @@ export const typography = css<GlobalStyleProps>`
     position: relative;
 
     &::before {
-      ${fontFamilyMixin('wb', true)}
+      ${props =>
+        fontFamilyMixin('wb', true, props.toggles?.designSystemFonts?.value)}
       position: absolute;
       content: '“';
       color: ${props => props.theme.color('accent.blue')};


### PR DESCRIPTION
And explicitly map intb/sb/m onto intsb as elsewhere

## What does this change?

Makes all instances of Inter medium/bold/semibold map only onto semibold. I also wasn't passing the toggle value to the `fontFamilyMixin`.

## How to test

- Visit e.g. the [accessibility](http://localhost:3000/visit-us/accessibility) page and check that h3s use semibold instead of bold

## How can we measure success?

Using the design system

## Have we considered potential risks?
n/a