### PR TITLE
Add HotjarLoader

### DIFF
--- a/common/services/app/analytics-scripts/hotjar-loader.tsx
+++ b/common/services/app/analytics-scripts/hotjar-loader.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent, useEffect, useState } from 'react';
 
-import { getConsentState } from '@weco/common/services/app/civic-uk';
-
-type ConsentChangedEvent = CustomEvent<{
-  analyticsConsent?: 'granted' | 'denied';
-  marketingConsent?: 'granted' | 'denied';
-}>;
+import {
+  CookieConsentEvent,
+  getConsentState,
+} from '@weco/common/services/app/civic-uk';
 
 const HOTJAR_ID = 3858;
 const HOTJAR_SV = 6;
@@ -20,7 +18,7 @@ export const HotjarLoader: FunctionComponent = () => {
     setHasConsent(initialConsent);
 
     // Listen for consent changes
-    const handleConsentChange = (event: ConsentChangedEvent) => {
+    const handleConsentChange = (event: CookieConsentEvent) => {
       if (event.detail.analyticsConsent === 'granted') {
         setHasConsent(true);
       } else if (event.detail.analyticsConsent === 'denied') {

--- a/common/services/app/civic-uk.ts
+++ b/common/services/app/civic-uk.ts
@@ -6,6 +6,12 @@ import { ConsentStatusProps } from '@weco/common/server-data/types';
 export const ACTIVE_COOKIE_BANNER_ID = 'ccc-overlay';
 export const COOKIE_BANNER_PARENT_ID = 'ccc';
 
+type ConsentType = 'granted' | 'denied';
+export type CookieConsentEvent = CustomEvent<{
+  analyticsConsent?: ConsentType;
+  marketingConsent?: ConsentType;
+}>;
+
 type CivicUKCookie = {
   optionalCookies?: {
     analytics: 'accepted' | 'revoked';

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -18,6 +18,7 @@ import {
 } from '@weco/common/server-data/types';
 import { AppErrorProps } from '@weco/common/services/app';
 import { HotjarLoader } from '@weco/common/services/app/analytics-scripts/hotjar-loader';
+import { CookieConsentEvent } from '@weco/common/services/app/civic-uk';
 import useMaintainPageHeight from '@weco/common/services/app/useMaintainPageHeight';
 import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
 import { deserialiseProps } from '@weco/common/utils/json';
@@ -99,13 +100,7 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
 
   useMaintainPageHeight();
 
-  type ConsentType = 'granted' | 'denied';
-  const onConsentChanged = (
-    event: CustomEvent<{
-      analyticsConsent?: ConsentType;
-      marketingConsent?: ConsentType;
-    }>
-  ) => {
+  const onConsentChanged = (event: CookieConsentEvent) => {
     // Update datalayer config with consent value
     gtag('consent', 'update', {
       ...(event.detail.analyticsConsent && {


### PR DESCRIPTION
## What does this change?

Re-adds hotjar within the repo, instead of loading it through GTM (where we weren't seeing it load in browsers consistently). The hope is that loading it this way will improve things.

We have to respect users' tracking preferences, so we conditionally add the script when analytics cookies have been granted. Various AIs hallucinated a 'consent API' for Hotjar, but I'm fairly confident after scouring the docs that such a thing doesn't actually exist (so we can't e.g. always load the script but set properties in the same way we do for the [dataLayer](https://github.com/wellcomecollection/wellcomecollection.org/blob/6426a078014861fac768b60bfbc643a6ff20caee/common/services/app/analytics-scripts/google-analytics.tsx#L59-L72))

- [ ] TODO: remove the hotjar script from GTM before we deploy this

## How to test
- Preview localhost through GTM, where I have provisionally removed the hotjar trigger/tag
- Clear cookies on localhost
- Load a page and check a `<script>` with `src="https://static.hotjar.com/c/hotjar-3858.js?sv=6"` doesn't exist in the `head` – `cmd-F` 'hotjar' in devtools should find 1 mention in the (unrelated) `cookieControl.optionalCookies` obejct
- disallow analytics cookies and check that the script still isn't in the `head`
- allow analytics cookies and check that it is in the `head` – `cmd-F` 'hotjar' should find 2 mentions

## How can we measure success?
See if we get more Hotjar data

## Have we considered potential risks?
More repo code to maintain

