### PR TITLE
Reduce horizontal space for PageHeader description

### DIFF
--- a/common/views/components/PageHeader/PageHeader.Landing.tsx
+++ b/common/views/components/PageHeader/PageHeader.Landing.tsx
@@ -48,7 +48,7 @@ const LandingPageHeader: FunctionComponent<Props> = ({
 
           {introText && introText.length > 0 && (
             <Grid>
-              <GridCell $sizeMap={{ s: [12], m: [10], l: [8], xl: [8] }}>
+              <GridCell $sizeMap={{ s: [12], m: [10], l: [7], xl: [7] }}>
                 <ContentWrapper>
                   <PrismicHtmlBlock
                     html={introText}


### PR DESCRIPTION
## What does this change?
Makes the PageHeader span 7 instead of 8 columns 

## How to test
- Visit `/stories`, `/collections`, `/get-involved` and check the subheading spans 7 of 12 columns at the l/xl breakpoint

## How can we measure success?
Happy designers

## Have we considered potential risks?
This was on the breakpoint QA but it seemed daft to change it behind the toggle, so it will change in production as well. I think this is fine. Dana gave it the thumbs-up.
