### PR TITLE
Featured card label

### DIFF
--- a/content/webapp/views/components/FeaturedCard/FeaturedCard.styles.ts
+++ b/content/webapp/views/components/FeaturedCard/FeaturedCard.styles.ts
@@ -51,7 +51,7 @@ export const FeaturedCardLeft = styled(GridCell)<HasIsReversed>`
 `;
 
 export const FeaturedCardRight = styled.div.attrs({
-  className: font('intb', 6),
+  className: font('intb', 6), // required for em value in label height calc below
 })<HasIsReversed>`
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What does this change?
The value for how much to pull the featured card text block up was hard coded because we knew what size the font was going to be. This is no longer the case with the incoming responsive typography that is calculated according to the viewport width. This feels like a slightly ridiculous thing to have to do, but I couldn't find a better alternative and it works

## How to test
- Look at a featured card on a small screen with/without the `designSystemFonts` toggle turned on and check that the label is (as good as) flush to the bottom of the image.

## How can we measure success?
Happy designers

## Have we considered potential risks?
I had to add an extra pixel of shift to insure against a sliver of whitespace appearing between the image and the copy block (presumably) because of sub-pixel rendering issues. I think it's ok though
