### PR TITLE
Add toggle for CLP

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -163,6 +163,14 @@ const toggles = {
       type: 'experimental',
     },
     {
+      id: 'newOnlineInCLP',
+      title: 'New Online block in CLP changes',
+      initialValue: false,
+      description:
+        'New online block in Collections landing page to render with Works API',
+      type: 'experimental',
+    },
+    {
       id: 'a11yPrototype',
       title: 'Accessibility prototype page',
       initialValue: false,


### PR DESCRIPTION
## What does this change?

Allows us to keep the Dynamic version of the New Online block (served with Works API) behind a different toggle so the changes can be released at a later point.

(We need to change how we query them)
