### PR TITLE
Make highlights yellow and use mix-blend-mode: color to ensure contrast

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFSearchWithin.tsx
@@ -22,8 +22,8 @@ import { arrayIndexToQueryParam } from '@weco/content/views/pages/works/work/III
 import { thumbnailsPageSize } from '@weco/content/views/pages/works/work/IIIFViewer/Paginators';
 
 const Highlight = styled.span`
-  background: ${props => props.theme.color('accent.purple')};
-  color: ${props => props.theme.color('white')};
+  background: ${props => props.theme.color('yellow')};
+  color: ${props => props.theme.color('black')};
 `;
 
 const SearchForm = styled.form`

--- a/content/webapp/views/pages/works/work/IIIFViewer/MainViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/MainViewer.tsx
@@ -85,8 +85,7 @@ type SearchTermHighlightProps = {
 type RotationValue = 0 | 90 | 180 | 270;
 
 const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
-  background: ${props => props.theme.color('accent.purple')};
-  opacity: 0.5;
+  background: ${props => props.theme.color('yellow')};
   position: absolute;
   z-index: 1;
   top: ${props => `${props.$top}px`};
@@ -95,6 +94,7 @@ const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
   height: ${props => `${props.$height}px`};
   transform-origin: 0 0;
   transform: ${props => `rotate(${props.$rotation}deg)`};
+  mix-blend-mode: color;
 `;
 
 const MessageContainer = styled.div`


### PR DESCRIPTION
For #12069 

## What does this change?
Changes the 'search within' highlights to be yellow background/black (or very dark) text.

The contrast ratio is more than 8:1 which far exceeds requirements for WCAG AA.

<img width="1150" height="921" alt="image" src="https://github.com/user-attachments/assets/170b6988-1291-4c30-a63f-3d31b169d79f" />

## How to test
- Go to http://localhost:3000/works/a2239muq/items?canvas=9&query=krebs and check highlight contrast

## How can we measure success?
Improved accesssibility

## Have we considered potential risks?
Can't think of any