### PR TITLE
make nav visibile on Safari 17

### DIFF
--- a/content/webapp/views/pages/about-us/prototype-a11y-november-2025.tsx
+++ b/content/webapp/views/pages/about-us/prototype-a11y-november-2025.tsx
@@ -58,7 +58,10 @@ const A11yPrototypePage: NextPage<page.Props> = props => {
           <SpacingComponent>
             <Container>
               <Grid style={{ background: 'white', rowGap: 0 }}>
-                <GridCell $sizeMap={{ s: [12], m: [12], l: [3], xl: [3] }}>
+                <GridCell
+                  $sizeMap={{ s: [12], m: [12], l: [3], xl: [3] }}
+                  style={{ background: 'white' }}
+                >
                   <InPageNavigation
                     links={props.page.onThisPage}
                     variant="sticky"


### PR DESCRIPTION
## What does this change?

🆙 

## How to test

- turn on 'Accessibility prototype page' toggle
- Visit https://www-dev.wellcomecollection.org/visit-us/accessibility in Safari 17
- check page side nav is visible

## How can we measure success?

Users can see the nav in Safari 17

## Have we considered potential risks?

none really, it's a prototype behind a toggle
