### PR TITLE
Make focus style more prominent on Concept Buttons.SolidLink

### DIFF
--- a/common/views/components/Buttons/Buttons.SolidLink.tsx
+++ b/common/views/components/Buttons/Buttons.SolidLink.tsx
@@ -43,6 +43,7 @@ const ButtonSolidLink: FunctionComponent<ButtonSolidLinkProps> = ({
       condition={isNextLink}
       wrapper={children =>
         typeof link === 'object' && (
+          // inline-block ensures focus styles wrap entire link
           <NextLink {...link} style={{ display: 'inline-block' }}>
             {children}
           </NextLink>

--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -87,7 +87,7 @@ const ImageSection: FunctionComponent<Props> = ({
       />
       <Space
         $v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}
-        style={{ position: 'relative' }}
+        style={{ position: 'relative' }} // relative to allow 'View all' button focus to stack above element that would otherwise clip it off
       >
         {labelBasedCount > singleSectionData.pageResults.length && (
           <MoreLink


### PR DESCRIPTION
## What does this change?
Ensures the focus styles are visible on the View all button near the top of a concept page

__before__
<img width="404" height="286" alt="image" src="https://github.com/user-attachments/assets/87f27ed7-ba67-486b-8741-d1cae9a3c39f" />

__after__
<img width="416" height="336" alt="image" src="https://github.com/user-attachments/assets/74b1bc5a-49a4-4184-8191-1f05c9d4c2ef" />


## How to test
Visit a [concept](http://localhost:3000/concepts/dhu46v23) and tab till you get to the View all button

## How can we measure success?
Visual consistency

## Have we considered potential risks?
Can't think of any
