### PR TITLE
Temporarily skip 6 E2E tests

### DIFF
--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -16,7 +16,7 @@ test('(1) | Does not create a tzitzit link for images in copyright', async ({
   ).toBeVisible();
 });
 
-test('(2) | Creates a tzitzit link for item pages', async ({
+test.skip('(2) | Creates a tzitzit link for item pages', async ({
   page,
   context,
 }) => {
@@ -32,7 +32,7 @@ test('(2) | Creates a tzitzit link for item pages', async ({
   );
 });
 
-test('(3) | Creates a tzitzit link for image pages', async ({
+test.skip('(3) | Creates a tzitzit link for image pages', async ({
   page,
   context,
 }) => {

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -92,7 +92,7 @@ test.describe('a Concept representing an Agent with no Images', () => {
 });
 
 test.describe('a Concept representing an Agent with Works and Images both about and by them', () => {
-  test('has both works and image sections grouped into "by" and "about" sections', async ({
+  test.skip('has both works and image sections grouped into "by" and "about" sections', async ({
     armyPage,
   }) => {
     // It has two tabs (works)
@@ -178,7 +178,7 @@ test.describe('a Concept representing a Genre with works and images both about a
 });
 
 test.describe('a Concept representing a Genre that is only used as a genre for both works and images', () => {
-  test('has both works and image sections showing records in that genre', async ({
+  test.skip('has both works and image sections showing records in that genre', async ({
     mohPage,
   }) => {
     // Both images and works sections exist

--- a/playwright/test/search-works.test.ts
+++ b/playwright/test/search-works.test.ts
@@ -132,7 +132,7 @@ test('(5) | The user is coming from a prefiltered series search; they should be 
 });
 
 // https://github.com/wellcomecollection/wellcomecollection.org/issues/10952
-test('(6) | Two options in two different filters have the same label/value; they should be uniquely identified', async ({
+test.skip('(6) | Two options in two different filters have the same label/value; they should be uniquely identified', async ({
   context,
   page,
 }) => {

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -82,7 +82,7 @@ test('(4) | The entire item can be downloaded', async ({ page, context }) => {
   );
 });
 
-test('(5) | The item has contributor information', async ({
+test.skip('(5) | The item has contributor information', async ({
   page,
   context,
 }) => {


### PR DESCRIPTION
## What does this change?

As a result of standardising concept labels across all pages, a few E2E tests (all related to concept labels) are failing when connected to the new works index (2025-11-20). This PR skips the relevant tests so that we can deploy the new works index to production. The tests will be brought back (in a modified form) in this PR: https://github.com/wellcomecollection/wellcomecollection.org/pull/12530


