### PR TITLE
Make button focus styles work for FF buttons as well

### DIFF
--- a/common/views/themes/base/wellcome-normalize.ts
+++ b/common/views/themes/base/wellcome-normalize.ts
@@ -32,7 +32,9 @@ export const wellcomeNormalize = css`
     height: auto;
   }
 
-  * {
+  *,
+  button {
+    /* Firefox needs 'button' to override specific UA focus styles */
     &:focus-visible,
     &:focus {
       ${focusStyle};


### PR DESCRIPTION
## What does this change?
FF has a specific `button:focus-visible` style: `outline: 1px dotted ButtonText;` but we want our focus style to work for all elements, so we add `button` alongside `*` in the selector list.

## How to test
- Visit any page in Firefox, tab along the main nav onto the search button in the header and check that it receives the same styles as the links in the nav.

## How can we measure success?
Consistent focus styles

## Have we considered potential risks?
n/a