### PR TITLE
Remove redundant highContrastOutlineFix

### DIFF
--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -433,9 +433,6 @@ export const themeValues = {
   },
   basicBoxShadow: `0 2px 8px 0 rgb(18, 18, 18, 0.4)`,
   focusBoxShadow: `0 0 0 3px ${colors['focus.yellow']}`,
-  // Problem: https://github.com/wellcomecollection/wellcomecollection.org/issues/10237
-  // Solution: https://benmyers.dev/blog/whcm-outlines/
-  highContrastOutlineFix: `3px solid transparent`,
   keyframes: {
     hoverBounce: keyframes`
       0% {


### PR DESCRIPTION
## What does this change?
We added this after an accessibility test showed us that we needed some sort of outline in order for windows high-contrast mode to work with focus. Now we explicitly use an outline for our focus styles we no longer need the fix.

## How to test
Look at the site in windows in browser stack and turn on high-contrast mode in the settings (or take my word for it).

<img width="1116" height="572" alt="image" src="https://github.com/user-attachments/assets/ed680d9f-128b-4c1d-a890-730e6609d728" />

## How can we measure success?
Less code

## Have we considered potential risks?
n/a