### PR TITLE
prevent pixelated images on new online

### DIFF
--- a/content/webapp/views/components/WorkCard/WorkCard.API.tsx
+++ b/content/webapp/views/components/WorkCard/WorkCard.API.tsx
@@ -34,6 +34,13 @@ const PopoutCardImage = styled(Space).attrs({
 
   /** This fixes an alignment issue with cards without images **/
   display: flex;
+
+  img {
+    width: auto;
+    max-width: 100%;
+    display: block;
+    margin: 0 auto;
+  }
 `;
 
 type LinkSpaceAttrs = {


### PR DESCRIPTION
## What does this change?

Relates to https://wellcome.slack.com/archives/CUA669WHH/p1764929325948609

We request thumbnails with the longest dimension set to 400px and we display them with a width of 100% of their parent element.
When we have portrait images with quite an extreme aspect ratios their width can be significantly less than the width at which they are displayed, causing them to be very tall and pixelated.

This changes it so the images are displayed at a maximum of 100% of their parent element and if they are smaller they will be centred in the space.

Before:
<img width="2916" height="10695" alt="1" src="https://github.com/user-attachments/assets/a1ce5dde-4add-4e48-afe0-3939e928707d" />

After:
<img width="2600" height="2900" alt="2" src="https://github.com/user-attachments/assets/6c3a8548-a572-455e-956e-db4640b9bbbe" />

## How to test
- Enable the New online listing page toggle
- Visit the [collections landing page](https://www-dev.wellcomecollection.org/collections) make sure the cards still appear correctly at various screen widths
- Visit the [new online page](https://www-dev.wellcomecollection.org/collections/new-online) make sure the cards still appear correctly at various screen widths

## How can we measure success?

We don't display pixelated images

## Have we considered potential risks?

We only use this card on the collections landing page and new online listing page, so if it looks ok we should be good

