### PR TITLE
Double checks thumbnail URL

### DIFF
--- a/content/webapp/views/components/WorkCard/WorkCard.API.tsx
+++ b/content/webapp/views/components/WorkCard/WorkCard.API.tsx
@@ -105,6 +105,11 @@ type Props = {
 };
 
 const WorkCard: FunctionComponent<Props> = ({ item }) => {
+  const THUMBNAIL_SIZE = 400;
+  const thumbnailUrl = item.thumbnail
+    ? convertIiifImageUri(item.thumbnail.url, THUMBNAIL_SIZE)
+    : undefined;
+
   const transformedWork = {
     title: item.title,
     url: '/works/' + item.id,
@@ -115,10 +120,13 @@ const WorkCard: FunctionComponent<Props> = ({ item }) => {
       item.cardLabels?.length > 0 && !item.cardLabels[0].labelColor
         ? [{ text: item.cardLabels[0].text }]
         : [],
-    imageUrl: item.thumbnail
-      ? convertIiifImageUri(item.thumbnail.url, 400)
-      : undefined,
-
+    imageUrl:
+      // Doubles check that the thumbnailUrl is valid
+      // If there is no sizes it might be wrongly formatted/not exist
+      thumbnailUrl &&
+      thumbnailUrl.includes(`${THUMBNAIL_SIZE},${THUMBNAIL_SIZE}`)
+        ? thumbnailUrl
+        : undefined,
     partOf: item.archiveLabels?.partOf,
     contributor: item.primaryContributorLabel,
     date: item.productionDates[0],


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12485#issuecomment-3626260601

Looks like there's another url type that can be passed in `thumbnail` from the manifest and that's `https://iiif.wellcomecollection.org/thumb/[bnumber]`. It happens for [this work] which I believe is a Born Digital work (it's just a PDF?) 

So I'm doing an extra check but it feels like a patchy one to me. As it also errors [on the works page](https://wellcomecollection.org/works/d8xmbrxk), I'm wondering if the check needs to happen at a different level?


## How to test

Run locally with the New Online toggle on

## How can we measure success?

Less borked looking

## Have we considered potential risks?
No _risk_, just hacky.