### PR TITLE
Remove `storiesOnWorks` toggle

### DIFF
--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { useToggles } from '@weco/common/server-data/Context';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Divider from '@weco/common/views/components/Divider';
@@ -64,7 +63,6 @@ export const WorkPage: NextPage<Props> = ({
   serverData,
 }) => {
   const { userIsStaffWithRestricted } = useUserContext();
-  const { storiesOnWorks } = useToggles();
   const isArchive = !!(
     work.parts.length || getArchiveAncestorArray(work).length > 0
   );
@@ -198,13 +196,11 @@ export const WorkPage: NextPage<Props> = ({
           </>
         )}
 
-        {storiesOnWorks && (
-          <StoriesOnWorks
-            workId={work.id}
-            showDivider={hasAtLeastOneSubject(work.subjects)}
-            toggles={serverData.toggles}
-          />
-        )}
+        <StoriesOnWorks
+          workId={work.id}
+          showDivider={hasAtLeastOneSubject(work.subjects)}
+          toggles={serverData.toggles}
+        />
 
         {/* If the work has no subjects, it's not worth adding this component */}
         {hasAtLeastOneSubject(work.subjects) && (

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -139,14 +139,6 @@ const toggles = {
       type: 'experimental',
     },
     {
-      id: 'storiesOnWorks',
-      title: 'Stories on work pages',
-      initialValue: false,
-      description:
-        'Shows stories that reference the current work on work pages',
-      type: 'experimental',
-    },
-    {
       id: 'designSystemBreakpoints',
       title: 'Design system breakpoints',
       initialValue: false,


### PR DESCRIPTION
## What does this change?

Removes `storiesOnWorks` toggle; I checked with Lauren and she's happy with it

## How to test

Run locally, can you still see them?  e.g. https://wellcomecollection.org/works/tq2ajvhq

## How can we measure success?

clean!

## Have we considered potential risks?
The component gets added to all stories as the fetching of said stories happens client-side; do we want to change that?