### PR TITLE
Add JP to country code captcha group

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -513,7 +513,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
       and_statement {
         statement {
           geo_match_statement {
-            country_codes = ["CN", "SG", "TW"]
+            country_codes = ["CN", "JP", "SG", "TW"]
           }
         }
         statement {


### PR DESCRIPTION
This pull request makes a minor update to the AWS WAF configuration by expanding the list of blocked countries in the `geo_match_statement`.

- Added "JP" (Japan) to the `country_codes` list in the `geo_match_statement` of the `aws_wafv2_web_acl` resource in `waf.tf`, increasing the set of countries matched by this rule.

See: https://wellcome.slack.com/archives/C02ANCYL90E/p1765467122760109