### PR TITLE
Prevent scaling to 0 during stage & e2e deployments

### DIFF
--- a/content/terraform/stack/main.tf
+++ b/content/terraform/stack/main.tf
@@ -49,8 +49,6 @@ module "content-service-17092020" {
   vpc_id  = local.vpc_id
   subnets = local.private_subnets
 
-  allow_scaling_to_zero = var.env_suffix != "prod"
-
   use_fargate_spot              = var.use_fargate_spot
   turn_off_outside_office_hours = var.turn_off_outside_office_hours
 }


### PR DESCRIPTION
## What does this change?

This change prevents scaling to zero tasks during deployments in e2e and stage, in an attempt to prevent the e2e stage failures we see often.

> [!Note] 
> This change has been applied.

These failures:

<img width="880" height="124" alt="Screenshot 2025-12-16 at 15 24 33" src="https://github.com/user-attachments/assets/1b7ce4cb-b31f-40a2-9145-3d5eab334bdf" />

## How to test

- [ ] Deploy to stage, does it fail?

## How can we measure success?

Less time wasted re-running tests.

## Have we considered potential risks?

Deployments will be slower, this may have unforeseen knock on effects.
