### PR TITLE
Account for brand font boldness

### DIFF
--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -30,7 +30,7 @@ export const fontFamilyMixin = (
 ): string => {
   return `
   font-family: ${fontFamilies[family]};
-  font-weight: ${designSystemTheme.font.weight[isBold ? 'semibold' : 'regular']};
+  font-weight: ${designSystemTheme.font.weight[family === 'brand' ? 'bold' : isBold ? 'semibold' : 'regular']};
   `;
 };
 


### PR DESCRIPTION
## What does this change?

[See Slack chat](https://wellcome.slack.com/archives/CUA669WHH/p1766066481666599)

<img width="1486" height="442" alt="image" src="https://github.com/user-attachments/assets/86af5ae6-bbc8-4781-ba95-12d42d6ca75d" />
https://wellcomecollection.org/concepts/k6p2u5fh

So all of our fonts except for Wellcome bold are to use the `semibold` font weight when "bold". The condition in place made the brand font have a font-weight of `400` (regular). If a character wasn't found and it defaulted to Inter, Inter would be `regular`, so even more different than the characters that did work. So I tweaked the condition a bit, hopefully it makes sense.

## How to test

Run https://www-dev.wellcomecollection.org/concepts/k6p2u5fh locally

<img width="638" height="132" alt="Screenshot 2025-12-18 at 14 33 53" src="https://github.com/user-attachments/assets/49e8f233-5807-4778-8d6e-056b7f172fff" />


## How can we measure success?

It looks less bad?

## Have we considered potential risks?
N/A 