### PR TITLE
Make preview work on Prismic stage

### DIFF
--- a/content/webapp/app.ts
+++ b/content/webapp/app.ts
@@ -66,7 +66,13 @@ const appPromise = nextApp
       // Kill any cookie we had set, as it think it is causing issues.
       ctx.cookies.set(prismic.cookie.preview);
 
-      const client = createPrismicClient();
+      // Detect if the preview is from stage or prod Prismic environment
+      const token = ctx.query.token as string | undefined;
+      const isPrismicStage = token?.includes(
+        'wellcomecollection-stage.prismic.io'
+      );
+
+      const client = createPrismicClient(isPrismicStage);
       client.enableAutoPreviewsFromReq(ctx.request);
 
       /**


### PR DESCRIPTION
For #12585 

## What does this change?
Checks if we're using Prismic stage for preview by looking for 'wellcomecollection-stage.prismic.io' in the token and creates the correct client accordingly.

## How to test
Look at something in the Prismic stage environment and try to preview it locally

## How can we measure success?
We don't have to publish things on Prismic stage in order to view them.

## Have we considered potential risks?
n/a