### PR TITLE
Only apply focus Styles to SeletctableTags and CheckboxRadio if you've

### DIFF
--- a/common/views/components/CheckboxRadio/index.tsx
+++ b/common/views/components/CheckboxRadio/index.tsx
@@ -70,11 +70,16 @@ const CheckboxRadioInput = styled.input.attrs<{ $type: string }>(props => ({
     border-width: ${props => (props.disabled ? '1px' : '2px')};
   }
 
-  &:focus-visible ~ ${CheckboxRadioBox}, &:focus ~ ${CheckboxRadioBox} {
+  &:focus-visible ~ ${CheckboxRadioBox} {
     ${focusStyle};
   }
 
-  &:focus ~ ${CheckboxRadioBox}:not(:focus-visible ~ ${CheckboxRadioBox}) {
+  &:focus ~ ${CheckboxRadioBox} {
+    ${focusStyle};
+  }
+
+  &:focus:not(:focus-visible) ~ ${CheckboxRadioBox} {
+    outline: none;
     box-shadow: none;
   }
 `;

--- a/content/webapp/views/components/SelectableTags/index.tsx
+++ b/content/webapp/views/components/SelectableTags/index.tsx
@@ -58,12 +58,16 @@ const InputField = styled.input`
   height: 0;
   width: 0;
 
-  &:focus-visible ~ ${StyledInput}, &:focus ~ ${StyledInput} {
+  &:focus-visible ~ ${StyledInput} {
     ${focusStyle};
   }
 
-  &:focus ~ ${StyledInput}:not(:focus-visible ~ ${StyledInput}),
-  &:active ~ ${StyledInput} {
+  &:focus ~ ${StyledInput} {
+    ${focusStyle};
+  }
+
+  &:focus:not(:focus-visible) ~ ${StyledInput} {
+    outline: none;
     box-shadow: none;
   }
 `;


### PR DESCRIPTION
## What does this change?

The SelectableTags and CheckboxRadio components currently have focus styles applied even if you click on the inputs. This is counter to how we've treated the rest of the focusable elements on the site where we only show you the focus style if you've navigated with the keyboard (or programatically) using `focus-visible`.

This PR makes the SelectableTags and CheckboxRadios behave the same as everything else.

## How to test

- Click on the SelectableTags in the Browse by theme section on the [Collections landing page](https://www-dev.wellcomecollection.org/collections) – check there's no outline
- Tab to the SelectableTags and check there is a border
- Do the same for the CheckboxRadio 'Available online only' on the Collections landing page

## How can we measure success?
Consistent UI and UX

## Have we considered potential risks?
n/a
