### PR TITLE
Bold active nav

### DIFF
--- a/common/utils/classnames.ts
+++ b/common/utils/classnames.ts
@@ -2,18 +2,16 @@
 type FontFamily = 'sans' | 'sans-bold' | 'brand' | 'mono';
 type FontSize = -2 | -1 | 0 | 1 | 2 | 4 | 5;
 
-export function font(family: FontFamily, size: FontSize): string;
-export function font(family: FontFamily): string;
-export function font(family: undefined, size: FontSize): string;
-export function font(family?: FontFamily, size?: FontSize): string {
-  if (family === undefined && size === undefined) {
-    throw new Error('font() requires at least one argument');
-  }
+export function fontFamily(family: FontFamily): string {
+  return `font-${family}`;
+}
 
-  const familyClass = family ? `font-${family}` : '';
-  const sizeClass = size !== undefined ? `font-size-f${size}` : '';
+export function fontSize(size: FontSize): string {
+  return `font-size-f${size}`;
+}
 
-  return [familyClass, sizeClass].filter(Boolean).join(' ');
+export function font(family: FontFamily, size: FontSize): string {
+  return `${fontFamily(family)} ${fontSize(size)}`;
 }
 
 type ClassNames = string[] | Record<string, boolean>;

--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { font, fontFamily } from '@weco/common/utils/classnames';
 import AnimatedUnderlineCSS, {
   AnimatedUnderlineProps,
 } from '@weco/common/views/components/styled/AnimatedUnderline';
@@ -119,7 +119,7 @@ type InPageNavAnimatedLinkProps = {
 export const InPageNavAnimatedLink = styled(
   AnimatedLink
 ).attrs<InPageNavAnimatedLinkProps>(props => ({
-  className: font(props.$isActive ? 'sans-bold' : 'sans'),
+  className: fontFamily(props.$isActive ? 'sans-bold' : 'sans'),
 }))<InPageNavAnimatedLinkProps>`
   color: ${props =>
     props.theme.color(


### PR DESCRIPTION
For #12606 

## What does this change?
Makes the active nav item bold.

~I thought it would be useful and less redundant to make the `font` function work with either `family` or `size` (as well as continuing to work with both as it does currently).  Because here (and likely elsewhere) we only wanted to change the font family, so didn't need to care about re-declaring what the font-size should be.~ **Edit:** I exported two new functions to handle changing fontFamily and fontSize independently

## How to test
- Visit a [page with a side nav](https://www-dev.wellcomecollection.org/concepts/patspgf3#works) and check the active item updates to bold when selected/scrolled-to

## How can we measure success?
Code matches the designs

## Have we considered potential risks?
There might be line-breaks when the text gets slightly wider. We know this might happen I think it's ok