### PR TITLE
Match design spacing/line-height

### DIFF
--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
@@ -78,7 +78,7 @@ export const ListItem = styled.li<{ $hasStuck: boolean; $isOnWhite: boolean }>`
   ${props =>
     props.theme.media('md')(`
     border-top: 0;
-    padding: 6px 0  6px ${leftOffset};
+    padding: 7px 0 7px ${leftOffset};
     margin: 0;
 
     &::before {
@@ -92,6 +92,7 @@ export const ListItem = styled.li<{ $hasStuck: boolean; $isOnWhite: boolean }>`
 const AnimatedLink = styled(NextLink)<AnimatedUnderlineProps>`
   ${AnimatedUnderlineCSS}
   text-decoration: none;
+  line-height: 1;
 
   ${props =>
     props.theme.media('md')(`
@@ -100,7 +101,7 @@ const AnimatedLink = styled(NextLink)<AnimatedUnderlineProps>`
 
   & > span {
     font-size: 14px;
-    line-height: 20px;
+    line-height: 1.6;
   }
 `;
 


### PR DESCRIPTION
For #12604 

## What does this change?
Matches the InPageNav designs inter-item spacing and within-item line-height.

## How to test
- Visit the [accessibility page](https://www-dev.wellcomecollection.org/visit-us/accessibility) with the twoColumns toggle and check the side-nav matches the spacing in [Figma](https://www.figma.com/design/LNi1QLXX8G9pbmQecwKEMM/Accessibility-information?node-id=4301-3073&m=dev)

## How can we measure success?
Consistency with designs

## Have we considered potential risks?
n/a