### PR TITLE
Exhibitions in events e2es

### DIFF
--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -83,10 +83,14 @@ const stageApiToggleCookie = createCookie({
   name: 'toggle_stagingApi',
   value: 'true',
 });
+const exInEvToggleCookie = createCookie({
+  name: 'toggle_exhibitionsInEvents',
+  value: 'true',
+});
 
 export const requiredCookies = useStageApis
-  ? [acceptCookieCookie, stageApiToggleCookie]
-  : [acceptCookieCookie];
+  ? [acceptCookieCookie, stageApiToggleCookie, exInEvToggleCookie]
+  : [acceptCookieCookie, exInEvToggleCookie];
 
 const multiVolumeItem = async (
   context: BrowserContext,


### PR DESCRIPTION
## What does this change?

Wanting to test whether or not making Exhibitions in Events public will break any e2e tests.


Edit: [they have passed with all the latest changes](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/7162)

This is not to be merged, but closed once we know it's been tested against the latest changes (keeping open in case changes are made in https://github.com/wellcomecollection/wellcomecollection.org/pull/12627 and it needs retesting). 