### PR TITLE
Check URL: ignore errors on new online for document fetching

### DIFF
--- a/playwright/url-checker/check-url.ts
+++ b/playwright/url-checker/check-url.ts
@@ -108,7 +108,7 @@ export const urlChecker =
       if (!url.includes('/collections/new-online')) {
         failures.push({
           failureType: 'page-request-failure',
-          description: `${url}Request made by page failed with ${errorText}: ${request.method()} ${request.url()}`,
+          description: `Request made by page failed with ${errorText}: ${request.method()} ${request.url()}`,
         });
       }
     });


### PR DESCRIPTION
## What does this change?

https://wellcome.slack.com/archives/CQ720BG02/p1767966580147499

I tested it locally when images were still failing and it did it


<img width="1091" height="630" alt="Screenshot 2026-01-09 at 14 31 09" src="https://github.com/user-attachments/assets/79f9d366-26d8-41b7-a469-6d52f38ea896" />

Maybe we think it's a gross fix though, but I do feel like unless we implement a different fix higher up the pipeline, this is sort of needed.

## How to test

Does it pass here? https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/7166#019ba334-d348-4bad-a200-a1268ea7d028

At the time of running, images were still 404-ing on https://wellcomecollection.org/collections/new-online

## How can we measure success?

Unblocks Check URL for this case out of our current control

## Have we considered potential risks?
We don't like it?