### PR TITLE
Align tops of left (nav) and right (main) columns

### DIFF
--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -298,7 +298,7 @@ const Body: FunctionComponent<Props> = ({
             />
 
             <GridCell $sizeMap={{ s: [12], m: [12], l: [9], xl: [9] }}>
-              <Space $v={{ size: 'sm', properties: ['padding-top'] }}>
+              <Space $v={{ size: 'md', properties: ['padding-top'] }}>
                 {children}
               </Space>
             </GridCell>


### PR DESCRIPTION
For #12605 

## What does this change?
Aligns the 'On this page' side navigation with the top of the content in the right column.

<img width="795" height="276" alt="image" src="https://github.com/user-attachments/assets/022f0c7b-2944-4d30-9955-24969ba39e3b" />

## How to test
- Visit [this page](https://www-dev.wellcomecollection.org/about-us/policies-and-plans) with the twoColumns toggle on
- Check 'On this page' and 'Strategic documents' are aligned
- Check other headings align to the same point when using the side nav

## How can we measure success?
Consistent UI/UX

## Have we considered potential risks?
n/a
