### PR TITLE
Use design system spaces for margins above/below Text slice h2s

### DIFF
--- a/common/views/components/styled/SpacingComponent.tsx
+++ b/common/views/components/styled/SpacingComponent.tsx
@@ -36,7 +36,7 @@ const SpacingComponent = styled.div.attrs<{ $sliceType?: string }>(props => ({
     */
     margin-top: 0;
 
-    .spaced-text > *:first-child {
+    .spaced-text > *:first-child:not(h2) {
       margin-top: ${props => props.theme.spacedTextTopMargin};
     }
   }
@@ -44,7 +44,7 @@ const SpacingComponent = styled.div.attrs<{ $sliceType?: string }>(props => ({
   & + &.slice-type-text {
     /* If there's a SpacingComponent (of any type) followed by a specific .slice-type-text
     SpacingComponent, and the latter has an h2 as its first child, we clear the space (which
-    would otherwise grow too large added to the margin on the top of the h2)  */
+    would otherwise grow too large added to the margin on the top of the h2) */
     &:has(h2:first-child) {
       margin-top: 0;
     }

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -247,6 +247,9 @@ export const typography = css<GlobalStyleProps>`
     h2 {
       ${responsiveSpaceMixin('space.xl', 'margin-top')}
       ${responsiveSpaceMixin('space.md', 'margin-bottom')}
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     &:first-of-type {


### PR DESCRIPTION
For #12601 

__Edit:__ You probably don't want to review this – try #12642 instead.

## What does this change?
1. Adds a mixin to add a ResponsiveSize value for a css property at each breakpoint
2. Implemented this mixin to add `margin-top` and `margin-bottom` to h2s inside Text slices
3. Overrides the `SpacingComponent` space if the first thing in it is an h2 in a Text slice

## How to test
- Visit the [accessibility page](https://www-dev.wellcomecollection.org/visit-us/accessibility) and check the design system (rem-based) margins are added above and below h2s
- Check the first h2 (in the first-of-type Text slice) has its margin-top overriden to `0`
- Visit [this article](https://www-dev.wellcomecollection.org/stories/acts-of-love-and-resistance-in-sudan) and scroll to the 'The search for water' heading', find it's enclosing `SpacingComponent` and check that its margin-top is overridden to `0` (without this override, the margin-top on the h2 would be added to the SpacingComponent h2 making the space overly large).

<img width="508" height="395" alt="image" src="https://github.com/user-attachments/assets/c9ee6827-8144-44dc-8139-0918dd47d636" />

## How can we measure success?
h2 spacing aligned with designs

## Have we considered potential risks?
This approach is good in that it uses values from the design system, but less good in that it is necessarily more declarative and less scalable (rather than using `em` that will scale with the size of the relevant text element, it uses `rem` that need to be specifically declared at each breakpoint).

Hopefully scoping it to the text-slices is a reasonable compromise but I'm definitely open to suggestion for how to do it differently/better. [Design system slack convo where I've raised my slight unease](https://wellcome.slack.com/archives/C01GH36GXDM/p1768481540724179).
