### PR TITLE
Position buttons from right instead of left

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewerControls.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewerControls.tsx
@@ -9,8 +9,8 @@ import { CanvasRotatedImage } from '@weco/content/types/item-viewer';
 
 const ImageViewerControlsEl = styled.div<{ $showControls?: boolean }>`
   position: absolute;
-  bottom: 0;
-  right: 20%;
+  bottom: 5%;
+  right: 10%;
   z-index: 1;
   opacity: ${props => (props.$showControls ? 1 : 0)};
   transition: opacity 300ms ease;


### PR DESCRIPTION
For #12448 

## What does this change?
The Viewer rotate/zoom controls were positioned a percentage from the left in order to appear on the right side of the screen. This meant that on smaller screens there wasn't necessarily enough room for them. Positioning them from the right since they're going to appear on the right means that they're not going to be clipped on smaller screens. I didn't overthink the amount of space to use, but 20% from the right looked to make for something approximately equivalent to how it was spaced from the left.

## How to test
- Visit [a work](https://www-dev.wellcomecollection.org/works/a2239muq/items?canvas=2) and make sure the zoom/rotate buttons aren't clipped at any screen size

## How can we measure success?
All controls are accessible

## Have we considered potential risks?
n/a

