### PR TITLE
Add image Id to subject line for visually similar images feedback email

### DIFF
--- a/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
+++ b/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
@@ -127,7 +127,7 @@ const VisuallySimilarImages: FunctionComponent<Props> = ({
         shapes and features.
         <br />
         <a
-          href={`mailto:digital@wellcomecollection.org?subject=Visually similar images feedback (${originalId})`}
+          href={`mailto:digital@wellcomecollection.org?subject=Visually similar images feedback (${encodeURIComponent(originalId)})`}
         >
           Let us know
         </a>{' '}


### PR DESCRIPTION
## What does this change?

#12633

Talked through it with Natalie and we're happy with this solution. Having the whole URL actually doesn't _work_ (might be a bug but the modal doesn't actually open when clicking on the URL with the id anchor), but we can use the id to query the image search so this is good.

## How to test

[Run image search](https://www-dev.wellcomecollection.org/search/images)
Open a couple modals and see if the feedback link opens an email with the ID in the subject line

## How can we measure success?

We can investigate feedback much faster

## Have we considered potential risks?
N/A