### PR TITLE
Simplify focus(-visible) styles

### DIFF
--- a/common/views/components/CheckboxRadio/index.tsx
+++ b/common/views/components/CheckboxRadio/index.tsx
@@ -70,12 +70,8 @@ const CheckboxRadioInput = styled.input.attrs<{ $type: string }>(props => ({
     border-width: ${props => (props.disabled ? '1px' : '2px')};
   }
 
-  &:focus-visible ~ ${CheckboxRadioBox}, &:focus ~ ${CheckboxRadioBox} {
+  &:focus-visible ~ ${CheckboxRadioBox} {
     ${focusStyle};
-  }
-
-  &:focus ~ ${CheckboxRadioBox}:not(:focus-visible ~ ${CheckboxRadioBox}) {
-    box-shadow: none;
   }
 `;
 

--- a/common/views/themes/base/wellcome-normalize.ts
+++ b/common/views/themes/base/wellcome-normalize.ts
@@ -35,14 +35,8 @@ export const wellcomeNormalize = css`
   *,
   button {
     /* Firefox needs 'button' to override specific UA focus styles */
-    &:focus-visible,
-    &:focus {
+    &:focus-visible {
       ${focusStyle};
-    }
-
-    :focus:not(:focus-visible) {
-      outline: none;
-      box-shadow: none;
     }
   }
 

--- a/content/webapp/views/components/SelectableTags/index.tsx
+++ b/content/webapp/views/components/SelectableTags/index.tsx
@@ -58,11 +58,10 @@ const InputField = styled.input`
   height: 0;
   width: 0;
 
-  &:focus-visible ~ ${StyledInput}, &:focus ~ ${StyledInput} {
+  &:focus-visible ~ ${StyledInput} {
     ${focusStyle};
   }
 
-  &:focus ~ ${StyledInput}:not(:focus-visible ~ ${StyledInput}),
   &:active ~ ${StyledInput} {
     box-shadow: none;
   }


### PR DESCRIPTION
For #12621 

## What does this change?
Our target browser have all supported `focus-visible` for a while so we no longer need to follow the pattern of providing `focus` styles and overriding them with `focus-visible` styles.

This simplifies the css, and means the SelectableTags and CheckboxRadios are no longer visibly focused when you click on them (but are focused when you tab to them).

One thing to note is apparently Safari's idea of what `focus-visible` should apply to are a bit stricter than other browsers. The upshot of this is Safari's `:focus-visible` heuristics don't trigger for arrow key navigation within radio groups, so e.g. if you tab to a SelectableTag, that one will have the `focus-visible` styles, but then if you use the keyboard to move focus between SelectableTags, those don't receive the `focus-visible` styles. However, since the `selected` style of the SelectableTag is applied, and using the arrow keys would be a deliberate intention on the user's part to move between co-located parts of UI, I think we can live with this quirk. I'm fairly sure it wouldn't be a WCAG issue since it is clear which tag is selected from the tags own styles, even though it doesn't get the outline styles.

The alternatives suggested seemed heavy handed to me (either rewrite the whole thing using aria-attributes and JS, or use JS to add a data-attribute to the focused element and then style that with e.g. `&[data-keyboard-focus="true"] ~ ${StyledInput}`).

## How to test
- Visit the [Collections page](https://www-dev.wellcomecollection.org/collections), tab to the SelectableTags, and use the arrow keys to move between tags. Check the focus styles are present  (with the exception that in Safari they aren't present during arrow key navigation)
- Check the focus styles aren't visible when you click the SelectableTags
- Do the same for the 'Available online' checkbox

## How can we measure success?
Simpler css and more consistent focus style behaviour.

## Have we considered potential risks?
Safari quirk outlined above (but I think this is ok).
