### PR TITLE
Revert the exception in Check URL

### DIFF
--- a/playwright/url-checker/check-url.ts
+++ b/playwright/url-checker/check-url.ts
@@ -103,14 +103,10 @@ export const urlChecker =
       if (errorText.includes('net::ERR_ABORTED')) {
         return;
       }
-      // Ignore 404s on this specific page as very recently digitised items could still be rendering their thumbnails
-      // https://wellcome.slack.com/archives/CQ720BG02/p1767966580147499
-      if (!url.includes('/collections/new-online')) {
-        failures.push({
-          failureType: 'page-request-failure',
-          description: `Request made by page failed with ${errorText}: ${request.method()} ${request.url()}`,
-        });
-      }
+      failures.push({
+        failureType: 'page-request-failure',
+        description: `Request made by page failed with ${errorText}: ${request.method()} ${request.url()}`,
+      });
     });
 
     page.on('response', response => {


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12630

According to the [Slack convo with Digirati](https://wellcome.slack.com/archives/CBT40CMKQ/p1767969116555679) and @agnesgaroux , they have upgraded the process capacity permanently (from 5 to 15).

Since this is also unlikely to happen often (mass ingests), we're happy to revert this for now, as we also don't love having exceptions in tests.

Should it happen again we'll be able to identify it quickly and consider other paths.

## How to test

Do tests pass here?

## How can we measure success?

No exceptions

## Have we considered potential risks?
Happens again.