### PR TITLE
Hide browse pages if toggle value is false

### DIFF
--- a/content/webapp/pages/collections/topics/[topic].tsx
+++ b/content/webapp/pages/collections/topics/[topic].tsx
@@ -289,7 +289,7 @@ export const getServerSideProps: GetServerSideProps<
   const serverData = await getServerData(context);
 
   // Return 404 if the browseCollections toggle is not enabled
-  if (!serverData.toggles.browseCollections) {
+  if (!serverData.toggles.browseCollections.value) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/collections/topics/index.tsx
+++ b/content/webapp/pages/collections/topics/index.tsx
@@ -100,7 +100,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const serverData = await getServerData(context);
 
   // Return 404 if the browseCollections toggle is not enabled
-  if (!serverData.toggles.browseCollections) {
+  if (!serverData.toggles.browseCollections.value) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/collections/types/[type].tsx
+++ b/content/webapp/pages/collections/types/[type].tsx
@@ -248,7 +248,7 @@ export const getServerSideProps: GetServerSideProps<
   const serverData = await getServerData(context);
 
   // Return 404 if the browseCollections toggle is not enabled
-  if (!serverData.toggles.browseCollections) {
+  if (!serverData.toggles.browseCollections.value) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/collections/types/index.tsx
+++ b/content/webapp/pages/collections/types/index.tsx
@@ -100,7 +100,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const serverData = await getServerData(context);
 
   // Return 404 if the browseCollections toggle is not enabled
-  if (!serverData.toggles.browseCollections) {
+  if (!serverData.toggles.browseCollections.value) {
     return {
       notFound: true,
     };


### PR DESCRIPTION
## What does this change?

Found this through reading a Copilot review session, the check here was wrong in the sense that turning off the toggle would still return a truthy value in this condition.

This is likely of no consequence as only someone internal would have set the cookie AND turned it off, but thought it was best to address.

## How to test

https://www-dev.wellcomecollection.org/collections/types without the cookie OR with the cookie set but turned OFF should 404

With the cookie set and ON, should display the page.

Same for
https://www-dev.wellcomecollection.org/collections/topics
https://www-dev.wellcomecollection.org/collections/topics/hk965y34
https://www-dev.wellcomecollection.org/collections/types/books

## How can we measure success?

Better conditionals on feature flags

## Have we considered potential risks?
N/A