### PR TITLE
Account for subpixel rendering artefacts on iOS

### DIFF
--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.Sticky.styles.tsx
@@ -284,8 +284,11 @@ export const NavGridCell = styled(GridCell)<{
     content: '';
     position: absolute;
     width: ${props => props.theme.containerPaddingVw};
-    bottom: 0;
-    top: 0;
+
+    /* These are -1px instead of 0 to account for iOS subpixel rendering artefacts
+    https://github.com/wellcomecollection/wellcomecollection.org/issues/12689 */
+    bottom: -1px;
+    top: -1px;
     transition: background-color ${props => props.theme.transitionProperties};
     background-color: var(--nav-grid-cell-background-color);
   }


### PR DESCRIPTION
For #12689 

## What does this change?
Stretches the rectangular `::before` and `::after` pseudo elements up/down by a pixel to prevent a small amount of whitespace from showing through on iOS.

## How to test
I've run this locally through ngrok and looked on my phone and seen the issue resolved. I wasn't able to consistently see the original issue using browserstack, so I don't think that is a particularly informative place to attempt to test.

## How can we measure success?
Less visual bugs

## Have we considered potential risks?
n/a
