### PR TITLE
koa replacement: don't erase required cookie for preview

### DIFF
--- a/content/webapp/pages/api/preview.ts
+++ b/content/webapp/pages/api/preview.ts
@@ -13,13 +13,15 @@ import { createClient } from '@weco/content/services/prismic/fetch';
  * ## How Prismic previews work:
  * 1. User clicks "Preview" in Prismic dashboard
  * 2. Prismic redirects to this endpoint with preview tokens in the URL query params
- * 3. This handler resolves the preview URL using Prismic's API via `resolvePreviewURL()`
- * 4. Prismic's SDK automatically sets the 'io.prismic.preview' cookie with the preview ref
+ * 3. createClient() calls enableAutoPreviewsFromReq() which reads the preview tokens
+ *    and sets the 'io.prismic.preview' cookie with the preview ref
+ * 4. This handler resolves the preview URL using Prismic's API via `resolvePreviewURL()`
  * 5. We set our own 'isPreview=true' cookie for app-level preview mode detection
  * 6. Redirects user to the actual preview content
  *
  * ## Cookie management:
- * - Prismic SDK sets 'io.prismic.preview' cookie containing the preview ref token
+ * - enableAutoPreviewsFromReq() (called by createClient) sets 'io.prismic.preview' cookie
+ *   containing the preview ref token from the URL query params
  * - We set 'isPreview=true' cookie with httpOnly=false (for client-side preview detection)
  *
  * ## Related files:


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/pull/12650 doesn't work in staging and I think this is the culprit as the `io.prismic.preview` cookie is set in staging but has no value (we need it to contain the token). We seemed to be clearing it.

## How to test

Run locally and preview... Although we did that last time and it worked so I think this needs to be tested in staging .


## How can we measure success?

Previews work and we don't need to revert everything

## Have we considered potential risks?
N/A won't go farther than staging if it doesn't fix it.