### PR TITLE
check for transformedManifest before updating Router

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
@@ -115,7 +115,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   // If the visible canvas changes because it is scrolled into view
   // we update the canvas param to match
   // Only applies when using FixedSizeList (scrollable viewer), not for paginated views
-  // shouldn't apply when there is no transformed manifest, e.g. when the viewer is use at
+  // shouldn't apply when there is no transformed manifest, e.g. when the viewer is used at
   // works/{id}/images?id={imageId}
   useSkipInitialEffect(() => {
     if (useFixedSizeList && isOnScreen && transformedManifest) {


### PR DESCRIPTION
## What does this change?

Fixes the issue we are seeing, described here: https://wellcome.slack.com/archives/C8X9YKM5X/p1770208957561189

where works/{workId}/images?id={imageId} are getting redirected to works/{workId}/images

I [mistakenly took out the check for transformedManifests in this PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/12645/changes), so am putting it back in

## How to test

Visit [one of the currently broken pages](https://github.com/wellcomecollection/wellcomecollection.org/pull/12645/changes) and it's no longer broken

## How can we measure success?

We don't mistakenly render 404s and people can see the images

## Have we considered potential risks?

Putting back original check, so think we'll be good

