### PR TITLE
Add tracking info to thematic browsing nav

### DIFF
--- a/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Navigation.tsx
+++ b/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Navigation.tsx
@@ -39,7 +39,7 @@ const ThematicBrowsingNavigation: FunctionComponent<{
       <SelectableTagsWrapper as={PlainList}>
         {tagItems.map((tag, i) => {
           const dataGtmProps: DataGtmProps = {
-            trigger: 'thematic_browsing_link',
+            trigger: 'thematic_browsing_navigation_link',
             label: tag.label,
             'position-in-list': `${i + 1}`,
           };


### PR DESCRIPTION
## What does this change?

#12760

As per Mankeet's request, I added some `data-gtm` to our Thematic browsing navigation

## How to test

Run locally and inspect the DOM, see it matches what Mankeet requested (see comments in ticket)

## How can we measure success?

He can do tracking magic

## Have we considered potential risks?
N/A