### PR TITLE
Check for port conflicts in local nginx setup

### DIFF
--- a/scripts/configure-local-apis/update-nginx-config.sh
+++ b/scripts/configure-local-apis/update-nginx-config.sh
@@ -10,6 +10,46 @@ NC='\033[0m' # no colour - reset console colour
 
 NGINX_HOME=$("${DIR}/locate-nginx.sh")
 
+# Ports used by local API services (see weco-local.conf)
+USED_PORTS=(8080 8081 3000 3001 3002 3003)
+
+# Check nginx config files for port conflicts with our local API services
+check_port_conflicts() {
+  local file="$1"
+  local has_conflict=false
+  for port in "${USED_PORTS[@]}"; do
+    if grep -qE '^\s*listen\s+.*\b'"$port"'\s*;' "$file"; then
+      if [ "$has_conflict" = false ]; then
+        echo ""
+        echo -e "${YELLOW}⚠️  Port conflict detected in ${file}:${NC}"
+        has_conflict=true
+      fi
+      echo -e "${YELLOW}   - A server block is listening on port ${port}, which is needed by a local API service.${NC}"
+    fi
+  done
+  if [ "$has_conflict" = true ]; then
+    echo ""
+    echo -e "${YELLOW}   Please comment out or remove the conflicting server block(s) in:${NC}"
+    echo -e "${YELLOW}   ${file}${NC}"
+    echo -e "${YELLOW}   Then restart nginx for the changes to take effect.${NC}"
+    echo ""
+  fi
+}
+
+# Check main nginx.conf
+if [ -f "$NGINX_HOME/nginx.conf" ]; then
+  check_port_conflicts "$NGINX_HOME/nginx.conf"
+fi
+
+# Check other configs in servers/ (excluding our own weco-local.conf)
+if [ -d "$NGINX_HOME/servers" ]; then
+  for conf in "$NGINX_HOME/servers/"*.conf; do
+    [ -f "$conf" ] || continue
+    [ "$(basename "$conf")" = "weco-local.conf" ] && continue
+    check_port_conflicts "$conf"
+  done
+fi
+
 # ensure $NGINX_HOME/servers exists
 mkdir -p $NGINX_HOME/servers
 


### PR DESCRIPTION
## What does this change?

The `configure-local-apis.sh` setup script now checks for port conflicts before copying the nginx config.

On macOS, Homebrew's default `nginx.conf` (and configs in `servers/`) can include server blocks listening on ports that our local API services need (e.g. port 8080 for the Catalogue API). This causes silent failures when running the local dev environment.

This change adds a `check_port_conflicts` function to `update-nginx-config.sh` that:

- Scans the main `nginx.conf` for `listen` directives on ports used by our local services (8080, 8081, 3000, 3001, 3002, 3003)
- Scans all `*.conf` files in the `servers/` directory (excluding our own `weco-local.conf`)
- Handles various `listen` directive formats (e.g. `listen 8080;`, `listen somename:8080;`, `listen 127.0.0.1:8080;`)
- Prints a clear warning identifying the conflicting file and port, with instructions to resolve it

No automatic modifications are made to the user's nginx config — just a warning with clear guidance.

## How to test

1. Add a server block listening on port 8080 to your nginx config (either `nginx.conf` or a file in `servers/`):
   ```nginx
   server {
       listen 8080;
       server_name localhost;
   }
   ```
2. Run `./scripts/configure-local-apis.sh`
3. Verify you see a warning like:
   ```
   ⚠️  Port conflict detected in /opt/homebrew/etc/nginx/servers/nginx.conf:
      - A server block is listening on port 8080, which is needed by a local API service.

      Please comment out or remove the conflicting server block(s) in:
      /opt/homebrew/etc/nginx/servers/nginx.conf
      Then restart nginx for the changes to take effect.
   ```
4. Remove the conflicting block and re-run — verify no warning appears.


Uploading Screen Recording 2026-02-16 at 13.52.47.mov…



## How can we measure success?

Fewer developers getting stuck debugging why the local Catalogue API isn't reachable when their default nginx config is occupying port 8080.

## Have we considered potential risks?

Very low risk — this is a read-only check that only prints warnings. It doesn't modify any nginx config files. The regex is intentionally conservative, matching `listen` directives with our specific ports.
