### PR TITLE
Change the New Online filters to yesterday 00:01

### DIFF
--- a/content/webapp/pages/collections/new-online.tsx
+++ b/content/webapp/pages/collections/new-online.tsx
@@ -2,6 +2,8 @@ import { NextPage } from 'next';
 
 import { getServerData } from '@weco/common/server-data';
 import { appError } from '@weco/common/services/app';
+import { addDays, today } from '@weco/common/utils/dates';
+import { formatIso8601Date } from '@weco/common/utils/format-date';
 import { serialiseProps } from '@weco/common/utils/json';
 import {
   ServerSideProps,
@@ -33,6 +35,11 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const serverData = await getServerData(context);
 
+  // We want to show works that have been made available online from 00:01 yesterday
+  // as some works require more time to properly build and we got errors in the past
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/12787
+  const yesterday = formatIso8601Date(addDays(today(), -1));
+
   const works = await getWorks({
     params: {
       availabilities: ['online'],
@@ -42,7 +49,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
         '!restricted',
         '!closed',
       ],
-      'items.locations.createdDate.to': '2026-02-18',
+      'items.locations.createdDate.to': yesterday,
       sort: 'items.locations.createdDate',
       sortOrder: 'desc',
       page,

--- a/content/webapp/pages/collections/subjects/[uid].tsx
+++ b/content/webapp/pages/collections/subjects/[uid].tsx
@@ -6,6 +6,8 @@ import {
 } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
 import { appError } from '@weco/common/services/app';
+import { addDays, today } from '@weco/common/utils/dates';
+import { formatIso8601Date } from '@weco/common/utils/format-date';
 import { serialiseProps } from '@weco/common/utils/json';
 import { getQueryPropertyValue } from '@weco/common/utils/search';
 import { getQueryResults } from '@weco/common/utils/search';
@@ -74,6 +76,10 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     'subjects-' + pageUid
   );
 
+  // We want to show works that have been made available online from 00:01 yesterday
+  // as some works require more time to properly build and we got errors in the past
+  // https://github.com/wellcomecollection/wellcomecollection.org/issues/12787
+  const yesterday = formatIso8601Date(addDays(today(), -1));
   const newOnlineWorks: Work[] = [];
   const newOnlineWorksQuery = await getWorks({
     params: {
@@ -85,7 +91,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
         '!restricted',
         '!closed',
       ],
-      'items.locations.createdDate.to': '2026-02-18',
+      'items.locations.createdDate.to': yesterday,
       sort: 'items.locations.createdDate',
       sortOrder: 'desc',
     },


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12787 (and [Slack](https://wellcome.slack.com/archives/C3TQSF63C/p1772461310601089?thread_ts=1771408955.003759&cid=C3TQSF63C))

We decided to filter up to yesterday 00:01, which gives the works ample time to complete. 

## How to test

Run locally, are the works new / do they render well?
https://www-dev.wellcomecollection.org/collections/subjects/sex-sexual-health-and-reproduction (not necessarily new as they might have had new ones in a while, it's mostly there as a safeguard)

https://www-dev.wellcomecollection.org/collections/new-online


## How can we measure success?

It updates again!

## Have we considered potential risks?
N/A