### PR TITLE
Invalidate e2e cache before test running.

### DIFF
--- a/.buildkite/e2e_on_pull_requests/pipeline.e2e-pull-requests.yml
+++ b/.buildkite/e2e_on_pull_requests/pipeline.e2e-pull-requests.yml
@@ -34,6 +34,9 @@
 
   key: invalidate-cloudfront-cache
 
+  concurrency_group: "dotorg-e2e-on-pull-requests-gate"
+  concurrency: 1
+
   plugins:
     - wellcomecollection/aws-assume-role#v0.2.2:
         role: 'arn:aws:iam::130871440101:role/experience-ci'
@@ -46,11 +49,18 @@
 
   depends_on: invalidate-cloudfront-cache
 
+  concurrency_group: "dotorg-e2e-on-pull-requests-gate"
+  concurrency: 1
+
   agents:
     queue: nano
 
 - label: "Run pa11y tests"
   depends_on: invalidate-cloudfront-cache
+
+  concurrency_group: "dotorg-e2e-on-pull-requests-gate"
+  concurrency: 1
+
   plugins:
     - docker-compose#v3.5.0:
         run: pa11y

--- a/.buildkite/e2e_on_pull_requests/pipeline.e2e-pull-requests.yml
+++ b/.buildkite/e2e_on_pull_requests/pipeline.e2e-pull-requests.yml
@@ -28,16 +28,29 @@
   agents:
     queue: nano
 
+- label: "Invalidate e2e CloudFront cache"
+  command: ".buildkite/scripts/invalidate_e2e_cloudfront_cache.sh"
+  depends_on: deploy-to-e2e-environment
+
+  key: invalidate-cloudfront-cache
+
+  plugins:
+    - wellcomecollection/aws-assume-role#v0.2.2:
+        role: 'arn:aws:iam::130871440101:role/experience-ci'
+
+  agents:
+    queue: nano
+
 - label: "Trigger e2e tests"
   command: ".buildkite/e2e_on_pull_requests/run_e2e_tests.sh"
 
-  depends_on: deploy-to-e2e-environment
+  depends_on: invalidate-cloudfront-cache
 
   agents:
     queue: nano
 
 - label: "Run pa11y tests"
-  depends_on: deploy-to-e2e-environment
+  depends_on: invalidate-cloudfront-cache
   plugins:
     - docker-compose#v3.5.0:
         run: pa11y

--- a/.buildkite/scripts/invalidate_e2e_cloudfront_cache.sh
+++ b/.buildkite/scripts/invalidate_e2e_cloudfront_cache.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Invalidate CloudFront cache for the e2e environment
+#
+# Usage:
+#   .buildkite/scripts/invalidate_e2e_cloudfront_cache.sh
+#
+# This script creates a CloudFront invalidation for all paths in the e2e
+# distribution. This is necessary after deploying to ensure tests run against
+# the latest code, not cached responses.
+
+# Exit immediately if any command fails
+set -o errexit
+# Exit if we try to use an unset variable
+set -o nounset
+
+# CloudFront distribution ID for e2e environment
+DISTRIBUTION_ID="E24KUWI00L6FA3"
+
+echo "Creating CloudFront invalidation for e2e distribution $DISTRIBUTION_ID..."
+
+# Create an invalidation for all paths (/*) in the distribution
+# - This tells CloudFront to clear all cached content
+# - Returns the invalidation ID which we need to track completion
+INVALIDATION_ID=$(
+  aws cloudfront create-invalidation \
+    --distribution-id "$DISTRIBUTION_ID" \
+    --paths "/*" \
+    --query 'Invalidation.Id' \
+    --output text
+)
+
+echo "Invalidation created with ID: $INVALIDATION_ID"
+echo "Waiting for invalidation to complete..."
+
+# Wait for the invalidation to complete before proceeding
+# - This ensures subsequent steps (like e2e tests) run against fresh content
+# - Typically takes 1-2 minutes but can vary
+aws cloudfront wait invalidation-completed \
+  --distribution-id "$DISTRIBUTION_ID" \
+  --id "$INVALIDATION_ID"
+
+echo "CloudFront cache successfully invalidated for e2e environment"

--- a/infrastructure/experience/iam.tf
+++ b/infrastructure/experience/iam.tf
@@ -10,3 +10,21 @@ resource "aws_iam_role_policy" "allow_ci_to_update_e2e_cluster" {
   role = "experience-ci"
   policy = data.aws_iam_policy_document.allow_ci_to_update_e2e_cluster.json
 }
+
+data "aws_iam_policy_document" "allow_ci_to_invalidate_cloudfront" {
+  statement {
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation"
+    ]
+
+    resources = [
+      "arn:aws:cloudfront::130871440101:distribution/E24KUWI00L6FA3"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_ci_to_invalidate_cloudfront" {
+  role   = "experience-ci"
+  policy = data.aws_iam_policy_document.allow_ci_to_invalidate_cloudfront.json
+}


### PR DESCRIPTION
## What does this change?
https://github.com/wellcomecollection/wellcomecollection.org/issues/12837
We found out the e2e environment is cached (ofc it is), so sometimes, tests run against a cached version of a page, defeating their purpose.

For example, [pa11y was failing here](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/19077) because the tests were running on pages where the `data-component` was not the new one, but the old one as it was serving a cached version of the page. Had to clear the cache and rerun. (and then the same in [a different branch](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/19079#019cbddf-1a03-4c9f-8d19-5d3dee4f92bb) and I had to invalidate again) 

So I worked with Claude to add this step in.

We had to add permission for the `experience-ci` role to create and get invalidations in the e2e environment, the TF change has been applied and [it can be seen here](https://us-east-1.console.aws.amazon.com/iam?region=us-east-1#/roles/details/experience-ci?section=permissions). (EDIT: I've now reverted this)

## How to test

See [the step in the build in this PR](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/19087#019cbe11-66fe-4092-ab6a-1ff4e92067c5) and [find the matching invalidation in Cloudfront](https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=eu-west-1#/distributions/E24KUWI00L6FA3/invalidations).

## How can we measure success?

Successful e2e runs! We apparently haven't always been testing the right thing, hopefully moving forward we will be.

## Have we considered potential risks?

Well I'm still a newbie to Permissions and Terraform and Infrastructure, but I found this quite simple and readable.