### PR TITLE
Change breadcrumb logic for Concept header

### DIFF
--- a/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Header.tsx
+++ b/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Header.tsx
@@ -19,7 +19,7 @@ import { ThematicBrowsingCategories } from '.';
 import ThematicBrowsingNavigation from './ThematicBrowsing.Navigation';
 
 const ThematicBrowsingHeaderContainer = styled(Space).attrs({
-  $v: { size: 'sm', properties: ['padding-top'] },
+  $v: { size: 'md', properties: ['padding-top'] },
 })`
   background-color: ${props => props.theme.color('accent.lightGreen')};
   padding-bottom: ${props => props.theme.gutter.xlarge};
@@ -45,7 +45,7 @@ const ThematicBrowsingHeader = ({
           <Space
             $v={{
               size: 'sm',
-              properties: ['margin-top', 'margin-bottom'],
+              properties: ['margin-bottom'],
               overrides: { md: '150' },
             }}
           >

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -22,14 +22,9 @@ import SourcedDescription from '@weco/content/views/components/SourcedDescriptio
 
 import RelatedConceptsGroup from './concept.RelatedConceptsGroup';
 
-const ConceptHero = styled(Space).attrs<{ $hasBreadcrumbs: boolean }>(
-  props => ({
-    $v: {
-      size: props.$hasBreadcrumbs ? 'sm' : 'xl',
-      properties: ['padding-top'],
-    },
-  })
-)`
+const ConceptHero = styled(Space).attrs({
+  $v: { size: 'md', properties: ['padding-top'] },
+})`
   background-color: ${props => props.theme.color('accent.lightGreen')};
   padding-bottom: ${props => props.theme.gutter.xlarge};
 `;
@@ -122,19 +117,15 @@ const ThemeHeader: FunctionComponent<{
         'collections',
         [getBreadcrumbParent({ type: concept.type })].filter(isNotUndefined)
       )
-    : { items: [] };
+    : getBreadcrumbItems('collections');
 
   return (
     <>
-      <ConceptHero $hasBreadcrumbs={breadcrumbs.items.length > 0}>
+      <ConceptHero>
         <Container>
-          {thematicBrowsing && (
-            <Space
-              $v={{ size: 'sm', properties: ['margin-top', 'margin-bottom'] }}
-            >
-              <Breadcrumb items={breadcrumbs.items} />
-            </Space>
-          )}
+          <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
+            <Breadcrumb items={breadcrumbs.items} />
+          </Space>
 
           <Layout gridSizes={gridSize10(false)}>
             <h1 className={font('brand-bold', 4)}>{concept.displayLabel}</h1>


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/pull/12841 introduced a change to the Header without the Thematic browsing toggle on that made it have no upper spacing and it looked weird. I also realised that we could always display Home > Collection even if the toggle wasn't turned on - it's better than just being lost and still directs people towards more concepts and journeys.

So I moved a few things around to address both things and centralise the spacing logic (also copied it to thematic browsing header since they were the same).

## How to test

https://www-dev.wellcomecollection.org/concepts/k6p2u5fh

[With](https://dash.wellcomecollection.org/toggles/?enableToggle=thematicBrowsing) and [without](https://dash.wellcomecollection.org/toggles/?disableToggle=thematicBrowsing) the toggle

## How can we measure success?

Looks good.

## Have we considered potential risks?
N/A