### PR TITLE
Remove picturefill

### DIFF
--- a/common/views/layouts/PageLayout/index.tsx
+++ b/common/views/layouts/PageLayout/index.tsx
@@ -244,11 +244,6 @@ const PageLayoutComponent: NextPage<Props> = ({
       */}
 
       <Script
-        src="https://i.wellcomecollection.org/assets/libs/picturefill.min.js"
-        async
-      />
-
-      <Script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(jsonLd),


### PR DESCRIPTION
Part of #12830

## What does this change?

Removes [picturefill.js](https://scottjehl.github.io/picturefill/) which is a polyfill for the `picture` element, since all our target browsers support it natively. I ran a lighthouse report on the site and it flagged that this script wasn't being served with a cache ttl value, but I figured a better performance improvement would be to remove the script altogether.

## How to test

Check the site still works without issues. The hero images at the top of story pages are `<picture>` elements so makes sense to check there.

## How can we measure success?

Better site performanace.

## Have we considered potential risks?

n/a
