### PR TITLE
Change retry codes

### DIFF
--- a/.buildkite/pipeline.e2e-universal.yml
+++ b/.buildkite/pipeline.e2e-universal.yml
@@ -1,6 +1,10 @@
 steps:
   - label: "build e2e test image"
     command: ./playwright/get_playwright_image.sh
+    retry:
+      automatic:
+        - exit_status: 143  # SIGTERM
+          limit: 2
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -10,6 +14,12 @@ steps:
   - wait
 
   - label: "Check URLs"
+    retry:
+      automatic:
+        - exit_status: 255  # docker-compose plugin exits with 255 on infrastructure interrupts
+          limit: 2
+        - exit_status: 143  # SIGTERM
+          limit: 2
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -24,6 +34,12 @@ steps:
           command: ["bash", "check_urls.sh"]
 
   - label: "e2e test:desktop [$DEPLOYMENT_ENVIRONMENT]"
+    retry:
+      automatic:
+        - exit_status: 255  # docker-compose plugin exits with 255 on infrastructure interrupts
+          limit: 2
+        - exit_status: 143  # SIGTERM
+          limit: 2
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::130871440101:role/experience-ci"
@@ -40,6 +56,12 @@ steps:
       queue: scala # High parallelism for expensive tests
 
   - label: "e2e test:mobile [$DEPLOYMENT_ENVIRONMENT]"
+    retry:
+      automatic:
+        - exit_status: 255  # docker-compose plugin exits with 255 on infrastructure interrupts
+          limit: 2
+        - exit_status: 143  # SIGTERM
+          limit: 2
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::130871440101:role/experience-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
   key: 'build_common'
   retry:
     automatic:
-      - exit_status: -1
+      - exit_status: 255  # bash wraps exit(-1) to 255, used by docker-compose plugin on interrupt
         limit: 2
       - exit_status: 143  # SIGTERM
         limit: 2
@@ -20,7 +20,7 @@
   key: 'build_content'
   retry:
     automatic:
-      - exit_status: -1
+      - exit_status: 255  # bash wraps exit(-1) to 255, used by docker-compose plugin on interrupt
         limit: 2
       - exit_status: 143  # SIGTERM
         limit: 2
@@ -43,7 +43,7 @@
   key: 'build_edge_lambdas'
   retry:
     automatic:
-      - exit_status: -1
+      - exit_status: 255  # bash wraps exit(-1) to 255, used by docker-compose plugin on interrupt
         limit: 2
       - exit_status: 143  # SIGTERM
         limit: 2
@@ -61,7 +61,7 @@
   key: 'build_identity'
   retry:
     automatic:
-      - exit_status: -1
+      - exit_status: 255  # bash wraps exit(-1) to 255, used by docker-compose plugin on interrupt
         limit: 2
       - exit_status: 143  # SIGTERM
         limit: 2


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/pull/12848 hasn't quite worked like I wanted it to, [build steps still failed](https://buildkite.com/wellcomecollection/wc-dot-org-build-plus-test/builds/19246#019cf6ee-8a5f-488a-a10b-7c33fea40aed). So I dug a bit more and it looks like the code sent is actually `255`, not `-1`. 

<img width="825" height="182" alt="Screenshot 2026-03-19 at 11 50 38" src="https://github.com/user-attachments/assets/797461be-4fbe-4ccf-89ff-fcba04274a82" />

The theory is that "exit codes are 0–255, so exit -1 in bash wraps to 255."

I also experienced it in an e2e run to staging which [sent a Slack alert ](https://wellcome.slack.com/archives/CQ720BG02/p1773913677168459)when it was actually fine ([see here](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/7627#019d057c-26dd-486b-a821-aa548d5d8719)). Be nice to avoid those too, so added some retries there as well. If the tests actually fail, they exit with code `1` and therefore will **not** retry.


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Retries work.

## Have we considered potential risks?

I do think that `255` is actually any exit code that is out of range, so could be other things, but in any case I don't think a retry trigger will hurt. We can keep an eye on how often this happens and adapt. In any case, it feels like we'll win some time back if retries happen automatically.