### PR TITLE
Audio player anchor position

### DIFF
--- a/content/webapp/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
@@ -59,15 +59,10 @@ const PlayRateList = styled.div<{
   margin: 0;
   padding: 0;
   border: none;
-
-  margin-bottom: 10px;
-  position: absolute;
-  bottom: 100%;
-  right: 0;
+  position: fixed;
 
   @supports (position-anchor: --play-rate-button) {
     position-anchor: --play-rate-button;
-    position: fixed;
     bottom: anchor(top);
     right: anchor(right);
     position-try-fallbacks: --below;
@@ -107,6 +102,7 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
 }) => {
   const [isPlayRateActive, setIsPlayRateActive] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { audioPlaybackRate, setAudioPlaybackRate } = useAppContext();
   const speeds = [0.5, 1, 1.5, 2];
 
@@ -141,6 +137,15 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
     if (isPlayRateActive) {
       popoverRef.current?.hidePopover();
     } else {
+      if (
+        !CSS.supports('position-anchor', '--x') &&
+        buttonRef.current &&
+        popoverRef.current
+      ) {
+        const rect = buttonRef.current.getBoundingClientRect();
+        popoverRef.current.style.bottom = `${window.innerHeight - rect.top + 10}px`;
+        popoverRef.current.style.right = `${window.innerWidth - rect.right}px`;
+      }
       popoverRef.current?.showPopover();
     }
   }
@@ -154,6 +159,7 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
     >
       <PlayRateContainer>
         <TogglePlayRateButton
+          ref={buttonRef}
           $isDark={isDark}
           onClick={toggleShowHidePlayRate}
           aria-controls={id}


### PR DESCRIPTION
## What does this change?
Removes PopperJS from the AudioPlayer so that the playrate popup position is handled by the [CSS anchor positioning module](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning) which is newly available in Baseline.

Browsers that don't support the anchor positioning properties yet will fallback to using `position: absolute` for the popup, relative to the playrate toggle button. The only behaviour that users of these browsers would miss out on is the [`position-try-fallbacks`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position-try-fallbacks) that makes the browser try to keep the positioned element within the viewport if there isn't enough space for it in the default direction. This felt like a reasonable trade-off.

![css-anchor-positioning](https://github.com/user-attachments/assets/3d49590f-0161-4bd9-942d-e2950d5e0faf)

## How to test

- Visit an [audio guide page](https://www-dev.wellcomecollection.org/guides/exhibitions/1880-that/audio-without-descriptions/3), click the play rate button
- Visit a [work with multiple audio files](https://www-dev.wellcomecollection.org/works/b4tj49m4/items) with/without the [extended viewer toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=extendedViewer), click the play rate button(s)
- Comment out the `@supports` block to check behaviour in older browsers

## How can we measure success?
Less JS (ok we still use popper elsewhere, but this is a step in the right direction)

## Have we considered potential risks?
New shiny? I think it's ok though.
