### PR TITLE
Fix highlight position

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -64,8 +64,8 @@ const MessageContainer = styled.div`
   position: relative;
   top: 50%;
   transform: translateY(-50%);
-  min-width: 360px;
-  max-width: 600px;
+  min-width: 300px;
+  max-width: 80%;
   margin: 0 auto;
   border: 1px solid ${props => props.theme.color('neutral.600')};
   height: 80%;
@@ -77,8 +77,6 @@ const Outline = styled(Space)<{ $border?: boolean }>`
   ${props =>
     props.$border
       ? `
-          padding-left: ${props.theme.spacingUnits['400']};
-          padding-right: ${props.theme.spacingUnits['400']};
           border: 1px solid;
           border-color:  ${props.theme.color('neutral.400')};
         `


### PR DESCRIPTION
## What does this change?

I noticed the highlighted terms, when searching within a digitised item, are misplaced, e.g. searching for 'tree'
 
<img width="226" height="179" alt="Screenshot 2026-03-24 at 10 47 33" src="https://github.com/user-attachments/assets/85ef3727-4dde-4053-91a1-2a062faa0b01" />

This fixes that:
<img width="256" height="200" alt="Screenshot 2026-03-24 at 10 47 09" src="https://github.com/user-attachments/assets/b1d46b24-af39-4d59-a63e-23bbd2d1f7df" />

It was to do with spacing being added to the Outline styled component. The spacing was there for positioning of the MessageContainer, so I removed it and added positioning styles directly to that.

## How to test

- Visit [an item with a search term highlight](https://www-dev.wellcomecollection.org/works/yae5sugf/items?canvas=4&query=tree) and see that it lines up correctly. Rotate the canvas/resize the window and it should still line up.

- Visit [an item with a restricted message](https://www-dev.wellcomecollection.org/works/pnud3fzb/items?canvas=2) and see that it is positioned correctly

## How can we measure success?

People can find the terms they searched for on an image

## Have we considered potential risks?

None I can think of

