### PR TITLE
Use CSS anchor positioning for the dropdown button

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -61,28 +61,26 @@ import IIIFItemDownload from './IIIFItem.Download';
 import VideoTranscript from './IIIFItem.VideoTranscript';
 
 const MessageContainer = styled.div`
-  min-width: 360px;
-  max-width: 600px;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  min-width: 300px;
+  max-width: 80%;
   margin: 0 auto;
   border: 1px solid ${props => props.theme.color('neutral.600')};
   height: 80%;
   padding: 10%;
 `;
 
-const Outline = styled(Space).attrs({
-  $v: {
-    size: 'md',
-    properties: ['margin-top', 'margin-bottom'],
-  },
-  $h: { size: 'lg', properties: ['margin-left', 'margin-right'] },
-})<{ $border?: boolean }>`
+const Outline = styled(Space)<{ $border?: boolean }>`
   position: relative;
-  padding-left: ${props => props.theme.spacingUnits['400']};
-  padding-right: ${props => props.theme.spacingUnits['400']};
   ${props =>
     props.$border
-      ? `border: 1px solid; border-color:  ${props.theme.color('neutral.400')}`
-      : ``};
+      ? `
+          border: 1px solid;
+          border-color:  ${props.theme.color('neutral.400')};
+        `
+      : ''};
   height: 100%;
 `;
 


### PR DESCRIPTION
## What does this change?
Refactors the `DropdownButton` component to replace Popper.js and `react-transition-group` with the CSS Anchor Positioning API.

The dropdown is now positioned using `anchor-name`/`position-anchor` CSS properties, with a `@position-try` fallback to flip above the trigger when there is insufficient space below. A `@supports` block ensures graceful degradation in browsers that do not support anchor positioning (it wouldn't flip). The animations are handled with simple CSS `opacity` and `transform` transitions directly on the styled component, removing the need for `CSSTransition` and its associated class-based animation hooks.

I added some space between the button and the dropdown because I thought it needed it (reckons?).

## How to test
- Visit a [search page](https://www-dev.wellcomecollection.org/search/works?query=egg) and click the (filter) dropdown buttons. The resulting menu should be horizontally centred beneath the button provided there's enough space. If there is too little space, it should render above

## How can we measure success?
Less JS, fewer imported packages, less to maintain.

## Have we considered potential risks?
n/a

