### PR TITLE
Remove Frequent Collaborators from sub-theme pages

### DIFF
--- a/content/webapp/pages/collections/subjects/[uid].tsx
+++ b/content/webapp/pages/collections/subjects/[uid].tsx
@@ -294,23 +294,6 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     /** */
 
     /**
-     * Frequent collaborators
-     * Deduplicate collaborators across multiple concepts by using a Map
-     * keyed by collaborator id, then convert back to an array
-     * */
-    // Typed Map for type safety
-    const frequentCollaboratorsMap = new Map<string, RelatedConcept>();
-    conceptResponse.results.forEach(concept => {
-      concept.relatedConcepts?.frequentCollaborators?.forEach(collaborator => {
-        if (!frequentCollaboratorsMap.has(collaborator.id)) {
-          frequentCollaboratorsMap.set(collaborator.id, collaborator);
-        }
-      });
-    });
-    const frequentCollaborators = Array.from(frequentCollaboratorsMap.values());
-    /** */
-
-    /**
      * Related topics
      * Round-robin through concepts: take 1st topic from each, then 2nd from each, etc.
      * */
@@ -349,7 +332,6 @@ export const getServerSideProps: ServerSidePropsOrAppError<
         categoryThemeCardsList: themeCardsListSlice,
         curatedUid: pageUid,
         newOnlineWorks: newOnlineWorks.map(toWorkBasic),
-        frequentCollaborators,
         relatedStoriesId,
         worksAndImagesAbout,
         relatedTopics,

--- a/content/webapp/views/pages/collections/subjects/sub-theme/index.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/index.tsx
@@ -21,7 +21,6 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { Link } from '@weco/content/types/link';
 import { Page } from '@weco/content/types/pages';
-import CollaboratorCards from '@weco/content/views/components/CollaboratorCards';
 import ImageModal, {
   useExpandedImage,
 } from '@weco/content/views/components/ImageModal';
@@ -63,7 +62,6 @@ export type Props = {
   curatedUid: string;
   categoryThemeCardsList?: RawThemeCardsListSlice;
   newOnlineWorks: WorkBasic[];
-  frequentCollaborators: RelatedConcept[];
   relatedStoriesId: string[];
   worksAndImagesAbout: WorksAndImagesResponse;
   relatedTopics: RelatedConcept[];
@@ -76,7 +74,6 @@ const WellcomeSubThemePage: NextPage<Props> & {
   thematicBrowsingPage,
   categoryThemeCardsList,
   newOnlineWorks,
-  frequentCollaborators,
   relatedStoriesId,
   worksAndImagesAbout,
   relatedTopics,
@@ -92,7 +89,6 @@ const WellcomeSubThemePage: NextPage<Props> & {
   const hasImagesAbout = !!(
     worksAndImagesAbout.images && worksAndImagesAbout.images.totalResults > 0
   );
-  const hasFrequentCollaborators = frequentCollaborators.length > 0;
   const hasRelatedTopics = relatedTopics.length > 0;
 
   const lowerCasePageTitle = thematicBrowsingPage.title.toLowerCase();
@@ -100,10 +96,6 @@ const WellcomeSubThemePage: NextPage<Props> & {
     hasNewOnlineWorks && {
       text: `New works in ${lowerCasePageTitle}`,
       url: `#new-online`,
-    },
-    hasFrequentCollaborators && {
-      text: 'Frequent collaborators',
-      url: `#frequent-collaborators`,
     },
     hasRelatedStories && {
       text: `Stories about ${lowerCasePageTitle}`,
@@ -162,21 +154,11 @@ const WellcomeSubThemePage: NextPage<Props> & {
               </SectionContainer>
             )}
 
-            {hasFrequentCollaborators && (
-              <SectionContainer
-                title="Frequent collaborators"
-                id="frequent-collaborators"
-                isFirst={!hasNewOnlineWorks}
-              >
-                <CollaboratorCards collaborators={frequentCollaborators} />
-              </SectionContainer>
-            )}
-
             {hasRelatedStories && (
               <SectionContainer
                 title={`Stories about ${lowerCasePageTitle}`}
                 id="stories"
-                isFirst={!hasNewOnlineWorks && !hasFrequentCollaborators}
+                isFirst={!hasNewOnlineWorks}
               >
                 <SubThemeStories relatedStoriesId={relatedStoriesId} />
               </SectionContainer>
@@ -203,10 +185,7 @@ const WellcomeSubThemePage: NextPage<Props> & {
                 title={`Works about ${lowerCasePageTitle}`}
                 id="works-about"
                 isFirst={
-                  !hasNewOnlineWorks &&
-                  !hasFrequentCollaborators &&
-                  !hasRelatedStories &&
-                  !hasImagesAbout
+                  !hasNewOnlineWorks && !hasRelatedStories && !hasImagesAbout
                 }
               >
                 <SubThemeWorks
@@ -223,7 +202,6 @@ const WellcomeSubThemePage: NextPage<Props> & {
                 id="related-topics"
                 isFirst={
                   !hasNewOnlineWorks &&
-                  !hasFrequentCollaborators &&
                   !hasRelatedStories &&
                   !hasImagesAbout &&
                   !hasWorksAbout


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12914

> As discussed with @LaurenFBaily , we won't be displaying that anymore. In our test sub-themes, they never showed and I think there's too many questions around how to frame it, so we'll remove it for now.

## How to test

Browse sub-theme pages, should look good and unchanged as none of them had Frequent Collaborators.

## How can we measure success?

Tidier

## Have we considered potential risks?
N/A