### PR TITLE
Fix ThemeCardList spacing on smaller screens

### DIFF
--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
@@ -26,8 +26,6 @@ export const ContentContainer = styled(PlainList)`
 `;
 
 export const ScrollShim = styled.li<{ $gridValues: number[] }>`
-  display: none;
-
   --container-padding: ${props => props.theme.containerPadding};
   --number-of-columns: ${props => (12 - props.$gridValues[0]) / 2};
   --gap-value: ${props => props.theme.gutter.small};
@@ -45,7 +43,6 @@ export const ScrollShim = styled.li<{ $gridValues: number[] }>`
 
   ${props =>
     props.theme.media('sm')(`
-      display: block;
       --number-of-columns: ${(12 - props.$gridValues[1]) / 2};
       --gap-value: ${props.theme.gutter.medium};
   `)}

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
@@ -23,9 +23,17 @@ export const ContentContainer = styled(PlainList)`
   overflow: hidden;
   position: relative;
   padding: 3px 0;
+
+  &:has(.scroll-shim) {
+    li:nth-child(2) {
+      padding-left: 0;
+    }
+  }
 `;
 
-export const ScrollShim = styled.li<{ $gridValues: number[] }>`
+export const ScrollShim = styled.li.attrs({
+  className: 'scroll-shim',
+})<{ $gridValues: number[] }>`
   --container-padding: ${props => props.theme.containerPadding};
   --number-of-columns: ${props => (12 - props.$gridValues[0]) / 2};
   --gap-value: ${props => props.theme.gutter.small};

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
@@ -24,6 +24,10 @@ export const ContentContainer = styled(PlainList)`
   position: relative;
   padding: 3px 0;
 
+  li:first-child {
+    padding-left: 0;
+  }
+
   &:has(.scroll-shim) {
     li:nth-child(2) {
       padding-left: 0;

--- a/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
+++ b/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
@@ -13,14 +13,12 @@ export const ListItem = styled.li<{ $usesShim?: boolean }>`
     props.$usesShim
       ? `
       &:nth-child(2) {
-        padding-left: 0;
         width: calc(400px - var(--gutter-size));
         max-width: calc(90vw - var(--gutter-size));
       }
       `
       : `
       &:first-child {
-        padding-left: 0;
         width: calc(400px - var(--gutter-size));
         max-width: calc(90vw - var(--gutter-size));
       }

--- a/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
+++ b/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
@@ -10,15 +10,21 @@ export const ListItem = styled.li<{ $usesShim?: boolean }>`
   padding-left: var(--gutter-size);
 
   ${props =>
-    !props.$usesShim
+    props.$usesShim
       ? `
-      &:first-child {
+      &:nth-child(2) {
         padding-left: 0;
         width: calc(400px - var(--gutter-size));
         max-width: calc(90vw - var(--gutter-size));
       }
       `
-      : ''}
+      : `
+      &:first-child {
+        padding-left: 0;
+        width: calc(400px - var(--gutter-size));
+        max-width: calc(90vw - var(--gutter-size));
+      }
+      `}
 
   &:last-child {
     width: calc(400px + var(--gutter-size));
@@ -43,7 +49,6 @@ export const ListItem = styled.li<{ $usesShim?: boolean }>`
         props.$usesShim
           ? `
           &:nth-child(2) {
-            padding-left: 0;
             width: calc((100vw - (${paddingCalc}) - (${smGutter} * 11)) / 2 + (${smGutter} * 5));
           }`
           : `


### PR DESCRIPTION
## What does this change?

If the shim is in use (`useShim`) then it is now always displays, and the list item after it (`nth-child(2)`) has it's `padding-left` set to `0` across all breakpoints.

## How to test

- Visit [`/collections`](https://www-dev.wellcomecollection.org/collections)
- Visit [`/collections/people-and-organisations`](https://www-dev.wellcomecollection.org/collections/people-and-organisations)
- Visit [`/collections/subjects/public-health`](https://www-dev.wellcomecollection.org/collections/subjects/public-health)
- Resize all three and check the alignment of the left-most `ThemeCard` is flush to the left of the grid

## How can we measure success?

Looks better

## Have we considered potential risks?

n/a

