### PR TITLE
Add a header to Pa11y action so we can whitelist it in WAF

### DIFF
--- a/pa11y/webapp/report-and-deploy.js
+++ b/pa11y/webapp/report-and-deploy.js
@@ -73,6 +73,8 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 const runPa11y = async url => {
   return pa11y(url, {
     timeout: 120000,
+    userAgent:
+      'WellcomeCollection-Pa11y/1.0 (GitHub Actions; accessibility testing)',
     chromeLaunchConfig: {
       args: ['--no-sandbox'],
     },


### PR DESCRIPTION
## What does this change?

We've been having issues with the automated Pa11y runs not succeeding due to what I _think_ is rate limiting related.
One of the suggested solutions is to pass it a customer user-agent header and then whitelisting that in WAF.

So this is me trying that! I'll do the WAF bit manually to test first. If successful, then I can terraform it.

Slack convos 
https://wellcome.slack.com/archives/CUA669WHH/p1776069144899039
https://wellcome.slack.com/archives/C3TQSF63C/p1776241487409529
https://wellcome.slack.com/archives/CUA669WHH/p1776335548248879

## How to test

Not sure, we see if the whitelisting helps for a few days?

## How can we measure success?

Pa11y tests are always whitelisted.

## Have we considered potential risks?
I don't fully know what I'm doing so, probably some risk, but this is just Pa11y runs which is just used by us.