### PR TITLE
Don't limit width of ThemeCards

### DIFF
--- a/common/views/components/ThemeCard/index.tsx
+++ b/common/views/components/ThemeCard/index.tsx
@@ -21,8 +21,6 @@ const Title = styled(Space).attrs({
 const CardWrapper = styled.div`
   position: relative;
   width: 100%;
-  max-width: 25rem;
-  margin: 0 auto;
   display: block;
   color: ${props => props.theme.color('white')};
   container-type: inline-size;


### PR DESCRIPTION
## What does this change?

Allows the ThemeCards to fill their available ListItem space meaning that they consistently line up with the grid at all breakpoints, preventing the scenario we currently see at c. 1000px in which the ThemeCards are centred within their available space limited to 25rem, making them appear to not line up on the grid.

## How to test

- Visit the collections landing page and resize from above to below 1000px, and check the first ThemeCard remains flush to the left side of the grid

## How can we measure success?

Things look less broken

## Have we considered potential risks?

The ThemeCards can now grow slightly taller than before at this specific browser width. But concluded that that's ok.

