### PR TITLE
Reorganise agents instructions md files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,7 +50,7 @@ Key locations for shared code:
 - `content/webapp/services/prismic/transformers/` - Prismic transformers
 - `content/webapp/services/` - API clients for catalogue, content, concepts
 
-Use `@weco/common` imports, not relative paths across package boundaries. If you see duplication, flag it and suggest the existing shared implementation.
+Use `@weco/` package names, not relative paths across package boundaries. If you see duplication, flag it and suggest the existing shared implementation.
 
 ## Prismic Conventions
 <!-- https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/451yLOIRTl5YiAJ88yIL/api-id-name-casing#future-api-id-naming -->

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,18 +1,87 @@
-# Wellcome Collection PR Review Guidelines
+# Wellcome Collection Coding Standards
 
-**These guidelines are specifically for PR reviews.** For active development guidelines, see [AGENTS.md](../AGENTS.md).
+These guidelines are read by all Copilot surfaces (IDE agent, PR reviewer, cloud agent). For agent-specific operational guidelines (build commands, working style), see [AGENTS.md](../AGENTS.md).
 
-Patterns and conventions to check for when reviewing pull requests. General coding standards (language, workspace structure, naming conventions, etc.) are in AGENTS.md.
+Use British English spelling throughout everything that is not code (e.g. CSS values are in American English).
 
-Please make sure you add a cow emoji to your review comment to confirm that you've read and considered these guidelines as part of your review.
+## Workspace Structure
 
-## TODOs and Technical Debt
+This is a monorepo with multiple Next.js apps managed by Yarn workspaces:
+- `common/` - shared code used by all apps (components, utilities, services, types)
+- `content/webapp/` - main public-facing website (stories, exhibitions, events, catalogue)
+- `identity/webapp/` - account management app (login, registration, library membership)
+- `toggles/webapp/` - feature flags management
+- `dash/webapp/` - internal dashboard
+
+All shared code lives in `common/` and is imported using `@weco/` package names, not relative paths across package boundaries.
+
+## Naming Conventions
+
+Follow these patterns consistently:
+- Component files: PascalCase (`Header.tsx`, `PageLayout.tsx`)
+- Utility files: kebab-case (`undici-agent.ts`, `json-ld.ts`)
+- Test files: same name as source with `.test.ts` / `.test.tsx` suffix (match the source extension, e.g. `Component.tsx` → `Component.test.tsx`)
+- Type declarations: `.d.ts` extension for ambient declarations
+- Service/utility folders: use `index.ts` as the main export point
+
+## Accessibility
+
+We aim for WCAG AA compliance as a minimum:
+
+- Semantic HTML (proper heading hierarchy, landmarks, form labels)
+- Keyboard navigation for all interactive elements
+- Alt text for meaningful images (empty `alt=""` for decorative ones)
+- Colour contrast ratios meet AA standards
+- ARIA attributes used correctly (don't over-use them — semantic HTML is usually better)
+- Focus management in interactive components (modals, dropdowns, etc.)
+- Screen reader navigation and announcements
+
+## Duplication and Code Reuse
+
+Before creating new utilities, helpers, or services:
+1. Search `common/utils/` and `common/services/` for existing implementations
+2. Check if similar logic exists elsewhere in the codebase
+3. If you find duplication, refactor to use a shared utility instead of creating a new one
+4. When removing dependencies, clean up unused imports and delete obsolete files
+
+Key locations for shared code:
+- `common/utils/` - shared utilities
+- `common/services/` - shared services (API clients, etc.)
+- `content/webapp/services/prismic/transformers/` - Prismic transformers
+- `content/webapp/services/` - API clients for catalogue, content, concepts
+
+Use `@weco/common` imports, not relative paths across package boundaries. If you see duplication, flag it and suggest the existing shared implementation.
+
+## Prismic Conventions
+<!-- https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/451yLOIRTl5YiAJ88yIL/api-id-name-casing#future-api-id-naming -->
+As the site has evolved we have introduced some inconsistencies in how we have named Prismic custom types, slices, and their fields. Some are kebab-case, some are camelCase and some are snake_case. Some are singular when they should have been plural. We put together an RFC to decide how we want to approach these names in future. We also discussed whether we wanted to unify what we already have but concluded that the effort and risk involved in changing existing API IDs wasn't worth it.
+
+### Future API ID naming
+- Custom type IDs should be kebab-case. Plural for repeatable types (e.g. `exhibition-highlight-tours`) and singular for singleton types (e.g. `global-alert`). This involves overriding the default snake_case ids that Prismic will suggest
+- Field IDs for all Custom types and Slices should be camelCase (e.g. `datePublished`). This involves overriding the default snake_case ids that Prismic will suggest
+- Slice IDs should be snake_case (e.g. `guide_section_heading`) — this is the default from Prismic and can't be overridden in the UI
+
+## Server vs Client Code
+
+Next.js code runs in both Node.js (server-side rendering) and the browser (client-side). When using Node.js-only APIs or packages:
+
+- Use `typeof window === 'undefined'` to detect server-side context
+- Use dynamic imports `await import()` for Node.js-only packages
+- Add webpack config to exclude server-only packages from client bundles
+
+Server-only packages that try to load in the browser will cause "Cannot find module" errors even with webpack exclusion. You need both webpack config AND runtime checks.
+
+## PR Review Guidelines
+
+When reviewing, check changes against the coding standards above (accessibility, duplication, naming, Prismic conventions).
+
+### TODOs and Technical Debt
 
 When you see new TODOs being added, ask whether this is the right time to add it or if it should be addressed in the current PR.
 
-For existing TODOs in the code being changed, check whether they are still relevant. If a TODO is clearly obsolete or the work has already been completed, you can suggest removing or updating it; otherwise, leave it in place, but you may note any apparent staleness to the author.
+For existing TODOs in the code being changed, check whether they are still relevant. If a TODO is clearly obsolete or the work has already been completed, suggest removing or updating it; otherwise, leave it in place, but note any apparent staleness to the author.
 
-## Documentation
+### Documentation
 
 When reviewing, check whether documentation needs updating:
 - READMEs affected by new features, changed commands, or modified setup steps
@@ -22,31 +91,3 @@ When reviewing, check whether documentation needs updating:
 - The AGENTS.md and copilot-instructions.md files if the changes affect coding standards or instructions for Copilot
 
 If the PR changes behaviour or adds features but doesn't update relevant docs, flag it.
-
-## Accessibility
-
-We aim for WCAG AA compliance as a minimum. When reviewing, check for:
-
-- Semantic HTML (proper heading hierarchy, landmarks, form labels)
-- Keyboard navigation support
-- Alt text for images
-- Colour contrast ratios
-- ARIA attributes used correctly (not over-used)
-- Focus management in interactive components
-- Screen reader navigation and announcements
-
-## Duplication and Code Reuse
-
-When reviewing, check whether:
-- New utilities or helpers duplicate existing code in `common/utils/` or `common/services/`
-- Logic appears in multiple places that could be centralised
-- Imports use `@weco/` packages rather than relative paths across package boundaries
-- Removed dependencies have left behind unused imports or obsolete files or functions
-
-Key locations for shared code:
-- `common/utils/` - shared utilities
-- `common/services/` - shared services
-- `content/webapp/services/prismic/transformers/` - Prismic transformers
-- `content/webapp/services/` - API clients
-
-If you see duplication, flag it and suggest the existing shared implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,8 @@
 # Wellcome Collection Development Guidelines
 
-**These guidelines are for active development and coding tasks.** For PR review guidelines, see [.github/copilot-instructions.md](.github/copilot-instructions.md).
+**These guidelines are for active development and coding tasks.** Shared coding standards and PR review guidelines are in [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
-Guidelines for AI assistants working on the Wellcome Collection codebase.
-
-## Special instructions for Copilot reviews
-Hi Copilot, please add a comment in your review that confirms whether or not you've 1) read this document and 2) considered it as part of your review. Make sure it ends with a sun emoji.
+Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions) are in [.github/copilot-instructions.md](.github/copilot-instructions.md) — don't duplicate them here.
 
 ## Working Style
 
@@ -18,26 +15,6 @@ Hi Copilot, please add a comment in your review that confirms whether or not you
 - Check that imports and dependencies are correct
 
 Use British English spelling throughout everything that is not code (e.g. CSS values are in American English). Write casually and keep explanations clear. Don't use emojis or bold text in responses.
-
-## Workspace Structure
-
-This is a monorepo with multiple Next.js apps managed by Yarn workspaces:
-- `common/` - shared code used by all apps (components, utilities, services, types)
-- `content/webapp/` - main public-facing website (stories, exhibitions, events, catalogue)
-- `identity/webapp/` - account management app (login, registration, library membership)
-- `toggles/webapp/` - feature flags management
-- `dash/webapp/` - internal dashboard
-
-All shared code lives in `common/` and is imported using `@weco/` package names, not relative paths across package boundaries.
-
-## Prismic values
-<!-- https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/451yLOIRTl5YiAJ88yIL/api-id-name-casing#future-api-id-naming -->
-As the site has evolved we have introduced some inconsistencies in how we have named Prismic custom types, slices, and their fields. Some are kebab-case, some are camelCaseand some are snake_case. Some are singular when they should have been plural. We put together an RFC to decide how we want to approach these names in future. We also discussed whether we wanted to unify what we already have but concluded that the effort and risk involved in changing existing API IDs wasn't worth it.
-
-### Future API ID naming
-- Custom type IDs should be kebab-case. Plural for repeatable types (e.g. `exhibition-highlight-tours` and singular for singleton types (e.g. `global-alert`). This involves overriding the default snake_caseids that Prismic will suggest
-- Field IDs for all Custom types and Slices should be camelCase (e.g. `datePublished`). This involves overriding the default snake_case ids that Prismic will suggest
-- Slice IDs should be snake_case (e.g. `guide_section_heading`) – this is the default from Prismic and can't be overridden in the UI
 
 ## Build and Test
 
@@ -89,42 +66,6 @@ The team is strong on front-end but may benefit from extra explanation of backen
 - **Docker and deployment**: How code gets built and deployed to production.
 
 When implementing backend code, explain the reasoning behind technical decisions, not just what the code does.
-
-## Accessibility
-
-We aim for WCAG AA compliance as a minimum. Implement accessible patterns:
-
-- Use semantic HTML (proper heading hierarchy, landmarks, form labels)
-- Ensure keyboard navigation works for all interactive elements
-- Provide alt text for meaningful images (empty alt="" for decorative ones)
-- Check colour contrast ratios meet AA standards
-- Use ARIA attributes correctly (don't over-use them - semantic HTML is usually better)
-- Manage focus properly in interactive components (modals, dropdowns, etc.)
-
-## Naming Conventions
-
-Follow these patterns consistently:
-- Component files: PascalCase (`Header.tsx`, `PageLayout.tsx`)
-- Utility files: kebab-case (`undici-agent.ts`, `json-ld.ts`)
-- Test files: same name as source with `.test.ts` / `.test.tsx` suffix (match the source extension, e.g. `Component.tsx` → `Component.test.tsx`)
-- Type declarations: `.d.ts` extension for ambient declarations
-- Service/utility folders: use `index.ts` as the main export point
-
-## Avoid Duplication
-
-Before creating new utilities, helpers, or services:
-1. Search `common/utils/` and `common/services/` for existing implementations
-2. Check if similar logic exists elsewhere in the codebase
-3. If you find duplication, refactor to use a shared utility instead of creating a new one
-4. When removing dependencies, clean up unused imports and delete obsolete files
-
-Key locations for shared code:
-- `common/utils/` - shared utilities
-- `common/services/` - shared services (API clients, etc.)
-- `content/webapp/services/prismic/transformers/` - Prismic content transformers
-- `content/webapp/services/` - API clients for catalogue, content, concepts
-
-Use `@weco/common` imports, not relative paths across package boundaries.
 
 ## Pull Requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Guidelines for AI assistants working on the Wellcome Collection codebase. Shared
 - Test your changes locally where possible
 - Check that imports and dependencies are correct
 
-Use British English spelling throughout everything that is not code (e.g. CSS values are in American English). Write casually and keep explanations clear. Don't use emojis or bold text in responses.
+Write casually and keep explanations clear. Don't use emojis or bold text in responses.
 
 ## Build and Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **These guidelines are for active development and coding tasks.** Shared coding standards and PR review guidelines are in [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
-Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions) are in [.github/copilot-instructions.md](.github/copilot-instructions.md) — don't duplicate them here.
+Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions) are in [.github/copilot-instructions.md](.github/copilot-instructions.md) — don't duplicate them here. The sections below cover agent-specific operational guidance.
 
 ## Working Style
 

--- a/common/views/components/DownloadLink/index.tsx
+++ b/common/views/components/DownloadLink/index.tsx
@@ -47,9 +47,6 @@ const TextToDisplay = styled.span<{ $isDark?: boolean }>`
   text-underline-offset: 0.1em;
 `;
 
-/**
- * TODO: figure out why Icon isn't able to be wrapped by styled...
- */
 const IconWrapper = styled(Space).attrs<{
   $forceInline: boolean;
 }>({ $h: { size: 'xs', properties: ['margin-right'] } })`


### PR DESCRIPTION
## What does this change?

I'd misunderstood what would read what. I saw `github/copilot-instructions` as "Github.com" when it IS read by all Copilots. 

So I moved our general conventions over, as we want both the reviewer Copilot and the IDE AIs to be aware of them.

`AGENTS.md` is now just the stuff that's useful when we vibe/pair code in our IDEs and we don't want to confuse the reviewer with.

See here for my investigation: https://wellcome.slack.com/archives/CUA669WHH/p1776849808807389

## How to test

Interact with it 🤷‍♀️ 

## How can we measure success?

Copilot reviews in Github consider all of our conventions (can you confirm this in your review, Copilot?)
Claude and all our IDE buddies are still aware of our conventions but also consider AGENTS.md for coding we like more.

## Have we considered potential risks?
None really, this is a tool for us.