### PR TITLE
Add WAF rule for whitelisting github actions IPs

### DIFF
--- a/cache/cloudfront_e2e.tf
+++ b/cache/cloudfront_e2e.tf
@@ -48,6 +48,7 @@ module "e2e_wc_org_cloudfront_distribution" {
   response_policies = module.cloudfront_policies.response_policies
   waf_ip_allowlist  = local.waf_ip_allowlist
 
-  google_bots_ip_set_arn = aws_wafv2_ip_set.google_bots.arn
-  header_shared_secret   = local.current_shared_secret
+  google_bots_ip_set_arn    = aws_wafv2_ip_set.google_bots.arn
+  github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
+  header_shared_secret      = local.current_shared_secret
 }

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -29,8 +29,9 @@ module "prod_wc_org_cloudfront_distribution" {
   response_policies = module.cloudfront_policies.response_policies
   waf_ip_allowlist  = local.waf_ip_allowlist
 
-  google_bots_ip_set_arn = aws_wafv2_ip_set.google_bots.arn
-  header_shared_secret   = local.current_shared_secret
+  google_bots_ip_set_arn    = aws_wafv2_ip_set.google_bots.arn
+  github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
+  header_shared_secret      = local.current_shared_secret
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -28,6 +28,7 @@ module "stage_wc_org_cloudfront_distribution" {
   /* We only need access where servers are running and we don't want to allow access from other countries as we have seen malicious traffic which disrupted staging. */
   allowed_countries = ["GB", "US", "IE"]
 
-  google_bots_ip_set_arn = aws_wafv2_ip_set.google_bots.arn
-  header_shared_secret   = local.current_shared_secret
+  google_bots_ip_set_arn    = aws_wafv2_ip_set.google_bots.arn
+  github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
+  header_shared_secret      = local.current_shared_secret
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -61,3 +61,8 @@ variable "google_bots_ip_set_arn" {
   type        = string
   description = "ARN of the shared google-bots IP set (defined at root level)"
 }
+
+variable "github_actions_ip_set_arn" {
+  type        = string
+  description = "ARN of the shared github-actions IP set (defined at root level)"
+}

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -181,8 +181,29 @@ resource "aws_wafv2_web_acl" "wc_org" {
   }
 
   rule {
-    name     = "managed-ip-blocking"
+    name     = "allow-github-actions"
     priority = 4
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = var.github_actions_ip_set_arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "allow-github-actions-${var.namespace}"
+    }
+  }
+
+  rule {
+    name     = "managed-ip-blocking"
+    priority = 5
 
     override_action {
       none {}
@@ -205,7 +226,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "apac-captcha-consent-block"
-    priority = 5
+    priority = 6
 
     action {
       captcha {}
@@ -255,7 +276,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "latam-captcha-consent-block"
-    priority = 6
+    priority = 7
 
     action {
       captcha {}
@@ -305,7 +326,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 7
+    priority = 8
 
     action {
       block {
@@ -340,7 +361,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 8
+    priority = 9
 
     action {
       block {
@@ -380,7 +401,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 9
+    priority = 10
 
     action {
       block {
@@ -417,7 +438,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 10
+    priority = 11
 
     action {
       block {}
@@ -439,7 +460,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 11
+    priority = 12
 
     action {
       block {}
@@ -477,7 +498,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 12
+    priority = 13
 
     override_action {
       none {}
@@ -500,7 +521,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 13
+    priority = 14
 
     override_action {
       none {}
@@ -523,7 +544,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 14
+    priority = 15
 
     override_action {
       none {}
@@ -545,7 +566,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 15
+    priority = 16
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -592,7 +613,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-user-agent-manual"
-    priority = 16
+    priority = 17
 
     action {
       block {}


### PR DESCRIPTION
## What does this change?

Follow https://github.com/wellcomecollection/wellcomecollection.org/pull/12979 for https://github.com/wellcomecollection/wellcomecollection.org/issues/12978

This adds a WAF rule for our 3 environments to ensure IPs listed in our GitHub Actions IP set are whitelisted. It should ensure Pa11y doesn't fail on automated runs, for example.

I've placed it just after the Google Bots rule that does the same thing

## How to test

I'll have applied it first, you will be able to see it and how it behaves in WAF.

## How can we measure success?

All our GH actions should run smoothly without running into our self made barriers.

## Have we considered potential risks?
Errrr can't think of any?
