### PR TITLE
Add mimeType to GTM props in Download button

### DIFF
--- a/cardigan/stories/components/Links/DownloadLink/DownloadLink.stories.tsx
+++ b/cardigan/stories/components/Links/DownloadLink/DownloadLink.stories.tsx
@@ -8,20 +8,19 @@ const meta: Meta<typeof DownloadLink> = {
   args: {
     href: '/',
     linkText: 'Download file',
-    format: 'PDF',
+    format: 'application/pdf',
     isDark: false,
   },
   argTypes: {
     href: { table: { disable: true } },
     isTabbable: { table: { disable: true } },
-    mimeType: { table: { disable: true } },
     linkText: {
       name: 'Text',
     },
     format: {
       name: 'Format',
       control: 'radio',
-      options: ['PDF', 'JPEG', 'MP3', undefined],
+      options: ['application/pdf', 'image/jpeg', 'audio/mpeg', undefined],
     },
     isDark: {
       name: 'isDark: is on a dark background',

--- a/common/utils/gtm.ts
+++ b/common/utils/gtm.ts
@@ -4,6 +4,7 @@ type DataGtmAttr =
   | 'category-position-in-list'
   | 'id'
   | 'label'
+  | 'mime-type'
   | 'position-in-list'
   | 'trigger';
 export type DataGtmProps = Partial<Record<DataGtmAttr, string>>;

--- a/common/views/components/DownloadLink/index.tsx
+++ b/common/views/components/DownloadLink/index.tsx
@@ -3,8 +3,10 @@ import styled from 'styled-components';
 
 import { download } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
+import { getFormatString } from '@weco/content/utils/iiif/v3';
 
 const DownloadLinkStyle = styled.a.attrs<{ $isDark?: boolean }>(props => ({
   className: props.$isDark ? font('sans', -1) : font('sans-bold', -1),
@@ -67,20 +69,21 @@ type Props = {
   isTabbable?: boolean;
   href: string;
   format?: string;
-  mimeType: string;
   isDark?: boolean;
 } & DisplayText;
+
 const DownloadLink: FunctionComponent<Props> = ({
   isTabbable = true,
   href,
   linkText,
   format,
-  mimeType,
   children,
   isDark,
 }: Props) => {
   const Wrapper = linkText ? DownloadLinkStyle : DownloadLinkUnStyled;
   const iconColor = isDark ? 'yellow' : 'accent.green';
+  const readableFormat = format ? getFormatString(format) : undefined;
+
   return (
     <Wrapper
       $isDark={isDark}
@@ -89,8 +92,10 @@ const DownloadLink: FunctionComponent<Props> = ({
       rel="noopener noreferrer"
       href={href}
       data-component="download-link"
-      data-gtm-trigger="download_link"
-      data-gtm-mime-type={mimeType}
+      {...dataGtmPropsToAttributes({
+        'mime-type': format || 'null', // Default value requested by analyst
+        trigger: 'download_link',
+      })}
     >
       <span
         style={
@@ -102,10 +107,12 @@ const DownloadLink: FunctionComponent<Props> = ({
         <IconWrapper $forceInline={!!children}>
           <Icon icon={download} matchText={!!children} iconColor={iconColor} />
         </IconWrapper>
+
         <TextToDisplay $isDark={isDark}>{linkText || children}</TextToDisplay>
-        {format && (
+
+        {readableFormat && (
           <Format as="span" $isDark={isDark}>
-            ({format})
+            ({readableFormat})
           </Format>
         )}
       </span>

--- a/common/views/components/DownloadLink/index.tsx
+++ b/common/views/components/DownloadLink/index.tsx
@@ -6,7 +6,6 @@ import { font } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
-import { getFormatString } from '@weco/content/utils/iiif/v3';
 
 const DownloadLinkStyle = styled.a.attrs<{ $isDark?: boolean }>(props => ({
   className: props.$isDark ? font('sans', -1) : font('sans-bold', -1),
@@ -64,6 +63,26 @@ type DisplayText =
       children?: never;
       linkText: string;
     };
+
+function getFormatString(format?: string): string {
+  switch (format) {
+    case 'application/pdf':
+      return 'PDF';
+    case 'text/plain':
+      return 'PLAIN';
+    case 'image/jpeg':
+      return 'JPG';
+    case 'video/mp4':
+      return 'MP4';
+    case 'video/webm':
+      return 'WebM';
+    case 'audio/mp3':
+    case 'audio/x-mpeg-3':
+      return 'MP3';
+    default:
+      return 'unknown format';
+  }
+}
 
 type Props = {
   isTabbable?: boolean;

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -148,9 +148,13 @@ export const defaultSerializer: JSXFunctionSerializer = (
         return (
           <DownloadLink
             href={linkUrl}
-            mimeType={getMimeTypeFromExtension(
-              (fileExtension && fileExtension[0].substring(1)) || ''
-            )}
+            format={
+              fileExtension
+                ? getMimeTypeFromExtension(
+                    fileExtension && fileExtension[0].substring(1)
+                  )
+                : undefined
+            }
           >
             {children}{' '}
             <span style={{ whiteSpace: 'nowrap' }}>

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -780,26 +780,6 @@ export function hasNonImagesOrOriginals(
   return !!hasNonImage;
 }
 
-export function getFormatString(format?: string): string {
-  switch (format) {
-    case 'application/pdf':
-      return 'PDF';
-    case 'text/plain':
-      return 'PLAIN';
-    case 'image/jpeg':
-      return 'JPG';
-    case 'video/mp4':
-      return 'MP4';
-    case 'video/webm':
-      return 'WebM';
-    case 'audio/mp3':
-    case 'audio/x-mpeg-3':
-      return 'MP3';
-    default:
-      return 'unknown format';
-  }
-}
-
 export function getStructures(manifest: Manifest | Collection): Range[] {
   if (isCollection(manifest)) {
     return [];

--- a/content/webapp/views/components/Download/index.tsx
+++ b/content/webapp/views/components/Download/index.tsx
@@ -8,7 +8,6 @@ import DownloadLink from '@weco/common/views/components/DownloadLink';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
 import { DownloadOption } from '@weco/content/types/manifest';
-import { getFormatString } from '@weco/content/utils/iiif/v3';
 
 export const DownloadOptions = styled.div.attrs({
   className: font('sans-bold', 0),
@@ -60,25 +59,20 @@ const Download: FunctionComponent<Props> = ({
         <DownloadOptions className={font('sans-bold', -1)}>
           <SpacingComponent>
             <PlainList>
-              {downloadOptions.map(option => {
-                const format = getFormatString(option.format);
-
-                return (
-                  <li key={option.id}>
-                    <DownloadLink
-                      href={option.id}
-                      linkText={
-                        option.format === 'application/pdf' &&
-                        option.label !== 'PDF Transcript'
-                          ? 'Whole item'
-                          : option.label
-                      }
-                      format={format}
-                      mimeType={option.format}
-                    />
-                  </li>
-                );
-              })}
+              {downloadOptions.map(option => (
+                <li key={option.id}>
+                  <DownloadLink
+                    href={option.id}
+                    linkText={
+                      option.format === 'application/pdf' &&
+                      option.label !== 'PDF Transcript'
+                        ? 'Whole item'
+                        : option.label
+                    }
+                    format={option.format}
+                  />
+                </li>
+              ))}
             </PlainList>
           </SpacingComponent>
         </DownloadOptions>

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Download.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Download.tsx
@@ -85,6 +85,7 @@ const IIIFItemDownload: FunctionComponent<Props> = ({
         text={action}
         ariaLabel={`${action} ${(displayLabel !== substituteTitle && label) || 'document'}`}
         dataGtmProps={{
+          trigger: 'canvas_download_link',
           'mime-type': format || 'null', // Default value requested by analyst
         }}
       />

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Download.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Download.tsx
@@ -67,21 +67,28 @@ const IIIFItemDownload: FunctionComponent<Props> = ({
         icon={isFilePdf ? pdf : file}
         sizeOverride="width: 48px; height: 48px;"
       />
+
       <Space
         className={font('sans-bold', -1)}
         $v={{ size: 'sm', properties: ['margin-top', 'margin-bottom'] }}
       >
         {displayLabel}
       </Space>
+
       {showWarning && (
         <div className={font('sans', -2)}>{bornDigitalWarning}</div>
       )}
+
       <Buttons
         variant="ButtonSolidLink"
         link={src}
         text={action}
         ariaLabel={`${action} ${(displayLabel !== substituteTitle && label) || 'document'}`}
+        dataGtmProps={{
+          'mime-type': format || 'null', // Default value requested by analyst
+        }}
       />
+
       <span className={font('sans', -2)}>
         Size:{' '}
         <span className={font('sans-bold', -2)}>{fileSize || 'unknown'}</span>

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.VideoTranscript.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.VideoTranscript.tsx
@@ -8,7 +8,6 @@ import { FunctionComponent } from 'react';
 
 import DownloadLink from '@weco/common/views/components/DownloadLink';
 import Space from '@weco/common/views/components/styled/Space';
-import { getFormatString } from '@weco/content/utils/iiif/v3';
 
 type Props = {
   supplementing: (ContentResource | ChoiceBody)[];
@@ -34,8 +33,7 @@ const VideoTranscript: FunctionComponent<Props> = ({
               <DownloadLink
                 href={displayItem.id}
                 linkText="Transcript of video"
-                format={getFormatString(displayItem.format)}
-                mimeType={displayItem.format || ''}
+                format={displayItem.format}
                 isDark={isDark}
               />
             </Space>

--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -42,7 +42,6 @@ import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iii
 import { hasRestrictedItem } from '@weco/content/utils/iiif/v3';
 import {
   getFileSize,
-  getFormatString,
   getImageServiceFromItem,
   getLabelString,
 } from '@weco/content/utils/iiif/v3';
@@ -487,7 +486,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             src={item.id}
             label={itemLabel}
             fileSize={getFileSize(canvas)}
-            format={'format' in item ? getFormatString(item.format) : undefined}
+            format={'format' in item ? item.format : undefined}
           />
         </IIIFItemWrapper>
       );
@@ -514,11 +513,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
                       src={original.id}
                       label={itemLabel}
                       fileSize={getFileSize(canvas)}
-                      format={
-                        'format' in item
-                          ? getFormatString(item.format)
-                          : undefined
-                      }
+                      format={'format' in item ? item.format : undefined}
                       showWarning={true}
                     />
                   </IIIFItemWrapper>

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -28,7 +28,6 @@ import {
 import {
   getAuthServices,
   getFileTypeLabel,
-  getFormatString,
   getIframeTokenSrc,
   getLabelString,
   hasItemType,
@@ -395,8 +394,7 @@ const WorkDetailsAvailableOnline = ({
                           <DownloadLink
                             href={rendering.id}
                             linkText={label || 'Download'}
-                            format={getFormatString(rendering.format)}
-                            mimeType={rendering.format || ''}
+                            format={rendering.format}
                           />
                         </Space>
                       );


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/wellcomecollection.org/issues/12977
<img width="825" height="463" alt="Screenshot 2026-04-22 at 16 46 55" src="https://github.com/user-attachments/assets/ddcdc799-13a3-4238-8b6b-53e88974d40d" />

Adds `data-gtm-mime-type` tracking to download links across the site. Previously, `DownloadLink` took separate `format` (for display) and `mimeType` (for analytics) props, with callers responsible for converting MIME types to readable strings via `getFormatString`. This was repetitive as every call site had to do the same conversion.

Now:
- `DownloadLink` accepts the raw MIME type as `format` and handles the display conversion internally using `getFormatString`
- The `mimeType` prop is removed — `format` serves both purposes
- `data-gtm-mime-type` is set via `dataGtmPropsToAttributes` instead of a hardcoded attribute, and `'mime-type'` is added to the `DataGtmAttr` type
- `IIIFItem.Download` (which uses `Buttons` rather than `DownloadLink`) passes `mime-type` via the `dataGtmProps` prop
- When no format is available, the value defaults to `'null'` as [requested by Mankeet](https://wellcome.slack.com/archives/CUA669WHH/p1776871802178139?thread_ts=1776869976.213099&cid=CUA669WHH)
- `getFormatString` was moved inside `DownloadLink` as it's never used elsewhere.

## How to test

1. Navigate to a work with downloadable files (e.g. https://www-dev.wellcomecollection.org/works/a5xuz9v5/items)
2. Inspect the download link/button elements in dev tools
3. Confirm `data-gtm-mime-type` is present with the correct MIME type value (e.g. `application/pdf`)
4. For items without a format, confirm `data-gtm-mime-type="null"` (I don't have an example at hand..)
5. Check the displayed format label still shows readable text (e.g. "PDF" not "application/pdf")

## How can we measure success?

Mankeet can filter download events by MIME type in GA, giving us visibility into which file formats users are downloading.

## Have we considered potential risks?

Low risk. This is a refactor of existing download link props plus adding a GTM attribute. No change to download functionality itself. The Cardigan stories have been updated to use MIME type strings to match the new prop contract.

