### PR TITLE
Add local pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## What does this change?
 
-<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
+<!-- A PR should have enough detail to be understandable far in the future. e.g., what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
 
 
 ## How to test

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+- For #
+
+## What does this change?
+
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
+
+
+## How to test
+
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+
+## Have we considered potential risks?
+
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 
 ## How to test
 
-<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z." -->
 
 
 ## Have we considered potential risks?


### PR DESCRIPTION
## What does this change?

Adds a local pull_request_template.md to override the [wellcomecollection org-wide template](https://github.com/wellcomecollection/.github/blob/main/PULL_REQUEST_TEMPLATE.md?plain=1)

## How to test

Read it and check it makes sense. The addition of a dash (-) before the 'For #' is deliberate: when linked issue numbers are in a list, they display their full title and merge status iconography instead of just the issue number.

## How can we measure success?

We stop having to fill this section in

## Have we considered potential risks?

We forget to measure success?