### PR TITLE
Pull `NestedList` out of `ArchiveTree`

### DIFF
--- a/content/webapp/test/works.test.ts
+++ b/content/webapp/test/works.test.ts
@@ -1,4 +1,3 @@
-import { idArray, uiTree } from '@weco/content/__mocks__/uiTree';
 import {
   legacyWorkWithMixedPartOf,
   legacyWorkWithPartOf,
@@ -15,7 +14,6 @@ import {
   getItemsWith,
   getProductionDates,
 } from '@weco/content/utils/works';
-import { getTabbableIds } from '@weco/content/views/pages/works/work/ArchiveTree/ArchiveTree.helpers';
 
 describe('getProductionDates', () => {
   it('extracts date labels from a work', () => {
@@ -310,13 +308,6 @@ it('Does not return non-archive parents', () => {
       availabilities: [],
     },
   ]);
-});
-
-describe('getTabbableIds', () => {
-  it('gets the ids from only the open branches of a uiTree and returns them as a flat array', () => {
-    const tabbableIds = getTabbableIds(uiTree);
-    expect(idArray).toEqual(tabbableIds);
-  });
 });
 
 describe('getDigitalLocationOfType', () => {

--- a/content/webapp/views/pages/works/work/ArchiveTree/ArchiveTree.WorkItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveTree/ArchiveTree.WorkItemRenderer.tsx
@@ -7,10 +7,13 @@ import { classNames, font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import { toWorkLink } from '@weco/content/views/components/WorkLink';
 import WorkTitle from '@weco/content/views/components/WorkTitle';
+import {
+  isRelatedWork,
+  TreeControl,
+} from '@weco/content/views/pages/works/work/NestedList';
 import { UiTreeNode } from '@weco/content/views/pages/works/work/work.types';
 
-import { isRelatedWork } from './ArchiveTree.helpers';
-import { StyledLink, TreeControl } from './ArchiveTree.styles';
+import { StyledLink } from './ArchiveTree.styles';
 
 const RefNumber = styled.span.attrs({
   className: font('sans', -2),
@@ -60,6 +63,7 @@ const WorkItem: FunctionComponent<WorkItemRendererProps> = ({
           <Icon rotate={item.openStatus ? undefined : 270} icon={chevron} />
         </TreeControl>
       )}
+
       <StyledLink
         {...toWorkLink({ id: item.work.id, scroll: false })}
         className={classNames({

--- a/content/webapp/views/pages/works/work/ArchiveTree/ArchiveTree.styles.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveTree/ArchiveTree.styles.tsx
@@ -4,13 +4,6 @@ import styled from 'styled-components';
 import Space from '@weco/common/views/components/styled/Space';
 import { controlDimensions } from '@weco/content/views/pages/works/work/work.helpers';
 
-import { TreeItemProps, verticalGuidePosition } from './ArchiveTree.helpers';
-
-export type TreeItemStyledProps = TreeItemProps & {
-  $isDarkMode?: boolean;
-  $listItem?: boolean;
-};
-
 export const TreeContainer = styled.div`
   border-right: 1px solid ${props => props.theme.color('warmNeutral.400')};
 `;
@@ -21,112 +14,6 @@ export const ButtonWrap = styled(Space).attrs({
   button {
     width: 100%;
     justify-content: center;
-  }
-`;
-
-export const TreeItem = styled.li.attrs<TreeItemStyledProps>(props => ({
-  className: props.$showGuideline ? 'guideline' : '',
-}))<TreeItemStyledProps>`
-  position: relative;
-
-  &.guideline::before,
-  &.guideline::after {
-    content: '';
-    position: absolute;
-    z-index: 2;
-  }
-
-  &.guideline::before {
-    border-left: 1px solid
-      ${props =>
-        props.$isDarkMode
-          ? props.theme.color('neutral.600')
-          : props.theme.color('yellow')};
-    width: 0;
-    top: ${verticalGuidePosition}px;
-    left: ${controlDimensions.controlWidth / 2}px;
-    height: calc(
-      100% - ${verticalGuidePosition + controlDimensions.controlHeight / 2}px
-    );
-  }
-
-  &.guideline::after {
-    display: block;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: ${props =>
-      props.$isDarkMode
-        ? props.theme.color('neutral.600')
-        : props.theme.color('yellow')};
-    left: ${controlDimensions.controlWidth / 2 - 3}px;
-    bottom: ${controlDimensions.controlHeight / 2}px;
-  }
-`;
-
-export type TreeControlStyledProps = {
-  $highlightCondition?: string;
-  $controlBackground?: string;
-  $controlBorder?: string;
-  $isDarkMode?: boolean;
-};
-
-export const TreeControl = styled.span<TreeControlStyledProps>`
-  display: inline-block;
-  cursor: pointer;
-  height: ${controlDimensions.controlHeight}px;
-  width: ${controlDimensions.controlWidth}px;
-  min-width: ${controlDimensions.controlWidth}px;
-  position: relative;
-  z-index: 1;
-
-  &::before {
-    content: '';
-    position: absolute;
-    height: ${controlDimensions.circleHeight}px;
-    width: ${controlDimensions.circleWidth}px;
-    top: calc(
-      (
-          ${controlDimensions.controlHeight}px -
-            ${controlDimensions.circleHeight}px
-        ) /
-        2
-    );
-    left: calc(
-      (
-          ${controlDimensions.controlWidth}px -
-            ${controlDimensions.circleWidth}px
-        ) /
-        2
-    );
-    background: ${props =>
-      props.$controlBackground ||
-      (props.$isDarkMode
-        ? props.theme.color('neutral.600')
-        : props.theme.color(
-            props.$highlightCondition === 'primary'
-              ? 'yellow'
-              : props.$highlightCondition === 'secondary'
-                ? 'lightYellow'
-                : 'neutral.300'
-          ))};
-    border: ${props =>
-      props.$controlBorder ||
-      (props.$isDarkMode
-        ? `2px solid ${props.theme.color('neutral.700')}`
-        : props.$highlightCondition === 'secondary'
-          ? `1px solid ${props.theme.color('yellow')}`
-          : `2px solid ${props.theme.color('white')}`)};
-    border-radius: 50%;
-  }
-
-  .icon {
-    position: absolute;
-    z-index: 1;
-    top: ${(controlDimensions.controlHeight - 24) / 2}px;
-    left: ${(controlDimensions.controlWidth - 24) / 2}px;
-    color: ${props =>
-      props.$isDarkMode ? props.theme.color('white') : 'inherit'};
   }
 `;
 

--- a/content/webapp/views/pages/works/work/ArchiveTree/index.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveTree/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { getWorkClientSide } from '@weco/content/services/wellcome/catalogue/works';
 import { getArchiveAncestorArray } from '@weco/content/utils/works';
+import NestedList from '@weco/content/views/pages/works/work/NestedList';
 import {
   Tree,
   TreeInstructions,
@@ -23,7 +24,6 @@ import {
   UiTreeNode,
 } from '@weco/content/views/pages/works/work/work.types';
 
-import NestedList from './ArchiveTree.NestedList';
 import { ButtonWrap, TreeContainer } from './ArchiveTree.styles';
 import WorkItem from './ArchiveTree.WorkItemRenderer';
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
@@ -23,7 +23,7 @@ import { getDigitalLocationInfo } from '@weco/content/utils/works';
 import LinkLabels from '@weco/content/views/components/LinkLabels';
 import WorkLink from '@weco/content/views/components/WorkLink';
 import WorkTitle from '@weco/content/views/components/WorkTitle';
-import NestedList from '@weco/content/views/pages/works/work/ArchiveTree/ArchiveTree.NestedList';
+import NestedList from '@weco/content/views/pages/works/work/NestedList';
 import DownloadItemRenderer from '@weco/content/views/pages/works/work/work.DownloadItemRenderer';
 import RestrictedItemMessage from '@weco/content/views/pages/works/work/work.RestrictedItemMessage';
 import WorksTree from '@weco/content/views/pages/works/work/WorkDetails/WorkDetails.Tree';

--- a/content/webapp/views/pages/works/work/NestedList/NestedList.ListItem.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/NestedList.ListItem.tsx
@@ -7,14 +7,14 @@ import {
   UiTreeNode,
 } from '@weco/content/views/pages/works/work/work.types';
 
+import NestedList from '.';
 import {
   getAriaLabel,
   getTabbableIds,
   ListProps,
   updateChildren,
-} from './ArchiveTree.helpers';
-import NestedList from './ArchiveTree.NestedList';
-import { TreeItem } from './ArchiveTree.styles';
+} from './NestedList.helpers';
+import { TreeItem } from './NestedList.styles';
 
 const LEFT = [37, 'ArrowLeft'];
 const RIGHT = [39, 'ArrowRight'];

--- a/content/webapp/views/pages/works/work/NestedList/NestedList.helpers.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/NestedList.helpers.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { RelatedWork } from '@weco/content/services/wellcome/catalogue/types';
+import { WorkItemRendererProps } from '@weco/content/views/pages/works/work/ArchiveTree/ArchiveTree.WorkItemRenderer';
 import { DownloadItemRendererProps } from '@weco/content/views/pages/works/work/work.DownloadItemRenderer';
 import { controlDimensions } from '@weco/content/views/pages/works/work/work.helpers';
 import {
@@ -9,8 +10,6 @@ import {
   UiTree,
   UiTreeNode,
 } from '@weco/content/views/pages/works/work/work.types';
-
-import { WorkItemRendererProps } from './ArchiveTree.WorkItemRenderer';
 
 export const verticalGuidePosition =
   controlDimensions.controlHeight / 2 +

--- a/content/webapp/views/pages/works/work/NestedList/NestedList.styles.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/NestedList.styles.tsx
@@ -1,0 +1,116 @@
+import styled from 'styled-components';
+
+import { controlDimensions } from '@weco/content/views/pages/works/work/work.helpers';
+
+import { TreeItemProps, verticalGuidePosition } from './NestedList.helpers';
+
+export type TreeItemStyledProps = TreeItemProps & {
+  $isDarkMode?: boolean;
+  $listItem?: boolean;
+};
+
+export const TreeItem = styled.li.attrs<TreeItemStyledProps>(props => ({
+  className: props.$showGuideline ? 'guideline' : '',
+}))<TreeItemStyledProps>`
+  position: relative;
+
+  &.guideline::before,
+  &.guideline::after {
+    content: '';
+    position: absolute;
+    z-index: 2;
+  }
+
+  &.guideline::before {
+    border-left: 1px solid
+      ${props =>
+        props.$isDarkMode
+          ? props.theme.color('neutral.600')
+          : props.theme.color('yellow')};
+    width: 0;
+    top: ${verticalGuidePosition}px;
+    left: ${controlDimensions.controlWidth / 2}px;
+    height: calc(
+      100% - ${verticalGuidePosition + controlDimensions.controlHeight / 2}px
+    );
+  }
+
+  &.guideline::after {
+    display: block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: ${props =>
+      props.$isDarkMode
+        ? props.theme.color('neutral.600')
+        : props.theme.color('yellow')};
+    left: ${controlDimensions.controlWidth / 2 - 3}px;
+    bottom: ${controlDimensions.controlHeight / 2}px;
+  }
+`;
+
+export type TreeControlStyledProps = {
+  $highlightCondition?: string;
+  $controlBackground?: string;
+  $controlBorder?: string;
+  $isDarkMode?: boolean;
+};
+
+export const TreeControl = styled.span<TreeControlStyledProps>`
+  display: inline-block;
+  cursor: pointer;
+  height: ${controlDimensions.controlHeight}px;
+  width: ${controlDimensions.controlWidth}px;
+  min-width: ${controlDimensions.controlWidth}px;
+  position: relative;
+  z-index: 1;
+
+  &::before {
+    content: '';
+    position: absolute;
+    height: ${controlDimensions.circleHeight}px;
+    width: ${controlDimensions.circleWidth}px;
+    top: calc(
+      (
+          ${controlDimensions.controlHeight}px -
+            ${controlDimensions.circleHeight}px
+        ) /
+        2
+    );
+    left: calc(
+      (
+          ${controlDimensions.controlWidth}px -
+            ${controlDimensions.circleWidth}px
+        ) /
+        2
+    );
+    background: ${props =>
+      props.$controlBackground ||
+      (props.$isDarkMode
+        ? props.theme.color('neutral.600')
+        : props.theme.color(
+            props.$highlightCondition === 'primary'
+              ? 'yellow'
+              : props.$highlightCondition === 'secondary'
+                ? 'lightYellow'
+                : 'neutral.300'
+          ))};
+    border: ${props =>
+      props.$controlBorder ||
+      (props.$isDarkMode
+        ? `2px solid ${props.theme.color('neutral.700')}`
+        : props.$highlightCondition === 'secondary'
+          ? `1px solid ${props.theme.color('yellow')}`
+          : `2px solid ${props.theme.color('white')}`)};
+    border-radius: 50%;
+  }
+
+  .icon {
+    position: absolute;
+    z-index: 1;
+    top: ${(controlDimensions.controlHeight - 24) / 2}px;
+    left: ${(controlDimensions.controlWidth - 24) / 2}px;
+    color: ${props =>
+      props.$isDarkMode ? props.theme.color('white') : 'inherit'};
+  }
+`;

--- a/content/webapp/views/pages/works/work/NestedList/NestedList.test.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/NestedList.test.tsx
@@ -1,4 +1,4 @@
-import { getTabbableIds } from './ArchiveTree.helpers';
+import { getTabbableIds } from './NestedList.helpers';
 
 describe('getTabbableIds', () => {
   it('finds all IDs', () => {
@@ -16,7 +16,7 @@ describe('getTabbableIds', () => {
     expect(result).toStrictEqual(['PENROSE', 'CRICK']);
   });
 
-  it('includes IDs of nodes which aren’t open', () => {
+  it('includes IDs of nodes which are not open', () => {
     const tree = [
       {
         work: { id: 'PENROSE' },

--- a/content/webapp/views/pages/works/work/NestedList/index.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/index.tsx
@@ -4,8 +4,8 @@ import { useAppContext } from '@weco/common/contexts/AppContext';
 import { font } from '@weco/common/utils/classnames';
 import { UiTree } from '@weco/content/views/pages/works/work/work.types';
 
-import { ListProps } from './ArchiveTree.helpers';
-import ListItem from './ArchiveTree.ListItem';
+import { ListProps } from './NestedList.helpers';
+import ListItem from './NestedList.ListItem';
 
 type NestedListProps = Omit<ListProps, 'item'> & {
   archiveTree: UiTree;
@@ -72,3 +72,6 @@ const NestedList: FunctionComponent<NestedListProps> = ({
 };
 
 export default NestedList;
+
+export { TreeControl } from './NestedList.styles';
+export { isRelatedWork } from './NestedList.helpers';

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -35,8 +35,8 @@ import {
 } from '@weco/content/utils/iiif/v3';
 import { DigitalLocationInfo } from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
-import NestedList from '@weco/content/views/pages/works/work/ArchiveTree/ArchiveTree.NestedList';
 import IIIFItemList from '@weco/content/views/pages/works/work/IIIFItemList';
+import NestedList from '@weco/content/views/pages/works/work/NestedList';
 import DownloadItemRenderer from '@weco/content/views/pages/works/work/work.DownloadItemRenderer';
 import { createDownloadTree } from '@weco/content/views/pages/works/work/work.helpers';
 import RestrictedItemMessage from '@weco/content/views/pages/works/work/work.RestrictedItemMessage';

--- a/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
@@ -9,7 +9,7 @@ import { controlDimensions } from '@weco/content/views/pages/works/work/work.hel
 import { UiTreeNode } from '@weco/content/views/pages/works/work/work.types';
 import DownloadItem from '@weco/content/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem';
 
-import { TreeControl } from './ArchiveTree/ArchiveTree.styles';
+import { TreeControl } from './NestedList';
 
 const ItemWrapper = styled.div.attrs({
   className: font('sans', -2),
@@ -62,6 +62,7 @@ const DownloadItemRenderer: FunctionComponent<DownloadItemRendererProps> = ({
     : fallbackIndex !== undefined && fallbackIndex >= 0
       ? fallbackIndex + 1
       : undefined;
+
   return (
     <ItemWrapper>
       {isEnhanced && hasControl && (


### PR DESCRIPTION
## What does this change?

We have to add analytics data to the tree but found it was used in different ways in different parts of works pages. Archive trees, but also download trees in Born digital works. We've also now added the latter to the item viewer. 

This refactor extracts and centralises the shared tree implementation for works pages into a new `NestedList` module as it was used outside of `ArchiveTree` (therefore removing old ArchiveTree-specific implementations).

Specifically it:
- adds a dedicated NestedList module under `content/webapp/views/pages/works/work/NestedList` (component, list item logic, helpers, styles, and tests)
- updates `ArchiveTree` and `IIIF/download` consumers to import `NestedList` from the shared module
- migrates `TreeControl` and `isRelatedWork` usage to the shared `NestedList` exports
- removes legacy duplicated `ArchiveTree` files that are no longer needed (`ArchiveTree.NestedList`, `ArchiveTree.ListItem`, `ArchiveTree.helpers`, `ArchiveTree.test`)
- removes duplicated `getTabbableIds` coverage from `content/webapp/test/works.test.ts` in favour of NestedList-local tests

## How to test

1. Tests should run well in this PR
2. Sanity-check the works tree UI manually:
   - Open [an archive work](https://www-dev.wellcomecollection.org/works/cj6wsn55) and verify expand/collapse behaviour in Collection contents
   - Verify keyboard navigation still works (left/right/up/down)
   - Verify the IIIF sidebar and Available online trees still render and expand correctly https://www-dev.wellcomecollection.org/works/cj6wsn55/items

## How can we measure success?

- No functional regression in tree rendering, expansion, or keyboard navigation across `ArchiveTree` and IIIF/download trees
- Reduced duplication in the works tree code path (single shared `NestedList `implementation)
- Future tree-related changes require editing one shared implementation rather than parallel ArchiveTree-specific copies

## Have we considered potential risks?

Potential risks:
- Shared module changes could affect multiple consumers at once (ArchiveTree, ViewerSidebar, AvailableOnline, DownloadItemRenderer)
- Subtle behavioural differences could appear if any consumer relied on the removed duplicate implementation