### PR TITLE
Use original format instead of item format

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -513,7 +513,9 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
                       src={original.id}
                       label={itemLabel}
                       fileSize={getFileSize(canvas)}
-                      format={'format' in item ? item.format : undefined}
+                      format={
+                        'format' in original ? original.format : undefined
+                      }
                       showWarning={true}
                     />
                   </IIIFItemWrapper>


### PR DESCRIPTION
## What does this change?
#12977 
https://github.com/wellcomecollection/wellcomecollection.org/pull/12992/changes

As Mankeet was testing he flagged the format was wrong for the button. https://wellcome.slack.com/archives/CUA669WHH/p1776949603092949?thread_ts=1776943157.106019&cid=CUA669WHH

Tbf I saw it too and David saw it when reviewing but we thought it was normal for Born Digitals - sorry! Turns out we should've been using the `original.format` as `item.format` is the placeholder.

## How to test

Inspect element: https://www-dev.wellcomecollection.org/works/a5xuz9v5/items

## How can we measure success?

Good tracking

## Have we considered potential risks?
AFAIK no - it's only used otherwise to determine whether or not it's a PDF to use a specific icon, so we might just get more of those.