### PR TITLE
Item viewer analytics additions

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
@@ -12,6 +12,7 @@ import { useUserContext } from '@weco/common/contexts/UserContext';
 import { arrow, chevron } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { classNames, font } from '@weco/common/utils/classnames';
+import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 import Icon from '@weco/common/views/components/Icon';
@@ -103,12 +104,14 @@ const AccordionButton = styled.button`
 
 type AccordionItemProps = PropsWithChildren<{
   title: string;
+  gtmData: DataGtmProps;
   testId?: string;
   defaultOpen?: boolean;
 }>;
 
 const AccordionItem = ({
   title,
+  gtmData,
   children,
   testId,
   defaultOpen = false,
@@ -122,7 +125,10 @@ const AccordionItem = ({
 
   return (
     <Item data-testid={testId}>
-      <AccordionInner onClick={() => setIsActive(!isActive)}>
+      <AccordionInner
+        onClick={() => setIsActive(!isActive)}
+        {...dataGtmPropsToAttributes(gtmData)}
+      >
         <AccordionButton
           aria-expanded={isActive ? 'true' : 'false'}
           aria-controls={toHtmlId(title)}
@@ -263,8 +269,12 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
           </WorkLink>
         </Space>
       </Inner>
+
       <Inner>
-        <AccordionItem title="Licence and re-use">
+        <AccordionItem
+          title="Licence and re-use"
+          gtmData={{ trigger: 'licence_and_re_use' }}
+        >
           <div className={font('sans', -2)}>
             {license && license.label && (
               <p>
@@ -292,12 +302,12 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
         </AccordionItem>
 
         {archiveTree.length > 0 && (
-          <AccordionItem title="Contents" defaultOpen={true}>
-            <div
-              style={{
-                overflow: 'auto',
-              }}
-            >
+          <AccordionItem
+            title="Contents"
+            gtmData={{ trigger: 'contents' }}
+            defaultOpen
+          >
+            <div style={{ overflow: 'auto' }}>
               <WorksTree
                 isDarkMode={true}
                 hasStructures={Boolean(structures && structures.length > 0)}
@@ -332,10 +342,11 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
 
         {Boolean(structures && structures.length > 0) &&
           hasOnlyRenderableImages && (
-            <AccordionItem title="Contents">
+            <AccordionItem title="Contents" gtmData={{ trigger: 'contents' }}>
               <ViewerStructures />
             </AccordionItem>
           )}
+
         {/*
           Note: this check for `behavior === 'multi-part'` is repeated in items.tsx to
           avoid sending unnecessary data about parent manifests that we're not going
@@ -345,11 +356,12 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
         {parentManifest &&
           parentManifest.behavior?.[0] === 'multi-part' &&
           parentManifest.canvases && (
-            <AccordionItem title="Volumes">
+            <AccordionItem title="Volumes" gtmData={{ trigger: 'volumes' }}>
               <MultipleManifestList />
             </AccordionItem>
           )}
       </Inner>
+
       {searchService && (
         <Inner>
           <IIIFSearchWithin />

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { file, imageFile } from '@weco/common/icons';
 import { font } from '@weco/common/utils/classnames';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import {
   CustomContentResource,
@@ -217,7 +218,13 @@ const DownloadItem: FunctionComponent<DownloadItemProps> = ({
             </td>
             <td>
               {!isRestricted || userIsStaffWithRestricted ? (
-                <a data-gtm-trigger="download_table_link" href={displayItem.id}>
+                <a
+                  href={displayItem.id}
+                  {...dataGtmPropsToAttributes({
+                    trigger: 'download_table_link',
+                    'mime-type': format || 'null', // Default value requested by analyst
+                  })}
+                >
                   Download
                 </a>
               ) : (


### PR DESCRIPTION
## What does this change?

#12977

- Adds triggers for side_panel navigation buttons: Mankeet requested `licence_and_re_use` and `contents` but there's also `volumes` so I thought might as well. I couldn't find examples of any work with Volumes though...
- `download_table_link` trigger now also has `data-gtm-mime-type`.

## How to test

https://www-dev.wellcomecollection.org/works/cj6wsn55/items inspect the dom

## How can we measure success?

Trackable!

## Have we considered potential risks?
N/A