### PR TITLE
only show the bottom bar on when mobile sidebar is inactive

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -449,7 +449,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             />
           </Zoom>
         )}
-        {isFullSupportBrowser && (
+        {isFullSupportBrowser && !isMobileSidebarActive && (
           <>
             <BottomBar>
               <ViewerBottomBar />

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -449,11 +449,13 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             />
           </Zoom>
         )}
-        {isFullSupportBrowser && !isMobileSidebarActive && (
+        {isFullSupportBrowser && (
           <>
-            <BottomBar>
-              <ViewerBottomBar />
-            </BottomBar>
+            {!isMobileSidebarActive && (
+              <BottomBar>
+                <ViewerBottomBar />
+              </BottomBar>
+            )}
             {hasOnlyRenderableImages && (
               <ThumbnailsWrapper
                 $isActive={gridVisible}


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13003

## What does this change?
I haven't addressed the issue in the ticket directly, but have made a change that makes it no longer relevant.

This change stops the previous next/controls from displaying at all when the mobile sidebar is being displayed.

I don't think it made sense to show the controls when you couldn't see the that thing they control, i.e. the main viewer area

## How to test

- visit https://www-dev.wellcomecollection.org/works/a99kyqec/items?canvas=3&shouldScrollToCanvas=true
- shrink the screen so that the previous/next links appear
- click the 'show info' button
- the previous and next links should go away
- click the 'hide info' button
- the previous and next links should display


## Have we considered potential risks?

none really