### PR TITLE
Don’t allow text to wrap in file hierarchy list

### DIFF
--- a/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
@@ -79,7 +79,12 @@ const DownloadItemRenderer: FunctionComponent<DownloadItemRendererProps> = ({
       )}
 
       {item.work.type === 'Range' && (
-        <span style={{ lineHeight: `${controlDimensions.controlHeight}px` }}>
+        <span
+          style={{
+            lineHeight: `${controlDimensions.controlHeight}px`,
+            whiteSpace: 'nowrap',
+          }}
+        >
           <span style={{ marginRight: '10px' }}>
             <Icon
               icon={item.openStatus ? openFolder : closedFolder}


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13012

## What does this change?

Adds white-space: nowrap to range titles in the file hierarchy in the viewer. This prevents the text from wrapping and overlaying the next item in the list

## How to test
- [enable the extendedViewer toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=extendedViewer)
- visit https://www-dev.wellcomecollection.org/works/zu2q4k2w/items
- make the browser narrow
- see that the folder name 'Advanced_Nephrology_Course_Part_1_-_28_September-1_October_2009' stays on one line

## Have we considered potential risks?

- it will add horizontal scrolling if the text is very long, but that seems reasonable 
