### PR TITLE
Viewer e2es

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerBottomBar.tsx
@@ -110,7 +110,7 @@ const ViewerBottomBar: FunctionComponent = () => {
   const hasMultipleCanvases = (canvases?.length || 0) > 1;
 
   return (
-    <BottomBar>
+    <BottomBar data-testid="bottombar">
       {!hasOnlyRenderableImages && hasMultipleCanvases ? (
         <NavigationBar>
           {previousCanvasLink ? (
@@ -127,7 +127,7 @@ const ViewerBottomBar: FunctionComponent = () => {
             </NavButton>
           )}
           <span className={font('sans', -1)} style={{ color: 'white' }}>
-            {canvas} / {totalCanvases}
+            {canvas}/{totalCanvases}
           </span>
           {nextCanvasLink ? (
             <NextLink {...nextCanvasLink} passHref legacyBehavior>

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.tsx
@@ -296,6 +296,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
 
   return (
     <TopBar
+      data-testid="topbar"
       $isZooming={showZoomed}
       $isDesktopSidebarActive={isDesktopSidebarActive}
       $useFixedList={hasOnlyRenderableImages}

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -83,10 +83,19 @@ const stageApiToggleCookie = createCookie({
   name: 'toggle_stagingApi',
   value: 'true',
 });
+const extendedViewerToggleCookie = createCookie({
+  name: 'toggle_extendedViewer',
+  value: 'true',
+});
 
 export const requiredCookies = useStageApis
   ? [acceptCookieCookie, stageApiToggleCookie]
   : [acceptCookieCookie];
+
+const requiredCookiesWithExtendedViewer = [
+  ...requiredCookies,
+  extendedViewerToggleCookie,
+];
 
 const multiVolumeItem = async (
   context: BrowserContext,
@@ -229,15 +238,7 @@ const itemWithVideo = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies([
-    ...requiredCookies,
-    {
-      name: 'toggle_extendedViewer',
-      value: 'true',
-      domain: new URL(baseUrl).host,
-      path: '/',
-    },
-  ]);
+  await context.addCookies(requiredCookiesWithExtendedViewer);
   await gotoWithoutCache(`${baseUrl}/works/sx4p4b75/items`, page);
 };
 
@@ -245,15 +246,7 @@ const itemWithAudio = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies([
-    ...requiredCookies,
-    {
-      name: 'toggle_extendedViewer',
-      value: 'true',
-      domain: new URL(baseUrl).host,
-      path: '/',
-    },
-  ]);
+  await context.addCookies(requiredCookiesWithExtendedViewer);
   await gotoWithoutCache(`${baseUrl}/works/tp9njewm/items`, page);
 };
 
@@ -261,15 +254,7 @@ const itemWithPdf = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies([
-    ...requiredCookies,
-    {
-      name: 'toggle_extendedViewer',
-      value: 'true',
-      domain: new URL(baseUrl).host,
-      path: '/',
-    },
-  ]);
+  await context.addCookies(requiredCookiesWithExtendedViewer);
   await gotoWithoutCache(`${baseUrl}/works/zu2q4k2w/items`, page);
 };
 
@@ -277,15 +262,7 @@ const itemWithMixedBornDigital = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies([
-    ...requiredCookies,
-    {
-      name: 'toggle_extendedViewer',
-      value: 'true',
-      domain: new URL(baseUrl).host,
-      path: '/',
-    },
-  ]);
+  await context.addCookies(requiredCookiesWithExtendedViewer);
   await gotoWithoutCache(`${baseUrl}/works/dn9jwck6/items`, page);
 };
 

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -225,6 +225,38 @@ const workWithBornDigitalDownloads = async (
   await gotoWithoutCache(`${baseUrl}/works/htzhunbw`, page);
 };
 
+const itemWithVideo = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/sx4p4b75/items`, page);
+};
+
+const itemWithAudio = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/tp9njewm/items`, page);
+};
+
+const itemWithPdf = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/zu2q4k2w/items`, page);
+};
+
+const itemWithMixedBornDigital = async (
+  context: BrowserContext,
+  page: Page
+): Promise<void> => {
+  await context.addCookies(requiredCookies);
+  await gotoWithoutCache(`${baseUrl}/works/dn9jwck6/items`, page);
+};
+
 const search = async (
   context: BrowserContext,
   page: Page,
@@ -353,15 +385,19 @@ export {
   event,
   isMobile,
   itemWithAltText,
+  itemWithAudio,
   itemWithNonRestrictedAndOpenAccess,
   itemWithOnlyOpenAccess,
   itemWithOnlyRestrictedAccessImages,
   itemWithOnlyRestrictedAccessNonImages,
+  itemWithPdf,
   itemWithReferenceNumber,
   itemWithRestrictedAndNonRestrictedAccess,
   itemWithRestrictedAndOpenAccess,
   itemWithSearchAndStructures,
   itemWithSearchAndStructuresAndQuery,
+  itemWithVideo,
+  itemWithMixedBornDigital,
   mediaOffice,
   multiVolumeItem,
   apiToolbarPage,

--- a/playwright/test/helpers/contexts.ts
+++ b/playwright/test/helpers/contexts.ts
@@ -229,7 +229,15 @@ const itemWithVideo = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies(requiredCookies);
+  await context.addCookies([
+    ...requiredCookies,
+    {
+      name: 'toggle_extendedViewer',
+      value: 'true',
+      domain: new URL(baseUrl).host,
+      path: '/',
+    },
+  ]);
   await gotoWithoutCache(`${baseUrl}/works/sx4p4b75/items`, page);
 };
 
@@ -237,7 +245,15 @@ const itemWithAudio = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies(requiredCookies);
+  await context.addCookies([
+    ...requiredCookies,
+    {
+      name: 'toggle_extendedViewer',
+      value: 'true',
+      domain: new URL(baseUrl).host,
+      path: '/',
+    },
+  ]);
   await gotoWithoutCache(`${baseUrl}/works/tp9njewm/items`, page);
 };
 
@@ -245,7 +261,15 @@ const itemWithPdf = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies(requiredCookies);
+  await context.addCookies([
+    ...requiredCookies,
+    {
+      name: 'toggle_extendedViewer',
+      value: 'true',
+      domain: new URL(baseUrl).host,
+      path: '/',
+    },
+  ]);
   await gotoWithoutCache(`${baseUrl}/works/zu2q4k2w/items`, page);
 };
 
@@ -253,7 +277,15 @@ const itemWithMixedBornDigital = async (
   context: BrowserContext,
   page: Page
 ): Promise<void> => {
-  await context.addCookies(requiredCookies);
+  await context.addCookies([
+    ...requiredCookies,
+    {
+      name: 'toggle_extendedViewer',
+      value: 'true',
+      domain: new URL(baseUrl).host,
+      path: '/',
+    },
+  ]);
   await gotoWithoutCache(`${baseUrl}/works/dn9jwck6/items`, page);
 };
 

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -559,3 +559,8 @@ test('(36) | Born digital files display and links update selected item and displ
     await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
   }
 });
+test('(37) | Born digital have downloads', async ({ page, context }) => {
+  await itemWithMixedBornDigital(context, page);
+  const downloadLink = page.getByRole('link', { name: /download/i });
+  await expect(downloadLink.first()).toBeVisible();
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -4,6 +4,7 @@ import {
   isMobile,
   itemWithAltText,
   itemWithAudio,
+  itemWithMixedBornDigital,
   itemWithNonRestrictedAndOpenAccess,
   itemWithOnlyOpenAccess,
   itemWithOnlyRestrictedAccessImages,
@@ -516,5 +517,45 @@ test('(35) | PDF file links update selected item, page indicator and pdf', async
     expect(await openLink.getAttribute('href')).toEqual(
       'https://iiif.wellcomecollection.org/file/SAREN_N_3_5---Advanced_Nephrology_Course_Part_1_-_28_September-1_October_2009---Monday---Sally-Anne_Hulton.pdf'
     );
+  }
+});
+test('(36) | Born digital files display and links update selected item and display media', async ({
+  page,
+  context,
+}) => {
+  await itemWithMixedBornDigital(context, page);
+
+  if (!isMobile(page)) {
+    // Find and verify download link is initially visible in the viewer
+    const mainViewer = page.getByTestId('main-viewer');
+    const downloadLink = mainViewer.getByRole('link', { name: /download/i });
+    await expect(downloadLink.first()).toBeVisible();
+
+    // Click the slide1.wav link
+    const audioLink = page.getByRole('link', { name: 'slide1.wav' });
+    await audioLink.click();
+
+    await checkAriaSelected(page, 'slide1.wav', true);
+
+    // Check that the audio player is displayed
+    await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
+  }
+
+  if (isMobile(page)) {
+    // Find and verify download link is initially visible in the viewer
+    const mainViewer = page.getByTestId('main-viewer');
+    const downloadLink = mainViewer.getByRole('link', { name: /download/i });
+    await expect(downloadLink.first()).toBeVisible();
+
+    // On mobile, need to show info panel
+    await accessSidebarOnMobile(page);
+    const audioLink = page.getByRole('link', { name: 'slide1.wav' });
+    await audioLink.click();
+
+    // It will be hidden on mobile because the sidebar closes when the link is clicked
+    await checkAriaSelected(page, 'slide1.wav', false);
+
+    // Check that the audio player is displayed
+    await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
   }
 });

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -564,3 +564,10 @@ test('(37) | Born digital have downloads', async ({ page, context }) => {
   const downloadLink = page.getByRole('link', { name: /download/i });
   await expect(downloadLink.first()).toBeVisible();
 });
+test('(38) | Born digital info panel displays heading', async ({
+  page,
+  context,
+}) => {
+  await itemWithMixedBornDigital(context, page);
+  await checkInfoPanelHasHeading(page);
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -22,6 +22,13 @@ const accessSidebarOnMobile = async (page: Page) => {
   }
 };
 
+const checkDownloadsAvailable = async (page: Page) => {
+  await expect(page.locator('#itemDownloads')).toHaveAttribute('inert');
+  await page.locator('[aria-controls="itemDownloads"]').click();
+  await expect(page.locator('#itemDownloads')).not.toHaveAttribute('inert');
+  await expect(page.locator('#itemDownloads a')).not.toHaveCount(0);
+};
+
 test.describe.configure({ mode: 'parallel' });
 
 test('(1) | The images can be zoomed', async ({ page, context }) => {
@@ -61,7 +68,7 @@ test('(3) | An image of the current canvas can be downloaded', async ({
   context,
 }) => {
   await multiVolumeItem(context, page);
-  await page.getByRole('button', { name: 'Downloads' }).click();
+  await checkDownloadsAvailable(page);
 
   const smallImageLink = page
     .getByRole('link')
@@ -73,7 +80,7 @@ test('(3) | An image of the current canvas can be downloaded', async ({
 
 test('(4) | The entire item can be downloaded', async ({ page, context }) => {
   await multiVolumeItem(context, page);
-  await page.getByRole('button', { name: 'Downloads' }).click();
+  await checkDownloadsAvailable(page);
 
   const smallImageLink = page
     .getByRole('link')

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -37,6 +37,29 @@ const checkInfoPanelHasHeading = async (page: Page) => {
   await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 };
 
+const checkPageIndicator = async (
+  page: Page,
+  expectedText: string,
+  location: 'topbar' | 'bottombar'
+) => {
+  const bar = page.locator(`[data-testid="${location}"]`);
+  await expect(bar.getByText(expectedText)).toBeVisible();
+};
+
+const checkAriaSelected = async (
+  page: Page,
+  expectedText: string,
+  shouldBeVisible: boolean
+) => {
+  const listItem = page.locator('[aria-selected="true"]');
+  if (shouldBeVisible) {
+    await expect(listItem).toBeVisible();
+  } else {
+    await expect(listItem).toBeHidden();
+  }
+  await expect(listItem).toContainText(expectedText);
+};
+
 test.describe.configure({ mode: 'parallel' });
 
 test('(1) | The images can be zoomed', async ({ page, context }) => {
@@ -452,4 +475,46 @@ test('(33) | PDF download options are available', async ({ page, context }) => {
 test('(34) | PDF info panel displays heading', async ({ page, context }) => {
   await itemWithPdf(context, page);
   await checkInfoPanelHasHeading(page);
+});
+
+test('(35) | PDF file links update selected item, page indicator and pdf', async ({
+  page,
+  context,
+}) => {
+  await itemWithPdf(context, page);
+
+  if (!isMobile(page)) {
+    // Click the PDF link
+    const pdfLink = page.getByRole('link', { name: 'Sally-Anne_Hulton.pdf' });
+    await pdfLink.click();
+
+    await checkAriaSelected(page, 'Sally-Anne_Hulton.pdf', true);
+    await checkPageIndicator(page, '5/27', 'topbar');
+
+    // Check that the iframe source is set to the PDF file
+    const pdfIframe = page.locator('iframe');
+    await expect(pdfIframe).toHaveAttribute(
+      'src',
+      'https://iiif.wellcomecollection.org/file/SAREN_N_3_5---Advanced_Nephrology_Course_Part_1_-_28_September-1_October_2009---Monday---Sally-Anne_Hulton.pdf'
+    );
+  }
+  if (isMobile(page)) {
+    // On mobile, need to show info panel first
+    await accessSidebarOnMobile(page);
+
+    // Click the PDF link
+    const pdfLink = page.getByRole('link', { name: 'Sally-Anne_Hulton.pdf' });
+    await pdfLink.click();
+
+    // It will be hidden on mobile because the sidebar closes when the link is clicked
+    await checkAriaSelected(page, 'Sally-Anne_Hulton.pdf', false);
+    await checkPageIndicator(page, '5/27', 'bottombar');
+
+    const openLink = page.getByRole('link', { name: /open/i });
+    await expect(openLink).toBeVisible({ timeout: 10000 });
+    // Check that the open link points to the correct PDF file
+    expect(await openLink.getAttribute('href')).toEqual(
+      'https://iiif.wellcomecollection.org/file/SAREN_N_3_5---Advanced_Nephrology_Course_Part_1_-_28_September-1_October_2009---Monday---Sally-Anne_Hulton.pdf'
+    );
+  }
 });

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -384,3 +384,11 @@ test('(27) | Video info panel displays heading', async ({ page, context }) => {
   await itemWithVideo(context, page);
   await checkInfoPanelHasHeading(page);
 });
+test('(28) | Audio player is visible and renders', async ({
+  page,
+  context,
+}) => {
+  await itemWithAudio(context, page);
+  // Check for custom audio player's play button
+  await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -366,3 +366,10 @@ test('(25) | Video playback controls are functional', async ({
   // Check that native controls are enabled
   await expect(video).toHaveAttribute('controls');
 });
+test('(26) | Video download options are available', async ({
+  page,
+  context,
+}) => {
+  await itemWithVideo(context, page);
+  await checkDownloadsAvailable(page);
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -409,3 +409,10 @@ test('(29) | Audio playback controls are functional', async ({
   // And aria-pressed should be true
   await expect(page.locator('button[aria-pressed="true"]')).toBeVisible();
 });
+test('(30) | Audio download options are available', async ({
+  page,
+  context,
+}) => {
+  await itemWithAudio(context, page);
+  await checkDownloadsAvailable(page);
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -12,6 +12,7 @@ import {
   itemWithRestrictedAndOpenAccess,
   itemWithSearchAndStructures,
   itemWithSearchAndStructuresAndQuery,
+  itemWithVideo,
   multiVolumeItem,
 } from './helpers/contexts';
 import { apiResponse } from './mocks/search-within';
@@ -344,4 +345,13 @@ test('(23) | Clicking thumbnail grid items updates the main viewer', async ({
 
   // Verify the correct image is now in the viewport (canvas 3 = image index 2)
   await expect(page.getByTestId('image-2')).toBeInViewport();
+});
+
+test('(24) | Video player is visible and renders', async ({
+  page,
+  context,
+}) => {
+  await itemWithVideo(context, page);
+  // Check for video element or video player container
+  await expect(page.locator('video')).toBeVisible();
 });

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -443,3 +443,7 @@ test('(32) | Renders the PDF document on Desktop or an "Open" link on Mobile', a
     await expect(openLink).toBeVisible({ timeout: 10000 });
   }
 });
+test('(33) | PDF download options are available', async ({ page, context }) => {
+  await itemWithPdf(context, page);
+  await checkDownloadsAvailable(page);
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -571,3 +571,20 @@ test('(38) | Born digital info panel displays heading', async ({
   await itemWithMixedBornDigital(context, page);
   await checkInfoPanelHasHeading(page);
 });
+test('(39) | Mobile pagination updates content in main viewer', async ({
+  page,
+  context,
+}) => {
+  await itemWithPdf(context, page);
+
+  if (isMobile(page)) {
+    await checkPageIndicator(page, '1/27', 'bottombar');
+    const bottombar = page.locator('[data-testid="bottombar"]');
+    const nextLink = bottombar.getByRole('link', { name: /next/i });
+    await nextLink.click();
+    await checkPageIndicator(page, '2/27', 'bottombar');
+    const previousLink = bottombar.getByRole('link', { name: /previous/i });
+    await previousLink.click();
+    await checkPageIndicator(page, '1/27', 'bottombar');
+  }
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -392,3 +392,20 @@ test('(28) | Audio player is visible and renders', async ({
   // Check for custom audio player's play button
   await expect(page.getByRole('button', { name: 'Play' })).toBeVisible();
 });
+test('(29) | Audio playback controls are functional', async ({
+  page,
+  context,
+}) => {
+  await itemWithAudio(context, page);
+  const playButton = page.getByRole('button', { name: 'Play' });
+  await expect(playButton).toBeVisible();
+
+  // Click play button
+  await playButton.click();
+
+  // After clicking, button's accessible name should change to Pause
+  await expect(page.getByRole('button', { name: 'Pause' })).toBeVisible();
+
+  // And aria-pressed should be true
+  await expect(page.locator('button[aria-pressed="true"]')).toBeVisible();
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -355,3 +355,14 @@ test('(24) | Video player is visible and renders', async ({
   // Check for video element or video player container
   await expect(page.locator('video')).toBeVisible();
 });
+
+test('(25) | Video playback controls are functional', async ({
+  page,
+  context,
+}) => {
+  await itemWithVideo(context, page);
+  const video = page.locator('video');
+  await expect(video).toBeVisible();
+  // Check that native controls are enabled
+  await expect(video).toHaveAttribute('controls');
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -3,10 +3,12 @@ import { expect, Page, test } from '@playwright/test';
 import {
   isMobile,
   itemWithAltText,
+  itemWithAudio,
   itemWithNonRestrictedAndOpenAccess,
   itemWithOnlyOpenAccess,
   itemWithOnlyRestrictedAccessImages,
   itemWithOnlyRestrictedAccessNonImages,
+  itemWithPdf,
   itemWithReferenceNumber,
   itemWithRestrictedAndNonRestrictedAccess,
   itemWithRestrictedAndOpenAccess,

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -387,7 +387,7 @@ test('(24) | Video player is visible and renders', async ({
   await expect(page.locator('video')).toBeVisible();
 });
 
-test('(25) | Video playback controls are functional', async ({
+test('(25) | Video playback controls are present', async ({
   page,
   context,
 }) => {

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -447,3 +447,7 @@ test('(33) | PDF download options are available', async ({ page, context }) => {
   await itemWithPdf(context, page);
   await checkDownloadsAvailable(page);
 });
+test('(34) | PDF info panel displays heading', async ({ page, context }) => {
+  await itemWithPdf(context, page);
+  await checkInfoPanelHasHeading(page);
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -30,6 +30,11 @@ const checkDownloadsAvailable = async (page: Page) => {
   await expect(page.locator('#itemDownloads a')).not.toHaveCount(0);
 };
 
+const checkInfoPanelHasHeading = async (page: Page) => {
+  await accessSidebarOnMobile(page);
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+};
+
 test.describe.configure({ mode: 'parallel' });
 
 test('(1) | The images can be zoomed', async ({ page, context }) => {
@@ -366,10 +371,16 @@ test('(25) | Video playback controls are functional', async ({
   // Check that native controls are enabled
   await expect(video).toHaveAttribute('controls');
 });
+
 test('(26) | Video download options are available', async ({
   page,
   context,
 }) => {
   await itemWithVideo(context, page);
   await checkDownloadsAvailable(page);
+});
+
+test('(27) | Video info panel displays heading', async ({ page, context }) => {
+  await itemWithVideo(context, page);
+  await checkInfoPanelHasHeading(page);
 });

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -416,3 +416,7 @@ test('(30) | Audio download options are available', async ({
   await itemWithAudio(context, page);
   await checkDownloadsAvailable(page);
 });
+test('(31) | Audio info panel displays heading', async ({ page, context }) => {
+  await itemWithAudio(context, page);
+  await checkInfoPanelHasHeading(page);
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -420,3 +420,24 @@ test('(31) | Audio info panel displays heading', async ({ page, context }) => {
   await itemWithAudio(context, page);
   await checkInfoPanelHasHeading(page);
 });
+test('(32) | Renders the PDF document on Desktop or an "Open" link on Mobile', async ({
+  page,
+  context,
+}) => {
+  await itemWithPdf(context, page);
+  const pdfIframe = page.locator('iframe[type="application/pdf"]');
+
+  if (!isMobile(page)) {
+    // On desktop, PDF is embedded in an iframe
+    await expect(pdfIframe).toBeVisible();
+  }
+
+  if (isMobile(page)) {
+    // On mobile, the PDF iframe is not rendered at all
+    await expect(pdfIframe).not.toBeAttached();
+    // Instead, look for a download or open link
+    const openLink = page.getByRole('link', { name: /open/i });
+    // Wait for it to be visible first, then check if hidden (will fail)
+    await expect(openLink).toBeVisible({ timeout: 10000 });
+  }
+});

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -452,7 +452,7 @@ test('(32) | Renders the PDF document on Desktop or an "Open" link on Mobile', a
   context,
 }) => {
   await itemWithPdf(context, page);
-  const pdfIframe = page.locator('iframe');
+  const pdfIframe = page.locator('iframe[title]');
 
   if (!isMobile(page)) {
     // On desktop, PDF is embedded in an iframe
@@ -493,7 +493,7 @@ test('(35) | PDF file links update selected item, page indicator and pdf', async
     await checkPageIndicator(page, '5/27', 'topbar');
 
     // Check that the iframe source is set to the PDF file
-    const pdfIframe = page.locator('iframe');
+    const pdfIframe = page.locator('iframe[title]');
     await expect(pdfIframe).toHaveAttribute(
       'src',
       'https://iiif.wellcomecollection.org/file/SAREN_N_3_5---Advanced_Nephrology_Course_Part_1_-_28_September-1_October_2009---Monday---Sally-Anne_Hulton.pdf'

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -422,12 +422,13 @@ test('(31) | Audio info panel displays heading', async ({ page, context }) => {
   await itemWithAudio(context, page);
   await checkInfoPanelHasHeading(page);
 });
+
 test('(32) | Renders the PDF document on Desktop or an "Open" link on Mobile', async ({
   page,
   context,
 }) => {
   await itemWithPdf(context, page);
-  const pdfIframe = page.locator('iframe[type="application/pdf"]');
+  const pdfIframe = page.locator('iframe');
 
   if (!isMobile(page)) {
     // On desktop, PDF is embedded in an iframe
@@ -435,18 +436,19 @@ test('(32) | Renders the PDF document on Desktop or an "Open" link on Mobile', a
   }
 
   if (isMobile(page)) {
-    // On mobile, the PDF iframe is not rendered at all
+    // On mobile, the PDF iframe is not rendered
     await expect(pdfIframe).not.toBeAttached();
-    // Instead, look for a download or open link
+    // Instead, an open link is provided
     const openLink = page.getByRole('link', { name: /open/i });
-    // Wait for it to be visible first, then check if hidden (will fail)
     await expect(openLink).toBeVisible({ timeout: 10000 });
   }
 });
+
 test('(33) | PDF download options are available', async ({ page, context }) => {
   await itemWithPdf(context, page);
   await checkDownloadsAvailable(page);
 });
+
 test('(34) | PDF info panel displays heading', async ({ page, context }) => {
   await itemWithPdf(context, page);
   await checkInfoPanelHasHeading(page);


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13019

## What does this change?

Adds tests for the non image things the viewer can now display (audio, video, pdf, non renderable files)

Enables the extendedViewer toggle for these tests in case we want to disable the toggle after we enable it publicly. We can remove this when we remove the toggle for good.

## How to test

run the tests:
```
cd playwright
yarn test test/view-items.test.ts
yarn test:mobile test/view-items.test.ts
```
## Have we considered potential risks?

Is there something else we should be testing that we aren't?
