### PR TITLE
Restore content ids

### DIFF
--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -12,7 +12,7 @@
     "tryAllContentPages": "tsx ./scripts/tryAllContentPages",
     "restorePrismicAssets": "AWS_PROFILE=catalogue-developer tsx ./restore/restore-prismic-assets.ts",
     "restorePrismicContent": "AWS_PROFILE=catalogue-developer tsx ./restore/restore-prismic-content.ts",
-    "transformSnapshot": "tsx ./restore/transform-snapshot.ts"
+    "transformSnapshot": "AWS_PROFILE=catalogue-developer tsx ./restore/transform-snapshot.ts"
   },
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.1000.0",

--- a/prismic-model/prismic_disaster_recovery_full.md
+++ b/prismic-model/prismic_disaster_recovery_full.md
@@ -103,8 +103,8 @@ All three append-only files are written to the gitignored `restore/status/` dire
 | Script             | Command                      | Description                                                                                                                                                                                                    |
 | ------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Restore assets     | `yarn restorePrismicAssets`  | Downloads the assets manifest and snapshot, uploads missing assets to the target repo, writes `asset-id-map.json` and `asset-slug-map.json`                                                                    |
-| Transform snapshot | `yarn transformSnapshot`     | Prepares the snapshot for import: rewrites asset IDs, fixes URL slugs, backfills article publish dates, optionally rewrites repo name in asset URLs; writes `restore/snapshot/prismic-snapshot-rewritten.json` |
-| Restore content    | `yarn restorePrismicContent` | Uploads documents from a snapshot to the target repo using the Migration API                                                                                                                                   |
+| Transform snapshot | `yarn transformSnapshot`     | Prepares the snapshot for import: rewrites asset IDs, content document IDs (if content-id-map.json exists), fixes URL slugs, backfills article publish dates, optionally rewrites repo name in asset URLs; writes `restore/snapshot/prismic-snapshot-rewritten.json`. Automatically detects which maps are available and only applies available transformations. |
+| Restore content    | `yarn restorePrismicContent` | Uploads documents from a snapshot to the target repo using the Migration API, creates/updates `content-id-map.json` to track old ID → new ID mappings                                                                                                                                   |
 
 **Flags:**
 
@@ -176,7 +176,7 @@ The script is **safe to interrupt and resume** — re-running it will skip alrea
 
 > **Note:** If the asset upload runs for a long time (hours), your AWS credentials may expire before you reach Step 4. Run `aws sso login` again before running `transformSnapshot` if needed.
 
-#### Step 4 — Rewrite the snapshot
+#### Step 4 — Rewrite the snapshot (first pass)
 
 Because the new repo issues new asset IDs and hosts assets under potentially different URLs, the snapshot must be rewritten before content is imported.
 
@@ -194,7 +194,9 @@ This produces `restore/snapshot/prismic-snapshot-rewritten.json` with:
 
 > If the repository name is unchanged, omit `--source-repo` and `--target-repo`. The script will still rewrite asset IDs and URL slugs.
 
-#### Step 5 — Restore content
+> **Note:** Content relationship fields will not be corrected yet as `content-id-map.json` doesn't exist until after the first content upload. This is expected and will be fixed in Step 7.
+
+#### Step 5 — Restore content (first upload)
 
 ```bash
 yarn restorePrismicContent \
@@ -215,7 +217,34 @@ yarn restorePrismicContent \
 
 The script uploads each document at 1 request/sec and is safe to interrupt and resume — already-created documents will be updated rather than duplicated.
 
-#### Step 6 — Update hardcoded IDs
+After this completes, the script creates `restore/status/content-id-map.json` which maps old document IDs to new ones. This is needed to fix content relationships in the next steps.
+
+#### Step 6 — Rewrite the snapshot (second pass)
+
+Now that `content-id-map.json` exists, run the transform script again to fix content relationship fields:
+
+```bash
+yarn transformSnapshot \
+  --source-repo wellcomecollection \
+  --target-repo <new-repo-name>
+```
+
+This second run will:
+- Apply all the same asset ID and URL transformations as before.
+- **Additionally** replace old content document IDs with new ones in relationship fields.
+
+#### Step 7 — Restore content (second upload)
+
+Upload the snapshot again with corrected content relationships:
+
+```bash
+yarn restorePrismicContent \
+  --snapshot ./restore/snapshot/prismic-snapshot-rewritten.json
+```
+
+This updates all documents with the correct content relationship references. Documents won't be duplicated — they'll be updated in place using the IDs from `content-id-map.json`.
+
+#### Step 8 — Update hardcoded IDs
 
 Some document IDs are hardcoded in [`/common/data/hardcoded-ids.ts`](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/common/data/hardcoded-ids.ts). After the restore, check `restore/status/content-id-map.json` for the new IDs corresponding to each hardcoded entry and update the file.
 
@@ -223,11 +252,11 @@ Some document IDs are hardcoded in [`/common/data/hardcoded-ids.ts`](https://git
 
 Once the PR is merged, delete the `restore/status/` directory — it is gitignored and will be recreated from scratch on the next restore.
 
-#### Step 7 — Point the frontend to the new repo
+#### Step 9 — Point the frontend to the new repo
 
 See [Frontend Cutover Guide](#frontend-cutover-guide).
 
-#### Step 8 — Recreate webhooks and integrations
+#### Step 10 — Recreate webhooks and integrations
 
 After cutover recreate any webhooks that were configured in the old repository (build triggers, content-api indexing, cache purge, document unpublish). These are not backed up automatically.
 
@@ -237,7 +266,7 @@ After cutover recreate any webhooks that were configured in the old repository (
 
 **Symptoms:** Repository and media library are intact; some or all documents are missing or corrupted.
 
-Asset IDs in the snapshot are still valid, so no asset upload is needed. The `transformSnapshot` step is still required — it backfills `publishDate` on any articles that are recreated (they would otherwise get today's date as their publication date, breaking ordering in list pages).
+Asset IDs in the snapshot are still valid, so no asset upload is needed. Content document IDs are also still valid (documents still in the repo keep their original IDs), so the two-stage content upload process isn't needed. However, `transformSnapshot` should still be run — it backfills `publishDate` on any articles that are recreated (they would otherwise get today's date as their publication date, breaking ordering in list pages).
 
 ```bash
 cd prismic-model

--- a/prismic-model/prismic_disaster_recovery_full.md
+++ b/prismic-model/prismic_disaster_recovery_full.md
@@ -100,11 +100,11 @@ All three append-only files are written to the gitignored `restore/status/` dire
 
 ### Script Reference
 
-| Script             | Command                      | Description                                                                                                                                                                                                    |
-| ------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Restore assets     | `yarn restorePrismicAssets`  | Downloads the assets manifest and snapshot, uploads missing assets to the target repo, writes `asset-id-map.json` and `asset-slug-map.json`                                                                    |
+| Script             | Command                      | Description                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Restore assets     | `yarn restorePrismicAssets`  | Downloads the assets manifest and snapshot, uploads missing assets to the target repo, writes `asset-id-map.json` and `asset-slug-map.json`                                                                                                                                                                                                                      |
 | Transform snapshot | `yarn transformSnapshot`     | Prepares the snapshot for import: rewrites asset IDs, content document IDs (if content-id-map.json exists), fixes URL slugs, backfills article publish dates, optionally rewrites repo name in asset URLs; writes `restore/snapshot/prismic-snapshot-rewritten.json`. Automatically detects which maps are available and only applies available transformations. |
-| Restore content    | `yarn restorePrismicContent` | Uploads documents from a snapshot to the target repo using the Migration API, creates/updates `content-id-map.json` to track old ID → new ID mappings                                                                                                                                   |
+| Restore content    | `yarn restorePrismicContent` | Uploads documents from a snapshot to the target repo using the Migration API, creates/updates `content-id-map.json` to track old ID → new ID mappings                                                                                                                                                                                                            |
 
 **Flags:**
 
@@ -230,6 +230,7 @@ yarn transformSnapshot \
 ```
 
 This second run will:
+
 - Apply all the same asset ID and URL transformations as before.
 - **Additionally** replace old content document IDs with new ones in relationship fields.
 

--- a/prismic-model/restore/restore-prismic-content.ts
+++ b/prismic-model/restore/restore-prismic-content.ts
@@ -91,7 +91,7 @@ async function findDestinationId(
     );
     searchUrl.searchParams.set(
       'q',
-      `[[at(document.type,"${type}")][at(my.${type}.uid,"${uid}")]]`
+      `[[at(document.type,"${type}")][at(document.uid,"${uid}")]]`
     );
     searchUrl.searchParams.set('ref', ref);
 

--- a/prismic-model/restore/transform-snapshot.ts
+++ b/prismic-model/restore/transform-snapshot.ts
@@ -6,22 +6,19 @@
  *
  * Transformations applied:
  *   - Rewrites old asset IDs to new IDs using asset-id-map.json
+ *   - Rewrites old content document IDs to new IDs using content-id-map.json
  *   - Corrects asset URL path segments using asset-slug-map.json
  *   - Backfills publishDate on articles from first_publication_date
  *   - Optionally rewrites the repository name in Prismic asset URLs
  *
- * The ID rewrite is done in two passes to guard against collisions where a new asset ID
- * happens to equal one of the old asset IDs:
+ * The ID rewrites are done in two passes to guard against collisions where a new ID
+ * happens to equal one of the old IDs:
  *
  *   Pass 1 — Replace every old ID with "<newId>__RESTORE_PLACEHOLDER__"
  *   Pass 2 — Strip the "__RESTORE_PLACEHOLDER__" suffix from every replaced value
  *
- * If --source-repo and --target-repo are both provided (and differ), a third pass rewrites
- * the repository name wherever it appears in Prismic asset URLs:
- *
- *   Pass 3 — Replace repository name in:
- *     https://images.prismic.io/<source-repo>/
- *     https://<source-repo>.cdn.prismic.io/<source-repo>/
+ * If --source-repo and --target-repo are both provided (and differ), a final pass rewrites
+ * the repository name wherever it appears in Prismic asset URLs.
  *
  * The result is written to a new file; the original snapshot is not modified.
  *
@@ -38,6 +35,12 @@
  * so the script can download the snapshot. When using Scenario 1, provide --snapshot
  * directly or ensure a snapshot exists in ./restore/snapshot/ (may already be downloaded
  * by restore-prismic-assets.ts).
+ *
+ * Two-stage workflow for content relationship fields:
+ *   1. First run (before content uploaded): only asset IDs are rewritten
+ *   2. After first content upload: content-id-map.json is created
+ *   3. Second run: both asset and content IDs are rewritten
+ *   4. Second content upload: content relationships now reference correct IDs
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -48,6 +51,7 @@ import {
   escapeRegex,
   readJsonFile,
 } from '@weco/prismic-model/restore/restore-utils';
+
 import 'dotenv/config';
 import {
   downloadLatestSnapshot,

--- a/prismic-model/restore/transform-snapshot.ts
+++ b/prismic-model/restore/transform-snapshot.ts
@@ -94,7 +94,10 @@ const argv = yargs(process.argv.slice(2))
 // ---------------------------------------------------------------------------
 
 const SNAPSHOT_DIR = path.resolve('./restore/snapshot/');
-const DEFAULT_MAP = path.resolve('./restore/status/asset-id-map.json');
+const DEFAULT_ASSET_MAP = path.resolve('./restore/status/asset-id-map.json');
+const DEFAULT_CONTENT_MAP = path.resolve(
+  './restore/status/content-id-map.json'
+);
 const DEFAULT_SLUG_MAP = path.resolve('./restore/status/asset-slug-map.json');
 
 // PRISMIC_S3_BUCKET is only required when no local snapshot exists
@@ -139,14 +142,23 @@ async function resolveSnapshotPath(): Promise<string> {
 async function init() {
   // Step 1: Resolve input paths (may download from S3 if needed)
   const snapshotPath = await resolveSnapshotPath();
-  const mapPath = DEFAULT_MAP;
+  const assetMapPath = DEFAULT_ASSET_MAP;
+  const contentMapPath = DEFAULT_CONTENT_MAP;
 
   // The asset ID map may not exist when no assets were re-uploaded (Scenario 2).
-  // In that case we skip ID/slug rewriting and only apply the publishDate backfill.
-  const mapExists = fs.existsSync(mapPath);
-  if (!mapExists) {
+  // The content ID map may not exist before the first content upload.
+  // The script will apply whichever transformations have their required maps available.
+  const assetMapExists = fs.existsSync(assetMapPath);
+  const contentMapExists = fs.existsSync(contentMapPath);
+
+  if (!assetMapExists) {
     logInfo(
-      `Asset ID map not found at ${mapPath} — skipping ID and URL slug rewriting.`
+      `Asset ID map not found at ${assetMapPath} — skipping asset ID and URL slug rewriting.`
+    );
+  }
+  if (!contentMapExists) {
+    logInfo(
+      `Content ID map not found at ${contentMapPath} — skipping content ID rewriting.`
     );
   }
 
@@ -156,7 +168,8 @@ async function init() {
   const outPath = argv.out ? path.resolve(argv.out) : defaultOut;
 
   logInfo(`Source snapshot : ${snapshotPath}`);
-  logInfo(`Asset ID map    : ${mapExists ? mapPath : '(none)'}`);
+  logInfo(`Asset ID map    : ${assetMapExists ? assetMapPath : '(none)'}`);
+  logInfo(`Content ID map  : ${contentMapExists ? contentMapPath : '(none)'}`);
   logInfo(`Output path     : ${outPath}`);
 
   const sourceRepo = argv.sourceRepo;
@@ -167,10 +180,15 @@ async function init() {
   }
 
   // Step 2: Load inputs
-  const idMap: Record<string, string> = mapExists
-    ? readJsonFile<Record<string, string>>(mapPath)
+  const assetIdMap: Record<string, string> = assetMapExists
+    ? readJsonFile<Record<string, string>>(assetMapPath)
     : {};
-  const oldIds = Object.keys(idMap);
+  const oldAssetIds = Object.keys(assetIdMap);
+
+  const contentIdMap: Record<string, string> = contentMapExists
+    ? readJsonFile<Record<string, string>>(contentMapPath)
+    : {};
+  const oldContentIds = Object.keys(contentIdMap);
 
   // Load the URL slug map if it exists (produced by restore-prismic-assets.ts).
   // Maps old URL path segments (e.g. "oldId_originalFile.jpg") to new path segments.
@@ -222,23 +240,46 @@ async function init() {
 
   // Pass 3/4: replace old asset IDs with new ones (skipped if no map).
   // Two-pass placeholder strategy guards against the case where a new ID equals an old one.
-  if (oldIds.length > 0) {
-    const escapedIds = oldIds.map(escapeRegex);
+  if (oldAssetIds.length > 0) {
+    const escapedIds = oldAssetIds.map(escapeRegex);
     // Regex: (id1|id2|id3|...) - matches any old asset ID globally
-    const pass1Re = new RegExp(escapedIds.join('|'), 'g');
-    let pass1Replacements = 0;
-    content = content.replace(pass1Re, match => {
-      pass1Replacements++;
-      return `${idMap[match]}${PLACEHOLDER}`;
+    const pass3Re = new RegExp(escapedIds.join('|'), 'g');
+    let pass3Replacements = 0;
+    content = content.replace(pass3Re, match => {
+      pass3Replacements++;
+      return `${assetIdMap[match]}${PLACEHOLDER}`;
     });
-    let pass2Count = 0;
+    let pass4Count = 0;
     // Regex: matches the placeholder suffix to remove it
     content = content.replace(new RegExp(PLACEHOLDER, 'g'), () => {
-      pass2Count++;
+      pass4Count++;
       return '';
     });
     logSuccess(
-      `Pass 3/4 complete: replaced ${pass1Replacements} asset IDs (${pass2Count} cleaned up)`
+      `Pass 3/4 complete: replaced ${pass3Replacements} asset IDs (${pass4Count} cleaned up)`
+    );
+  }
+
+  // Pass 5/6: replace old content document IDs with new ones (skipped if no map).
+  // This corrects content relationship fields that reference other documents.
+  // Two-pass placeholder strategy guards against the case where a new ID equals an old one.
+  if (oldContentIds.length > 0) {
+    const escapedIds = oldContentIds.map(escapeRegex);
+    // Regex: (id1|id2|id3|...) - matches any old content document ID globally
+    const pass5Re = new RegExp(escapedIds.join('|'), 'g');
+    let pass5Replacements = 0;
+    content = content.replace(pass5Re, match => {
+      pass5Replacements++;
+      return `${contentIdMap[match]}${PLACEHOLDER}`;
+    });
+    let pass6Count = 0;
+    // Regex: matches the placeholder suffix to remove it
+    content = content.replace(new RegExp(PLACEHOLDER, 'g'), () => {
+      pass6Count++;
+      return '';
+    });
+    logSuccess(
+      `Pass 5/6 complete: replaced ${pass5Replacements} content document IDs (${pass6Count} cleaned up)`
     );
   }
   // Prismic embeds the repo name in two URL patterns:
@@ -273,10 +314,10 @@ async function init() {
     });
 
     logSuccess(
-      `Pass 5 complete: rewrote ${imagesCount} images.prismic.io URLs and ${cdnCount} cdn.prismic.io URLs`
+      `Pass 7 complete: rewrote ${imagesCount} images.prismic.io URLs and ${cdnCount} cdn.prismic.io URLs`
     );
   }
-  // Step 6: Backfill publishDate on articles
+  // Step 8: Backfill publishDate on articles
   // Articles restored to a new repo receive a new first_publication_date, so we
   // preserve the original publication date by setting publishDate from
   // first_publication_date whenever it is absent. This keeps list-page ordering
@@ -308,7 +349,7 @@ async function init() {
     `Pass publishDate: backfilled publishDate on ${publishDateCount} articles`
   );
 
-  // Step 7: Validate the result is still valid JSON before writing
+  // Step 9: Validate the result is still valid JSON before writing
   try {
     JSON.parse(content);
   } catch (err) {
@@ -317,7 +358,7 @@ async function init() {
     );
   }
 
-  // Step 8: Write the output file
+  // Step 10: Write the output file
   fs.writeFileSync(outPath, content, 'utf-8');
   logSuccess(`Rewritten snapshot written to ${outPath}`);
   logInfo(

--- a/prismic-model/restore/transform-snapshot.ts
+++ b/prismic-model/restore/transform-snapshot.ts
@@ -11,11 +11,11 @@
  *   - Backfills publishDate on articles from first_publication_date
  *   - Optionally rewrites the repository name in Prismic asset URLs
  *
- * The ID rewrites are done in two passes to guard against collisions where a new ID
- * happens to equal one of the old IDs:
+ * Replacements that could collide with existing values are applied using a
+ * two-pass placeholder strategy:
  *
- *   Pass 1 — Replace every old ID with "<newId>__RESTORE_PLACEHOLDER__"
- *   Pass 2 — Strip the "__RESTORE_PLACEHOLDER__" suffix from every replaced value
+ *   1. Replace every matched value with "<newValue>__RESTORE_PLACEHOLDER__"
+ *   2. Strip the "__RESTORE_PLACEHOLDER__" suffix from every replaced value
  *
  * If --source-repo and --target-repo are both provided (and differ), a final pass rewrites
  * the repository name wherever it appears in Prismic asset URLs.

--- a/prismic-model/restore/transform-snapshot.ts
+++ b/prismic-model/restore/transform-snapshot.ts
@@ -153,7 +153,7 @@ async function init() {
 
   if (!assetMapExists) {
     logInfo(
-      `Asset ID map not found at ${assetMapPath} — skipping asset ID and URL slug rewriting.`
+      `Asset ID map not found at ${assetMapPath} — skipping asset ID rewriting.`
     );
   }
   if (!contentMapExists) {

--- a/prismic-model/restore/transform-snapshot.ts
+++ b/prismic-model/restore/transform-snapshot.ts
@@ -221,20 +221,20 @@ async function init() {
   if (oldSlugs.length > 0) {
     const escapedSlugs = oldSlugs.map(escapeRegex);
     // Regex: (slug1|slug2|slug3|...) - matches any old URL path segment globally
-    const pass3Re = new RegExp(escapedSlugs.join('|'), 'g');
-    let pass3Replacements = 0;
-    content = content.replace(pass3Re, match => {
-      pass3Replacements++;
+    const slugPattern = new RegExp(escapedSlugs.join('|'), 'g');
+    let slugReplacements = 0;
+    content = content.replace(slugPattern, match => {
+      slugReplacements++;
       return `${slugMap[match]}${PLACEHOLDER}`;
     });
-    let pass4Count = 0;
+    let slugPlaceholdersRemoved = 0;
     // Regex: matches the placeholder suffix to remove it
     content = content.replace(new RegExp(PLACEHOLDER, 'g'), () => {
-      pass4Count++;
+      slugPlaceholdersRemoved++;
       return '';
     });
     logSuccess(
-      `Pass 1/2 complete: replaced ${pass3Replacements} URL path segments (${pass4Count} cleaned up)`
+      `URL slug replacement complete: replaced ${slugReplacements} path segments (${slugPlaceholdersRemoved} placeholders removed)`
     );
   }
 
@@ -243,20 +243,20 @@ async function init() {
   if (oldAssetIds.length > 0) {
     const escapedIds = oldAssetIds.map(escapeRegex);
     // Regex: (id1|id2|id3|...) - matches any old asset ID globally
-    const pass3Re = new RegExp(escapedIds.join('|'), 'g');
-    let pass3Replacements = 0;
-    content = content.replace(pass3Re, match => {
-      pass3Replacements++;
+    const assetIdPattern = new RegExp(escapedIds.join('|'), 'g');
+    let assetIdReplacements = 0;
+    content = content.replace(assetIdPattern, match => {
+      assetIdReplacements++;
       return `${assetIdMap[match]}${PLACEHOLDER}`;
     });
-    let pass4Count = 0;
+    let assetIdPlaceholdersRemoved = 0;
     // Regex: matches the placeholder suffix to remove it
     content = content.replace(new RegExp(PLACEHOLDER, 'g'), () => {
-      pass4Count++;
+      assetIdPlaceholdersRemoved++;
       return '';
     });
     logSuccess(
-      `Pass 3/4 complete: replaced ${pass3Replacements} asset IDs (${pass4Count} cleaned up)`
+      `Asset ID replacement complete: replaced ${assetIdReplacements} asset IDs (${assetIdPlaceholdersRemoved} placeholders removed)`
     );
   }
 
@@ -266,20 +266,20 @@ async function init() {
   if (oldContentIds.length > 0) {
     const escapedIds = oldContentIds.map(escapeRegex);
     // Regex: (id1|id2|id3|...) - matches any old content document ID globally
-    const pass5Re = new RegExp(escapedIds.join('|'), 'g');
-    let pass5Replacements = 0;
-    content = content.replace(pass5Re, match => {
-      pass5Replacements++;
+    const contentIdPattern = new RegExp(escapedIds.join('|'), 'g');
+    let contentIdReplacements = 0;
+    content = content.replace(contentIdPattern, match => {
+      contentIdReplacements++;
       return `${contentIdMap[match]}${PLACEHOLDER}`;
     });
-    let pass6Count = 0;
+    let contentIdPlaceholdersRemoved = 0;
     // Regex: matches the placeholder suffix to remove it
     content = content.replace(new RegExp(PLACEHOLDER, 'g'), () => {
-      pass6Count++;
+      contentIdPlaceholdersRemoved++;
       return '';
     });
     logSuccess(
-      `Pass 5/6 complete: replaced ${pass5Replacements} content document IDs (${pass6Count} cleaned up)`
+      `Content ID replacement complete: replaced ${contentIdReplacements} content document IDs (${contentIdPlaceholdersRemoved} placeholders removed)`
     );
   }
   // Prismic embeds the repo name in two URL patterns:
@@ -314,7 +314,7 @@ async function init() {
     });
 
     logSuccess(
-      `Pass 7 complete: rewrote ${imagesCount} images.prismic.io URLs and ${cdnCount} cdn.prismic.io URLs`
+      `Repository URL rewriting complete: rewrote ${imagesCount} images.prismic.io URLs and ${cdnCount} cdn.prismic.io URLs`
     );
   }
   // Step 8: Backfill publishDate on articles
@@ -346,7 +346,7 @@ async function init() {
   }
   content = JSON.stringify(docs, null, 2);
   logSuccess(
-    `Pass publishDate: backfilled publishDate on ${publishDateCount} articles`
+    `Article publishDate backfill complete: set publishDate on ${publishDateCount} articles`
   );
 
   // Step 9: Validate the result is still valid JSON before writing


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13017

## What does this change?

- Adds a pass in the snapshot transformer script for updating the content ids of linked documents, using the content-id-map file.
- Updates documentation to reflect the change.

## How to test

- run `yarn transformSnapshot` without the content-id-map.json file
- Expected output: Content ID map not found at ... — skipping content ID rewriting."
- create a dummy content-id-map.json file in the status folder containing something like
{
  "Z9ikdhEAACAA-ZWF": "YNEWdocID789",
  "aR8DZxAAACgAaG6e": "YNEWdocID012"
}
- run `yarn transformSnapshot` again
- Expected output should include: "Pass 5/6 complete: replaced X content document IDs (X cleaned up)"
- check the ids have been updated in the rewritten snapshot

## Have we considered potential risks?

The ids aren't updated as expected