### PR TITLE
Add toggle for inGallery stuff

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -35,14 +35,6 @@ const toggles = {
       type: 'permanent',
     },
     {
-      id: 'inGallery',
-      title: 'Gallery display mode',
-      initialValue: false,
-      description:
-        'Enables gallery-specific features such as removing external links and showing inactivity redirect after 10 minutes',
-      type: 'permanent',
-    },
-    {
       id: 'conceptsSearch',
       title: 'Concepts search',
       initialValue: false,
@@ -151,6 +143,14 @@ const toggles = {
       initialValue: false,
       description: 'Allows testing of vertical videos.',
       type: 'experimental',
+    },
+    {
+      id: 'inGallery',
+      title: 'Gallery display mode',
+      initialValue: false,
+      description:
+        'Enables gallery-specific features such as removing external links and showing inactivity redirect after 10 minutes',
+      type: 'permanent',
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -35,6 +35,14 @@ const toggles = {
       type: 'permanent',
     },
     {
+      id: 'inGallery',
+      title: 'Gallery display mode',
+      initialValue: false,
+      description:
+        'Enables gallery-specific features such as removing external links and showing inactivity redirect after 10 minutes',
+      type: 'permanent',
+    },
+    {
       id: 'conceptsSearch',
       title: 'Concepts search',
       initialValue: false,

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -150,7 +150,7 @@ const toggles = {
       initialValue: false,
       description:
         'Enables gallery-specific features such as removing external links and showing inactivity redirect after 10 minutes',
-      type: 'permanent',
+      type: 'experimental',
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -149,7 +149,7 @@ const toggles = {
       title: 'Gallery display mode',
       initialValue: false,
       description:
-        'Enables gallery-specific features such as removing external links and showing inactivity redirect after 10 minutes',
+        'Enables gallery-specific features such as removing external links and showing an inactivity redirect after a period of inactivity',
       type: 'experimental',
     },
   ] as const,


### PR DESCRIPTION
- Relates to https://github.com/wellcomecollection/wellcomecollection.org/issues/13025

## What does this change?

Adds an inGallery toggle we can use to change the display/functionality of pages if they are being viewed in a gallery on a designated device.

We'll probably want to change it from experimental to permanent once the work is finished