### PR TITLE
update search terms for testing

### DIFF
--- a/content/webapp/views/components/PrototypeSearchSelects/index.tsx
+++ b/content/webapp/views/components/PrototypeSearchSelects/index.tsx
@@ -15,16 +15,16 @@ type Props = {
 };
 
 const predefinedTerms = [
-  'brain',
-  'witch',
-  'chinese medicine',
-  'aids',
-  'flowers',
-  'history of psychiatry book 21st century',
-  'medicinal drugs of india',
-  'medical officer of health',
-  'burke and hare murders',
-  'eighteenth century collections online',
+  'Brain',
+  'Chinese medicine',
+  'Florence Nightingale',
+  'AIDS',
+  'Flowers',
+  'History of psychiatry book 21st century',
+  'Medicinal drugs of India',
+  'Medical officer of health',
+  'Eighteenth century collections online',
+  'The history of witches and wizards',
 ];
 
 const PrototypeSearchSelects: FunctionComponent<Props> = ({


### PR DESCRIPTION
- For https://wellcome.slack.com/archives/C0AH3GW4Z8A/p1778503641019119

## What does this change?

Small change to the predefined search terms to use in the testing


## How to test
- [turn on the Semantic search prototype toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=semanticSearchPrototype)
- View https://www-dev.wellcomecollection.org/search/works
- Check the terms in the 'Select a term' select box

## Have we considered potential risks?

none really