### PR TITLE
Undici url check

### DIFF
--- a/common/services/prismic/fetch/index.ts
+++ b/common/services/prismic/fetch/index.ts
@@ -1,8 +1,8 @@
 import * as prismic from '@prismicio/client';
 
 import sliceMachineConfig from '@weco/common/slicemachine.config.json';
+import { fetchWithTrustedHosts } from '@weco/common/utils/trusted-fetch';
 import { isUndefined } from '@weco/common/utils/type-guards';
-import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
 
 export function createClient(isPrismicStage?: boolean): prismic.Client {
   // We use an access token for Prismic in prod to avoid certain classes of
@@ -36,8 +36,9 @@ export function createClient(isPrismicStage?: boolean): prismic.Client {
   const endpoint = prismic.getRepositoryEndpoint(
     `wellcomecollection${isPrismicStage ? '-stage' : ''}`
   );
+  const allowedHost = new URL(endpoint).hostname;
   const client = prismic.createClient(endpoint, {
-    fetch: fetchWithUndiciAgent,
+    fetch: (url, options) => fetchWithTrustedHosts(url, options, [allowedHost]),
     accessToken,
     ...sliceMachineConfig,
   });

--- a/common/utils/trusted-fetch.test.ts
+++ b/common/utils/trusted-fetch.test.ts
@@ -1,0 +1,74 @@
+import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
+
+import { fetchWithTrustedHosts } from './trusted-fetch';
+
+jest.mock('@weco/common/utils/undici-agent', () => ({
+  fetchWithUndiciAgent: jest.fn(),
+}));
+
+describe('fetchWithTrustedHosts', () => {
+  const mockFetchWithUndiciAgent = fetchWithUndiciAgent as jest.MockedFunction<
+    typeof fetchWithUndiciAgent
+  >;
+
+  beforeEach(() => {
+    mockFetchWithUndiciAgent.mockReset();
+  });
+
+  it('forwards allowlisted requests to undici fetch', async () => {
+    const mockResponse = { ok: true } as Response;
+    mockFetchWithUndiciAgent.mockResolvedValue(mockResponse);
+
+    const options = { method: 'GET' };
+    const result = await fetchWithTrustedHosts(
+      'https://api.wellcomecollection.org/works',
+      options,
+      ['api.wellcomecollection.org']
+    );
+
+    expect(result).toBe(mockResponse);
+    expect(mockFetchWithUndiciAgent).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, calledOptions] = mockFetchWithUndiciAgent.mock.calls[0];
+    expect(calledUrl).toBeInstanceOf(URL);
+    expect((calledUrl as URL).hostname).toBe('api.wellcomecollection.org');
+    expect(calledOptions).toEqual(options);
+  });
+
+  it('accepts allowlist entries provided as full URLs', async () => {
+    const mockResponse = { ok: true } as Response;
+    mockFetchWithUndiciAgent.mockResolvedValue(mockResponse);
+
+    await fetchWithTrustedHosts(
+      'https://api-stage.wellcomecollection.org/events',
+      undefined,
+      ['https://api-stage.wellcomecollection.org']
+    );
+
+    expect(mockFetchWithUndiciAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when URL host is not allowlisted', async () => {
+    await expect(
+      fetchWithTrustedHosts('https://example.com/works', undefined, [
+        'api.wellcomecollection.org',
+      ])
+    ).rejects.toThrow(
+      'Blocked outgoing request to untrusted host: example.com'
+    );
+
+    expect(mockFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
+
+  it('throws when no valid trusted hosts are configured', async () => {
+    await expect(
+      fetchWithTrustedHosts(
+        'https://api.wellcomecollection.org/works',
+        undefined,
+        ['', '   ', '://not-a-host']
+      )
+    ).rejects.toThrow('No trusted hosts configured for trusted fetch');
+
+    expect(mockFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
+});

--- a/common/utils/trusted-fetch.test.ts
+++ b/common/utils/trusted-fetch.test.ts
@@ -31,7 +31,9 @@ describe('fetchWithTrustedHosts', () => {
 
     const [calledUrl, calledOptions] = mockFetchWithUndiciAgent.mock.calls[0];
     expect(calledUrl).toBeInstanceOf(URL);
-    expect((calledUrl as URL).hostname).toBe('api.wellcomecollection.org');
+    expect((calledUrl as URL).origin).toBe(
+      'https://api.wellcomecollection.org'
+    );
     expect(calledOptions).toEqual(options);
   });
 
@@ -54,7 +56,7 @@ describe('fetchWithTrustedHosts', () => {
         'api.wellcomecollection.org',
       ])
     ).rejects.toThrow(
-      'Blocked outgoing request to untrusted host: example.com'
+      'Blocked outgoing request to untrusted origin: https://example.com'
     );
 
     expect(mockFetchWithUndiciAgent).not.toHaveBeenCalled();
@@ -68,6 +70,34 @@ describe('fetchWithTrustedHosts', () => {
         ['', '   ', '://not-a-host']
       )
     ).rejects.toThrow('No trusted hosts configured for trusted fetch');
+
+    expect(mockFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
+
+  it('blocks requests when scheme differs from allowlisted origin', async () => {
+    await expect(
+      fetchWithTrustedHosts(
+        'http://api.wellcomecollection.org/works',
+        undefined,
+        ['api.wellcomecollection.org']
+      )
+    ).rejects.toThrow(
+      'Blocked outgoing request to untrusted origin: http://api.wellcomecollection.org'
+    );
+
+    expect(mockFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
+
+  it('blocks requests when port differs from allowlisted origin', async () => {
+    await expect(
+      fetchWithTrustedHosts(
+        'https://api.wellcomecollection.org:4444/works',
+        undefined,
+        ['https://api.wellcomecollection.org']
+      )
+    ).rejects.toThrow(
+      'Blocked outgoing request to untrusted origin: https://api.wellcomecollection.org:4444'
+    );
 
     expect(mockFetchWithUndiciAgent).not.toHaveBeenCalled();
   });

--- a/common/utils/trusted-fetch.ts
+++ b/common/utils/trusted-fetch.ts
@@ -1,0 +1,61 @@
+import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
+
+// Convert supported RequestInfo shapes into a URL so host checks are consistent.
+function parseRequestUrl(url: RequestInfo | URL): URL {
+  if (url instanceof URL) {
+    return url;
+  }
+
+  if (typeof url === 'string') {
+    return new URL(url);
+  }
+
+  if (typeof Request !== 'undefined' && url instanceof Request) {
+    return new URL(url.url);
+  }
+
+  throw new Error('Unsupported URL type for trusted fetch');
+}
+
+// Allow callers to pass either hostnames or full URLs, and compare using hostname only.
+function normaliseAllowedHosts(allowedHosts: string[]): Set<string> {
+  const hosts = new Set<string>();
+
+  for (const host of allowedHosts) {
+    const trimmedHost = host.trim();
+    if (!trimmedHost) continue;
+
+    try {
+      const asUrl =
+        trimmedHost.startsWith('http://') || trimmedHost.startsWith('https://')
+          ? new URL(trimmedHost)
+          : new URL(`https://${trimmedHost}`);
+      hosts.add(asUrl.hostname.toLowerCase());
+    } catch {
+      // Ignore malformed allowlist entries.
+    }
+  }
+
+  return hosts;
+}
+
+// Wrapper around outbound fetch that enforces a host allowlist before any network call.
+export async function fetchWithTrustedHosts(
+  url: RequestInfo | URL,
+  options: RequestInit | undefined,
+  allowedHosts: string[]
+): Promise<Response> {
+  const trustedHosts = normaliseAllowedHosts(allowedHosts);
+  if (trustedHosts.size === 0) {
+    throw new Error('No trusted hosts configured for trusted fetch');
+  }
+
+  const parsedUrl = parseRequestUrl(url);
+  if (!trustedHosts.has(parsedUrl.hostname.toLowerCase())) {
+    throw new Error(
+      `Blocked outgoing request to untrusted host: ${parsedUrl.hostname}`
+    );
+  }
+
+  return fetchWithUndiciAgent(parsedUrl, options);
+}

--- a/common/utils/trusted-fetch.ts
+++ b/common/utils/trusted-fetch.ts
@@ -1,5 +1,9 @@
 import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
 
+function isHttpProtocol(protocol: string): boolean {
+  return protocol === 'http:' || protocol === 'https:';
+}
+
 // Convert supported RequestInfo shapes into a URL so host checks are consistent.
 function parseRequestUrl(url: RequestInfo | URL): URL {
   if (url instanceof URL) {
@@ -17,9 +21,9 @@ function parseRequestUrl(url: RequestInfo | URL): URL {
   throw new Error('Unsupported URL type for trusted fetch');
 }
 
-// Allow callers to pass either hostnames or full URLs, and compare using hostname only.
-function normaliseAllowedHosts(allowedHosts: string[]): Set<string> {
-  const hosts = new Set<string>();
+// Allow callers to pass either origins or hostnames; compare using normalised origins.
+function normaliseAllowedOrigins(allowedHosts: string[]): Set<string> {
+  const origins = new Set<string>();
 
   for (const host of allowedHosts) {
     const trimmedHost = host.trim();
@@ -30,13 +34,17 @@ function normaliseAllowedHosts(allowedHosts: string[]): Set<string> {
         trimmedHost.startsWith('http://') || trimmedHost.startsWith('https://')
           ? new URL(trimmedHost)
           : new URL(`https://${trimmedHost}`);
-      hosts.add(asUrl.hostname.toLowerCase());
+      if (!isHttpProtocol(asUrl.protocol)) {
+        continue;
+      }
+
+      origins.add(asUrl.origin.toLowerCase());
     } catch {
       // Ignore malformed allowlist entries.
     }
   }
 
-  return hosts;
+  return origins;
 }
 
 // Wrapper around outbound fetch that enforces a host allowlist before any network call.
@@ -45,15 +53,21 @@ export async function fetchWithTrustedHosts(
   options: RequestInit | undefined,
   allowedHosts: string[]
 ): Promise<Response> {
-  const trustedHosts = normaliseAllowedHosts(allowedHosts);
-  if (trustedHosts.size === 0) {
+  const trustedOrigins = normaliseAllowedOrigins(allowedHosts);
+  if (trustedOrigins.size === 0) {
     throw new Error('No trusted hosts configured for trusted fetch');
   }
 
   const parsedUrl = parseRequestUrl(url);
-  if (!trustedHosts.has(parsedUrl.hostname.toLowerCase())) {
+  if (!isHttpProtocol(parsedUrl.protocol)) {
     throw new Error(
-      `Blocked outgoing request to untrusted host: ${parsedUrl.hostname}`
+      `Blocked outgoing request with unsupported scheme: ${parsedUrl.protocol}`
+    );
+  }
+
+  if (!trustedOrigins.has(parsedUrl.origin.toLowerCase())) {
+    throw new Error(
+      `Blocked outgoing request to untrusted origin: ${parsedUrl.origin}`
     );
   }
 

--- a/content/webapp/services/wellcome/index.ts
+++ b/content/webapp/services/wellcome/index.ts
@@ -1,4 +1,4 @@
-import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
+import { fetchWithTrustedHosts } from '@weco/common/utils/trusted-fetch';
 import { Toggles } from '@weco/toggles';
 
 type envOptions = 'prod' | 'stage' | 'dev';
@@ -17,6 +17,9 @@ export const rootUris = {
   stage: 'https://api-stage.wellcomecollection.org',
   dev: 'https://api-dev.wellcomecollection.org',
 };
+const ALLOWED_HOSTS = Object.values(rootUris).map(
+  rootUri => new URL(rootUri).hostname
+);
 
 type ApiEnvOptions = {
   catalogue: envOptions;
@@ -118,7 +121,7 @@ export const wellcomeApiFetch = async (
   url: string,
   options?: RequestInit
 ): Promise<Response> => {
-  return fetchWithUndiciAgent(url, options);
+  return fetchWithTrustedHosts(url, options, ALLOWED_HOSTS);
 };
 
 export const wellcomeApiError = (): WellcomeApiError => ({

--- a/identity/webapp/test/fetch-helpers.test.ts
+++ b/identity/webapp/test/fetch-helpers.test.ts
@@ -1,4 +1,13 @@
+import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
 import { FetchClient, FetchError } from '@weco/identity/utils/fetch-helpers';
+
+jest.mock('@weco/common/utils/undici-agent', () => ({
+  fetchWithUndiciAgent: jest.fn(),
+}));
+
+const mockedFetchWithUndiciAgent = fetchWithUndiciAgent as jest.MockedFunction<
+  typeof fetchWithUndiciAgent
+>;
 
 describe('FetchError', () => {
   it('should create error with response details', () => {
@@ -25,6 +34,22 @@ describe('FetchError', () => {
 });
 
 describe('FetchClient', () => {
+  beforeEach(() => {
+    mockedFetchWithUndiciAgent.mockReset();
+    mockedFetchWithUndiciAgent.mockImplementation(
+      async (_url: RequestInfo | URL, options?: RequestInit) => {
+        if (options?.signal?.aborted) {
+          throw new DOMException('This operation was aborted', 'AbortError');
+        }
+
+        return new Response('{}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    );
+  });
+
   it('should create instance with baseURL and headers', () => {
     const client = new FetchClient({
       baseURL: 'http://api.local',
@@ -75,5 +100,30 @@ describe('FetchClient', () => {
         signal: controller.signal,
       })
     ).rejects.toThrow();
+  });
+
+  it('should allow requests for relative baseURL clients', async () => {
+    const client = new FetchClient({ baseURL: '/account/api' });
+
+    await client.request({ url: '/users/me' });
+
+    expect(mockedFetchWithUndiciAgent).toHaveBeenCalledWith(
+      '/account/api/users/me',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+  });
+
+  it('should block absolute URLs for relative baseURL clients', async () => {
+    const client = new FetchClient({ baseURL: '/account/api' });
+
+    await expect(
+      client.request({ url: 'https://example.com/evil' })
+    ).rejects.toThrow(
+      'Blocked absolute URL request for relative-base client: https://example.com/evil'
+    );
+
+    expect(mockedFetchWithUndiciAgent).not.toHaveBeenCalled();
   });
 });

--- a/identity/webapp/test/fetch-helpers.test.ts
+++ b/identity/webapp/test/fetch-helpers.test.ts
@@ -126,4 +126,38 @@ describe('FetchClient', () => {
 
     expect(mockedFetchWithUndiciAgent).not.toHaveBeenCalled();
   });
+
+  it('should block requests outside base path after pathname normalisation', async () => {
+    const client = new FetchClient({ baseURL: '/account/api' });
+
+    await expect(client.request({ url: '/../admin' })).rejects.toThrow(
+      'Blocked request outside configured base path: /account/admin'
+    );
+
+    expect(mockedFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
+
+  it('should block absolute URLs with scheme mismatch for absolute baseURL clients', async () => {
+    const client = new FetchClient({ baseURL: 'https://api.local' });
+
+    await expect(
+      client.request({ url: 'http://api.local/test' })
+    ).rejects.toThrow(
+      'Blocked request to untrusted origin: http://api.local. Expected: https://api.local'
+    );
+
+    expect(mockedFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
+
+  it('should block absolute URLs with port mismatch for absolute baseURL clients', async () => {
+    const client = new FetchClient({ baseURL: 'https://api.local' });
+
+    await expect(
+      client.request({ url: 'https://api.local:4444/test' })
+    ).rejects.toThrow(
+      'Blocked request to untrusted origin: https://api.local:4444. Expected: https://api.local'
+    );
+
+    expect(mockedFetchWithUndiciAgent).not.toHaveBeenCalled();
+  });
 });

--- a/identity/webapp/utils/fetch-helpers.ts
+++ b/identity/webapp/utils/fetch-helpers.ts
@@ -37,12 +37,20 @@ export class FetchError extends Error {
   }
 }
 
-function getHostname(url: string): string {
-  return new URL(url).hostname.toLowerCase();
+function getOrigin(url: string): string {
+  return new URL(url).origin.toLowerCase();
 }
 
 function isAbsoluteHttpUrl(url: string): boolean {
   return /^https?:\/\//i.test(url);
+}
+
+function normalisePathname(pathOrUrl: string): string {
+  return new URL(pathOrUrl, 'https://trusted.local').pathname;
+}
+
+function ensureTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`;
 }
 
 /**
@@ -163,11 +171,11 @@ export class FetchClient {
     }
 
     if (isAbsoluteHttpUrl(baseURL)) {
-      const trustedHost = getHostname(baseURL);
-      const requestHost = getHostname(fullUrl);
-      if (requestHost !== trustedHost) {
+      const trustedOrigin = getOrigin(baseURL);
+      const requestOrigin = getOrigin(fullUrl);
+      if (requestOrigin !== trustedOrigin) {
         throw new Error(
-          `Blocked request to untrusted host: ${requestHost}. Expected: ${trustedHost}`
+          `Blocked request to untrusted origin: ${requestOrigin}. Expected: ${trustedOrigin}`
         );
       }
     } else {
@@ -177,9 +185,17 @@ export class FetchClient {
         );
       }
 
-      if (!fullUrl.startsWith(baseURL)) {
+      const normalisedBasePath = ensureTrailingSlash(
+        normalisePathname(baseURL)
+      );
+      const normalisedRequestPath = normalisePathname(fullUrl);
+      const isWithinBasePath =
+        normalisedRequestPath === normalisedBasePath.slice(0, -1) ||
+        normalisedRequestPath.startsWith(normalisedBasePath);
+
+      if (!isWithinBasePath) {
         throw new Error(
-          `Blocked request outside configured base path: ${fullUrl}`
+          `Blocked request outside configured base path: ${normalisedRequestPath}`
         );
       }
     }

--- a/identity/webapp/utils/fetch-helpers.ts
+++ b/identity/webapp/utils/fetch-helpers.ts
@@ -37,6 +37,14 @@ export class FetchError extends Error {
   }
 }
 
+function getHostname(url: string): string {
+  return new URL(url).hostname.toLowerCase();
+}
+
+function isAbsoluteHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
 /**
  * Parse response body with fallback handling
  * Tries JSON first, falls back to text for error responses
@@ -67,13 +75,12 @@ async function parseResponseData(response: Response): Promise<unknown> {
  * Wrapper around fetch that throws FetchError for non-2xx responses
  * Similar to axios behavior of throwing on error status codes
  */
-export async function fetchWithErrorHandling(
+async function fetchWithErrorHandling(
   url: RequestInfo | URL,
   options?: RequestInit & { validateStatus?: (status: number) => boolean }
 ): Promise<Response> {
   const { validateStatus, ...fetchOptions } = options || {};
 
-  // Use undici agent on server, regular fetch on client
   const response = await fetchWithUndiciAgent(url, fetchOptions);
 
   // Custom validation function or default to 2xx check
@@ -147,6 +154,35 @@ export class FetchClient {
   ): Promise<Response> {
     const fullUrl = this.buildUrl(url);
     const headers = this.mergeHeaders(options?.headers);
+    const baseURL = this.baseURL;
+
+    if (!baseURL) {
+      throw new Error(
+        'FetchClient requires a baseURL to execute trusted requests'
+      );
+    }
+
+    if (isAbsoluteHttpUrl(baseURL)) {
+      const trustedHost = getHostname(baseURL);
+      const requestHost = getHostname(fullUrl);
+      if (requestHost !== trustedHost) {
+        throw new Error(
+          `Blocked request to untrusted host: ${requestHost}. Expected: ${trustedHost}`
+        );
+      }
+    } else {
+      if (isAbsoluteHttpUrl(fullUrl)) {
+        throw new Error(
+          `Blocked absolute URL request for relative-base client: ${fullUrl}`
+        );
+      }
+
+      if (!fullUrl.startsWith(baseURL)) {
+        throw new Error(
+          `Blocked request outside configured base path: ${fullUrl}`
+        );
+      }
+    }
 
     const controller = new AbortController();
     let timeoutId: NodeJS.Timeout | undefined;


### PR DESCRIPTION
- For CodeQL comments left in https://github.com/wellcomecollection/wellcomecollection.org/pull/13047

## What does this change?

This branch adds targeted outbound request hardening on top of `dependabot/npm_and_yarn/all-c368efeabc`.

- Adds a shared trusted fetch helper in `common/utils/trusted-fetch.ts`.
- Applies trusted fetch checks to Prismic client requests in `common/services/prismic/fetch/index.ts`.
- Applies trusted fetch checks to Wellcome API requests in `content/webapp/services/wellcome/index.ts`.
- Strengthens identity FetchClient request validation in `identity/webapp/utils/fetch-helpers.ts`:
  - absolute baseURL clients are locked to the configured origin (scheme + host + port)
  - relative baseURL clients reject absolute URL overrides
  - relative baseURL clients enforce normalised base-path boundaries (including dot-segment normalisation)
- Keeps fetchWithErrorHandling internal to the module (no external export) in `identity/webapp/utils/fetch-helpers.ts`.
- Adds regression coverage for trusted-fetch and FetchClient hardening in:
  - `common/utils/trusted-fetch.test.ts`
  - `identity/webapp/test/fetch-helpers.test.ts`

Security intent:
- Prevent outbound requests from being redirected to untrusted origins.
- Prevent protocol/port drift when hostnames match.
- Prevent relative path escape via dot-segments.



## How to test

Do tests pass?

Verify normal page/API behaviour that depends on:
- Wellcome API fetches from content webapp
- identity account API calls that use `FetchClient`

## Have we considered potential risks?

- Risk: stricter origin/path checks could block legitimate calls that previously passed.
  - Mitigation: checks are scoped to known API/Prismic hosts and identity base paths, with regression tests for allowed and blocked scenarios.

- Risk: false confidence from hostname-only matching.
  - Mitigation: origin comparison now includes scheme and port.

- Risk: path-traversal style escape from relative-base clients.
  - Mitigation: pathnames are normalised before boundary checks.

- Risk: operational regressions in runtime fetch behaviour.
  - Mitigation: existing test coverage is expanded and the branch has been type-checked across workspaces.

No documentation updates appear required beyond this PR description, as there are no new user-facing features or setup changes.
