### PR TITLE
Default to the video embed title

### DIFF
--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -7201,7 +7201,7 @@ export interface PortraitVideoListSliceDefaultItem {
    * Embed field in *PortraitVideoList → Items*
    *
    * - **Field Type**: Embed
-   * - **Placeholder**: For YouTube shorts urls, replace '/shorts/' with '/watch?v='
+   * - **Placeholder**: For YouTube Shorts, replace '/shorts/' with '/watch?v='
    * - **API ID Path**: portraitVideoList.items[].embed
    * - **Documentation**: https://prismic.io/docs/fields/embed
    */
@@ -7231,7 +7231,7 @@ export interface PortraitVideoListSliceDefaultItem {
    * Title field in *PortraitVideoList → Items*
    *
    * - **Field Type**: Text
-   * - **Placeholder**: *None*
+   * - **Placeholder**: Leave this blank to use the title from the embed
    * - **API ID Path**: portraitVideoList.items[].title
    * - **Documentation**: https://prismic.io/docs/fields/text
    */

--- a/common/views/slices/PortraitVideoList/index.tsx
+++ b/common/views/slices/PortraitVideoList/index.tsx
@@ -25,7 +25,7 @@ const PortraitVideoListSlice: FunctionComponent<
         videoProvider: embed.videoProvider,
         posterImage: transformImage(item.poster_image) ?? undefined,
         duration: item.duration ?? undefined,
-        title: item.title ?? undefined,
+        title: item.title ?? embed.title ?? undefined,
         transcript: item.transcript,
       },
     ];

--- a/common/views/slices/PortraitVideoList/index.tsx
+++ b/common/views/slices/PortraitVideoList/index.tsx
@@ -25,7 +25,7 @@ const PortraitVideoListSlice: FunctionComponent<
         videoProvider: embed.videoProvider,
         posterImage: transformImage(item.poster_image) ?? undefined,
         duration: item.duration ?? undefined,
-        title: item.title ?? embed.title ?? undefined,
+        title: item.title || embed.title || undefined,
         transcript: item.transcript,
       },
     ];

--- a/common/views/slices/PortraitVideoList/model.json
+++ b/common/views/slices/PortraitVideoList/model.json
@@ -25,7 +25,7 @@
           "fieldset": "Embed",
           "config": {
             "label": "Embed",
-            "placeholder": "For YouTube shorts urls, replace '/shorts/' with '/watch?v='"
+            "placeholder": "For YouTube Shorts, replace '/shorts/' with '/watch?v='"
           }
         },
         "poster_image": {
@@ -47,7 +47,7 @@
           "type": "Text",
           "config": {
             "label": "Title",
-            "placeholder": ""
+            "placeholder": "Leave this blank to use the title from the embed"
           }
         },
         "transcript": {


### PR DESCRIPTION
- For #12926

## What does this change?

Adds the ability to use the title of the video from the embed (if the `title` field is left blank)

## How to test

Check the 'Onward journeys' tab for the Tenderness and rage exhibition in the Prismic stage environment. See the first PortraitVideo item has a blank title field. Check that the title of that video on YouTube ("Wellcome Collection shuts ‘racist’ Medicine Man exhibition after 15 years") is what's displayed below the item when visiting the [exhibition page](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage) with the following toggles on:

- [Prismic stage toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=prismicStage)
- [Exhibition pages and Collection content toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection)
- [Vertical videos toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=verticalVideos)


## Have we considered potential risks?

n/a