### PR TITLE
Prismic lint Slack: Send alert once outside the loop

### DIFF
--- a/prismic-model/scripts/lintPrismicData.ts
+++ b/prismic-model/scripts/lintPrismicData.ts
@@ -493,22 +493,22 @@ async function run() {
         console.log(`- ${msg}`);
       }
       console.log('');
+    }
+  }
 
-      // Send an alert to Editors if anything is found on a GitHub Action run
-      // https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml
-      if (slackWebhookUrl) {
-        try {
-          await fetch(slackWebhookUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json; charset=UTF-8' },
-            body: JSON.stringify({
-              message: `The Prismic linting script has found ${pluralize(errors.length, 'thing')} that require${errors.length > 1 ? '' : 's'} your attention.`,
-            }),
-          });
-        } catch (e) {
-          console.log(e);
-        }
-      }
+  // Send a single alert to Editors if anything is found on a GitHub Action run
+  // https://github.com/wellcomecollection/wellcomecollection.org/actions/workflows/prismic-linting.yml
+  if (slackWebhookUrl && totalErrors > 0) {
+    try {
+      await fetch(slackWebhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+        body: JSON.stringify({
+          message: `The Prismic linting script has found ${pluralize(totalErrors, 'thing')} that require${totalErrors > 1 ? '' : 's'} your attention.`,
+        }),
+      });
+    } catch (e) {
+      console.log(e);
     }
   }
 


### PR DESCRIPTION
- For Editorial

## What does this change?

The alert was being sent in the loop, sending one alert per test set

<img width="681" height="425" alt="Screenshot 2026-05-12 at 11 35 47" src="https://github.com/user-attachments/assets/02aeaef8-01e1-4de7-b722-7688a04d64c3" />


This should make sure it works properly, but I will test it once deployed.

## How to test

It's a bit inconsequential to merge it, I'll test once main is updated if that's alright

## Have we considered potential risks?
N/A internal tool