### PR TITLE
Skip concept tests

### DIFF
--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -92,7 +92,7 @@ test.describe('a Concept representing an Agent with no Images', () => {
 });
 
 test.describe('a Concept representing an Agent with Works and Images both about and by them', () => {
-  test('has both works and image sections grouped into "by" and "about" sections', async ({
+  test.skip('has both works and image sections grouped into "by" and "about" sections', async ({
     armyPage,
   }) => {
     // It has two tabs (works)
@@ -135,7 +135,7 @@ test.describe('a Concept representing an Agent with Works and Images both about 
 });
 
 test.describe('a Concept representing a Genre with works and images both about and using them', () => {
-  test('has both works and image sections, each with about and using tabs', async ({
+  test.skip('has both works and image sections, each with about and using tabs', async ({
     statisticsPage,
   }) => {
     const title = encodeURIComponent('"Statistics"');
@@ -178,7 +178,7 @@ test.describe('a Concept representing a Genre with works and images both about a
 });
 
 test.describe('a Concept representing a Genre that is only used as a genre for both works and images', () => {
-  test('has both works and image sections showing records in that genre', async ({
+  test.skip('has both works and image sections showing records in that genre', async ({
     mohPage,
   }) => {
     // Both images and works sections exist

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -92,7 +92,8 @@ test.describe('a Concept representing an Agent with no Images', () => {
 });
 
 test.describe('a Concept representing an Agent with Works and Images both about and by them', () => {
-  test('has both works and image sections grouped into "by" and "about" sections', async ({
+  // Temporarily skip test. See https://wellcome.slack.com/archives/C02ANCYL90E/p1778571606333069
+  test.skip('has both works and image sections grouped into "by" and "about" sections', async ({
     armyPage,
   }) => {
     // It has two tabs (works)
@@ -135,7 +136,8 @@ test.describe('a Concept representing an Agent with Works and Images both about 
 });
 
 test.describe('a Concept representing a Genre with works and images both about and using them', () => {
-  test('has both works and image sections, each with about and using tabs', async ({
+  // Temporarily skip test. See https://wellcome.slack.com/archives/C02ANCYL90E/p1778571606333069
+  test.skip('has both works and image sections, each with about and using tabs', async ({
     statisticsPage,
   }) => {
     const title = encodeURIComponent('"Statistics"');
@@ -178,7 +180,8 @@ test.describe('a Concept representing a Genre with works and images both about a
 });
 
 test.describe('a Concept representing a Genre that is only used as a genre for both works and images', () => {
-  test('has both works and image sections showing records in that genre', async ({
+  // Temporarily skip test. See https://wellcome.slack.com/archives/C02ANCYL90E/p1778571606333069
+  test.skip('has both works and image sections showing records in that genre', async ({
     mohPage,
   }) => {
     // Both images and works sections exist


### PR DESCRIPTION
- For [#6331](https://github.com/wellcomecollection/platform/issues/6331)

## What does this change?

Temporarily skip concept E2E tests while we're switching to a Python-populated images index. See https://wellcome.slack.com/archives/C02ANCYL90E/p1778571606333069 for more info.

Once the new index is in production, we will:
* Merge [this PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/13060) to populate image search pages based on displayLabel instead of label
* Merge [this PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/13058) to re-enable a modified version of the tests 

## How to test

Run the concept tests against the new index locally, verifying that they pass:
```
PLAYWRIGHT_BASE_URL=https://www-dev.wellcomecollection.org yarn test concept.test.ts
```

## Have we considered potential risks?

We know why the tests are failing and we're skipping them temporarily to unblock a production deployment. We used the same approach when we were switching to the Python-populated works index.