### PR TITLE
Dev ex: Change command line for typescript check

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy-dev": "yarn workspace @weco/deploy deploy-dev",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "lint:css": "stylelint \"**/*.{js,ts,tsx}\"",
-    "tsc": "yarn workspaces run tsc --noEmit --skipLibCheck"
+    "tsc": "tsc --build --verbose"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,25 @@
   "files": [],
   "references": [
     {
-      "path": "./identity/webapp"
-    },
-    {
-      "path": "./content/webapp"
+      "path": "./cardigan"
     },
     {
       "path": "./common"
     },
     {
+      "path": "./content/webapp"
+    },
+    {
       "path": "./deploy"
+    },
+    {
+      "path": "./identity/webapp"
+    },
+    {
+      "path": "./prismic-model"
+    },
+    {
+      "path": "./toggles/webapp"
     }
   ]
 }


### PR DESCRIPTION
## What does this change?

`yarn tsc` was taking ~98 seconds because it used `yarn workspaces run tsc --noEmit --skipLibCheck`, which spawned a separate `tsc` process in each of the 7 workspaces sequentially. Each process started a fresh compiler that couldn't share type information or incremental caches with the others. This was tedious, especially when testing package upgrades and needing to run it often.

If that was just a me problem I'm happy to let it go too, but I'd be curious to know how long it takes on `main` for youse as well.

This switches to `tsc --build --verbose`, which:

- Uses the project references already defined in the root `tsconfig.json` to check all workspaces in a single compiler invocation
- Leverages `.tsbuildinfo` incremental caches, so subsequent runs only recheck changed files
- Prints which project it's checking and how long each takes (`--verbose`)

The root `tsconfig.json` was also missing 3 workspaces (cardigan, prismic-model, toggles/webapp) — these have been added and the list alphabetised.

### Performance

| | Before | After (cold) | After (warm) |
|---|---|---|---|
| `yarn tsc` | ~98s | ~40s | ~1.5s |

The `--noEmit` and `--skipLibCheck` flags are no longer passed on the command line because they're already set in `config/tsconfig-base.json`, which all workspace tsconfigs extend.

## How to test

1. `yarn tsc` — should complete in a couple of seconds if the cache is warm, and print verbose output showing each project
2. Introduce a type error in any workspace and confirm it's reported
3. Verify all 7 workspaces are checked (cardigan, common, content/webapp, deploy, identity/webapp, prismic-model, toggles/webapp)

## Have we considered potential risks?

Low risk. `tsc --build` uses the same project references and tsconfig settings that were already in place. The only behavioural difference is that errors in shared projects (e.g. common/) will be reported once per dependent project, which is slightly noisier but functionally correct.

### What else uses `yarn tsc`?

- **CI (`tsc.yml`)** — The `(Workspaces) yarn tsc` step will pick up this change and be faster. No action needed.
- **Playwright and Dash** — CI checks these separately (`cd playwright && yarn tsc`, `cd dash/webapp && yarn tsc`). They have their own package.json scripts and are unaffected. They weren't in the root tsconfig references before and still aren't.
- **`cache/edge_lambdas`** — Has its own `"tsc": "tsc --noEmit --skipLibCheck"` script. Not part of the root workspaces, unaffected.
- **Git hooks** — Don't run tsc, unaffected.
