### PR TITLE
Dev ex: Use a helper to build readable URLs in tests

### DIFF
--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { apiToolbarPage } from './helpers/contexts';
+import { urlWithParams } from './helpers/utils';
 
 test('(1) | Does not create a tzitzit link for images in copyright', async ({
   page,
@@ -28,7 +29,15 @@ test('(2) | Creates a tzitzit link for item pages', async ({
   const url = await anchor.getAttribute('href');
 
   expect(url).toBe(
-    'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fitems&author=Bryan+Charnley'
+    urlWithParams(
+      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html',
+      {
+        title: 'Fish schizophrene.',
+        sourceName: 'Wellcome Collection',
+        sourceLink: 'https://wellcomecollection.org/works/ccg335hm/items',
+        author: 'Bryan Charnley',
+      }
+    )
   );
 });
 
@@ -44,6 +53,16 @@ test('(3) | Creates a tzitzit link for image pages', async ({
   const url = await anchor.getAttribute('href');
 
   expect(url).toBe(
-    'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?title=Fish+schizophrene.&sourceName=Wellcome+Collection&sourceLink=https%3A%2F%2Fwellcomecollection.org%2Fworks%2Fccg335hm%2Fimages%3Fid%3Dsrfsqn7t&licence=CC-BY-NC&author=Bryan+Charnley'
+    urlWithParams(
+      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html',
+      {
+        title: 'Fish schizophrene.',
+        sourceName: 'Wellcome Collection',
+        sourceLink:
+          'https://wellcomecollection.org/works/ccg335hm/images?id=srfsqn7t',
+        licence: 'CC-BY-NC',
+        author: 'Bryan Charnley',
+      }
+    )
   );
 });

--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import { apiToolbarPage } from './helpers/contexts';
+import { urlWithParams } from './helpers/utils';
 
 test('(1) | Does not create a tzitzit link for images in copyright', async ({
   page,
@@ -27,15 +28,16 @@ test('(2) | Creates a tzitzit link for item pages', async ({
 
   const url = await anchor.getAttribute('href');
 
-  const expectedParams = new URLSearchParams({
-    title: 'Fish schizophrene.',
-    sourceName: 'Wellcome Collection',
-    sourceLink: 'https://wellcomecollection.org/works/ccg335hm/items',
-    author: 'Bryan Charnley',
-  });
-
   expect(url).toBe(
-    `https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?${expectedParams}`
+    urlWithParams(
+      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html',
+      {
+        title: 'Fish schizophrene.',
+        sourceName: 'Wellcome Collection',
+        sourceLink: 'https://wellcomecollection.org/works/ccg335hm/items',
+        author: 'Bryan Charnley',
+      }
+    )
   );
 });
 
@@ -50,16 +52,17 @@ test('(3) | Creates a tzitzit link for image pages', async ({
 
   const url = await anchor.getAttribute('href');
 
-  const expectedParams = new URLSearchParams({
-    title: 'Fish schizophrene.',
-    sourceName: 'Wellcome Collection',
-    sourceLink:
-      'https://wellcomecollection.org/works/ccg335hm/images?id=srfsqn7t',
-    licence: 'CC-BY-NC',
-    author: 'Bryan Charnley',
-  });
-
   expect(url).toBe(
-    `https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?${expectedParams}`
+    urlWithParams(
+      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html',
+      {
+        title: 'Fish schizophrene.',
+        sourceName: 'Wellcome Collection',
+        sourceLink:
+          'https://wellcomecollection.org/works/ccg335hm/images?id=srfsqn7t',
+        licence: 'CC-BY-NC',
+        author: 'Bryan Charnley',
+      }
+    )
   );
 });

--- a/playwright/test/api-toolbar.test.ts
+++ b/playwright/test/api-toolbar.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from '@playwright/test';
 
 import { apiToolbarPage } from './helpers/contexts';
-import { urlWithParams } from './helpers/utils';
 
 test('(1) | Does not create a tzitzit link for images in copyright', async ({
   page,
@@ -28,16 +27,15 @@ test('(2) | Creates a tzitzit link for item pages', async ({
 
   const url = await anchor.getAttribute('href');
 
+  const expectedParams = new URLSearchParams({
+    title: 'Fish schizophrene.',
+    sourceName: 'Wellcome Collection',
+    sourceLink: 'https://wellcomecollection.org/works/ccg335hm/items',
+    author: 'Bryan Charnley',
+  });
+
   expect(url).toBe(
-    urlWithParams(
-      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html',
-      {
-        title: 'Fish schizophrene.',
-        sourceName: 'Wellcome Collection',
-        sourceLink: 'https://wellcomecollection.org/works/ccg335hm/items',
-        author: 'Bryan Charnley',
-      }
-    )
+    `https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?${expectedParams}`
   );
 });
 
@@ -52,17 +50,16 @@ test('(3) | Creates a tzitzit link for image pages', async ({
 
   const url = await anchor.getAttribute('href');
 
+  const expectedParams = new URLSearchParams({
+    title: 'Fish schizophrene.',
+    sourceName: 'Wellcome Collection',
+    sourceLink:
+      'https://wellcomecollection.org/works/ccg335hm/images?id=srfsqn7t',
+    licence: 'CC-BY-NC',
+    author: 'Bryan Charnley',
+  });
+
   expect(url).toBe(
-    urlWithParams(
-      'https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html',
-      {
-        title: 'Fish schizophrene.',
-        sourceName: 'Wellcome Collection',
-        sourceLink:
-          'https://wellcomecollection.org/works/ccg335hm/images?id=srfsqn7t',
-        licence: 'CC-BY-NC',
-        author: 'Bryan Charnley',
-      }
-    )
+    `https://s3-eu-west-1.amazonaws.com/tzitzit.wellcomecollection.org/index.html?${expectedParams}`
   );
 });

--- a/playwright/test/concept.test.ts
+++ b/playwright/test/concept.test.ts
@@ -1,6 +1,7 @@
 import { test as base, expect } from '@playwright/test';
 
 import { concept } from './helpers/contexts';
+import { urlWithParams } from './helpers/utils';
 import { ConceptPage } from './pages/concept';
 
 const test = base.extend<{
@@ -112,24 +113,32 @@ test.describe('a Concept representing an Agent with Works and Images both about 
     await armyPage.worksAboutTab.click();
     await expect(armyPage.allWorksLink).toHaveAttribute(
       'href',
-      '/search/works?subjects.label=%22British+Army%22'
+      urlWithParams('/search/works', {
+        'subjects.label': '"British Army"',
+      })
     );
 
     await armyPage.worksByTab.click();
     await expect(armyPage.allWorksLink).toHaveAttribute(
       'href',
-      '/search/works?contributors.agent.label=%22British+Army%22'
+      urlWithParams('/search/works', {
+        'contributors.agent.label': '"British Army"',
+      })
     );
 
     // It has links to all images by
     await expect(armyPage.allImagesByLink).toHaveAttribute(
       'href',
-      '/search/images?source.contributors.agent.label=%22British+Army%22'
+      urlWithParams('/search/images', {
+        'source.contributors.agent.label': '"British Army"',
+      })
     );
     // ...and images about
     await expect(armyPage.allImagesAboutLink).toHaveAttribute(
       'href',
-      '/search/images?source.subjects.label=%22British+Army%22'
+      urlWithParams('/search/images', {
+        'source.subjects.label': '"British Army"',
+      })
     );
   });
 });
@@ -189,15 +198,19 @@ test.describe('a Concept representing a Genre that is only used as a genre for b
     await expect(mohPage.worksAboutTab).not.toBeVisible();
     await expect(mohPage.worksInTab).not.toBeVisible();
 
-    // It has links to filtered searches, (not using encodeURIComponent because the genre includes '+'")
+    // It has links to filtered searches
     await expect(mohPage.allWorksLink).toHaveAttribute(
       'href',
-      `/search/works?genres.label=%22Medical+Officer+of+Health+%28MOH%29+reports%22`
+      urlWithParams('/search/works', {
+        'genres.label': '"Medical Officer of Health (MOH) reports"',
+      })
     );
 
     await expect(mohPage.allImagesInLink).toHaveAttribute(
       'href',
-      `/search/images?source.genres.label=%22Medical+Officer+of+Health+%28MOH%29+reports%22`
+      urlWithParams('/search/images', {
+        'source.genres.label': '"Medical Officer of Health (MOH) reports"',
+      })
     );
   });
 });

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -23,5 +23,7 @@ export function urlWithParams(
   params: Record<string, string>
 ): string {
   const query = new URLSearchParams(params).toString();
-  return `${path}?${query}`;
+  if (!query) return path;
+  const separator = path.includes('?') ? '&' : '?';
+  return `${path}${separator}${query}`;
 }

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -17,16 +17,23 @@ export const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
 
 /** Build a URL with properly encoded query params from readable values.
  *
+ *  By default, encodes spaces as + (matching URLSearchParams / href attributes).
+ *  Pass browserUrl: true to encode spaces as %20 (matching browser URL bar).
+ *
  *  e.g. urlWithParams('/search/works', { query: 'art of science' })
+ *  → '/search/works?query=art+of+science'
+ *
+ *  e.g. urlWithParams('/search/works', { query: 'art of science' }, { browserUrl: true })
  *  → '/search/works?query=art%20of%20science'
  */
 export function urlWithParams(
   path: string,
-  params: Record<string, string>
+  params: Record<string, string>,
+  { browserUrl = false }: { browserUrl?: boolean } = {}
 ): string {
-  // URLSearchParams encodes spaces as +, but browsers display %20 in the URL bar
-  const query = new URLSearchParams(params).toString().replaceAll('+', '%20');
+  let query = new URLSearchParams(params).toString();
   if (!query) return path;
+  if (browserUrl) query = query.replaceAll('+', '%20');
   const separator = path.includes('?') ? '&' : '?';
   return `${path}${separator}${query}`;
 }

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -12,3 +12,16 @@ export const useStageApis = process.env.USE_STAGE_APIS
 export const slowExpect = expect.configure({ timeout: 10000 });
 
 export const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
+
+/** Build a URL with properly encoded query params from readable values.
+ *
+ *  e.g. urlWithParams('/search/works', { 'subjects.label': '"British Army"' })
+ *  → '/search/works?subjects.label=%22British+Army%22'
+ */
+export function urlWithParams(
+  path: string,
+  params: Record<string, string>
+): string {
+  const query = new URLSearchParams(params).toString();
+  return `${path}?${query}`;
+}

--- a/playwright/test/helpers/utils.ts
+++ b/playwright/test/helpers/utils.ts
@@ -1,8 +1,10 @@
 import { expect } from 'playwright/test';
 
-export const baseUrl = process.env.PLAYWRIGHT_BASE_URL
-  ? process.env.PLAYWRIGHT_BASE_URL
-  : 'http://localhost:3000';
+export const baseUrl = (
+  process.env.PLAYWRIGHT_BASE_URL
+    ? process.env.PLAYWRIGHT_BASE_URL
+    : 'http://localhost:3000'
+).replace(/\/$/, '');
 export const useStageApis = process.env.USE_STAGE_APIS
   ? process.env.USE_STAGE_APIS && process.env.USE_STAGE_APIS === 'true'
   : false;
@@ -15,14 +17,15 @@ export const ItemViewerURLRegex = /\/works\/[a-zA-Z0-9]+\/images[?]id=/;
 
 /** Build a URL with properly encoded query params from readable values.
  *
- *  e.g. urlWithParams('/search/works', { 'subjects.label': '"British Army"' })
- *  → '/search/works?subjects.label=%22British+Army%22'
+ *  e.g. urlWithParams('/search/works', { query: 'art of science' })
+ *  → '/search/works?query=art%20of%20science'
  */
 export function urlWithParams(
   path: string,
   params: Record<string, string>
 ): string {
-  const query = new URLSearchParams(params).toString();
+  // URLSearchParams encodes spaces as +, but browsers display %20 in the URL bar
+  const query = new URLSearchParams(params).toString().replaceAll('+', '%20');
   if (!query) return path;
   const separator = path.includes('?') ? '&' : '?';
   return `${path}${separator}${query}`;

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -25,7 +25,7 @@ test('(1) | The users changes tabs; the query (but not the filters) should be ma
   ).toBeVisible();
   await page.getByRole('link', { name: 'Catalogue' }).click();
   await slowExpect(page).toHaveURL(
-    `${baseUrl}${urlWithParams('/search/works', { query: 'art of science' })}`
+    `${baseUrl}${urlWithParams('/search/works', { query: 'art of science' }, { browserUrl: true })}`
   );
 });
 

--- a/playwright/test/search.test.ts
+++ b/playwright/test/search.test.ts
@@ -9,7 +9,7 @@ import {
   selectAndWaitForFilter,
   testIfFilterIsApplied,
 } from './helpers/search';
-import { baseUrl, slowExpect } from './helpers/utils';
+import { baseUrl, slowExpect, urlWithParams } from './helpers/utils';
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -25,7 +25,7 @@ test('(1) | The users changes tabs; the query (but not the filters) should be ma
   ).toBeVisible();
   await page.getByRole('link', { name: 'Catalogue' }).click();
   await slowExpect(page).toHaveURL(
-    `${baseUrl}/search/works?query=art%20of%20science`
+    `${baseUrl}${urlWithParams('/search/works', { query: 'art of science' })}`
   );
 });
 

--- a/playwright/yarn.lock
+++ b/playwright/yarn.lock
@@ -139,10 +139,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node24/-/node24-24.0.4.tgz#ae50cc6b3288c1010454f0ec4659b47b520ca1b1"
   integrity sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==
 
-"@types/node@^24.0.0":
-  version "24.12.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.0.tgz#6222e028210e5322e4f4f6767f8d88e5ea3b33d2"
-  integrity sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==
+"@types/node@^24.10.0":
+  version "24.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
+  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
   dependencies:
     undici-types "~7.16.0"
 


### PR DESCRIPTION
Based on a Copilot review comment: https://github.com/wellcomecollection/wellcomecollection.org/pull/13058#discussion_r3225899497

## What does this change?

We created a helper to build out URLs in a much more readable way for our tests. I thought it was a great idea, don't know about you but I find this MUCH easier to read and potentially debug.


## How to test

Do e2es pass?


## Have we considered potential risks?
N/A