### PR TITLE
In gallery PoC

### DIFF
--- a/common/server-data/__mocks__/index.ts
+++ b/common/server-data/__mocks__/index.ts
@@ -1,5 +1,8 @@
 import { CollectionVenueDocument as RawCollectionVenueDocument } from '@weco/common/prismicio-types';
-import { ServerData } from '@weco/common/server-data/types';
+import {
+  defaultExhibitionExtras,
+  ServerData,
+} from '@weco/common/server-data/types';
 import {
   emptyGlobalAlert,
   emptyPopupDialog,
@@ -27,5 +30,6 @@ export async function getServerData(): Promise<ServerData> {
       marketing: false,
       cookieExists: false,
     },
+    exhibitionExtras: defaultExhibitionExtras,
   };
 }

--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -22,7 +22,7 @@ import { simplifyServerData } from '@weco/common/services/prismic/transformers/s
 
 import prismicHandler from './prismic';
 import togglesHandler, { getTogglesFromContext } from './toggles';
-import { SimplifiedServerData } from './types';
+import { defaultExhibitionExtras, SimplifiedServerData } from './types';
 
 export type Handler<DefaultData, FetchedData> = {
   defaultValue: DefaultData;
@@ -137,7 +137,12 @@ export const getServerData = async (
 
   const consentStatus = getAllConsentStates(context);
 
-  const serverData = { toggles, prismic, consentStatus };
+  const serverData = {
+    toggles,
+    prismic,
+    consentStatus,
+    exhibitionExtras: defaultExhibitionExtras,
+  };
 
   return simplifyServerData(serverData);
 };

--- a/common/server-data/types.ts
+++ b/common/server-data/types.ts
@@ -14,18 +14,81 @@ export type ServerData = {
   toggles: Toggles;
   prismic: PrismicData;
   consentStatus: ConsentStatusProps;
+  exhibitionExtras: Record<string, GalleryExhibitionData>;
 };
 
 export type SimplifiedServerData = {
   toggles: Toggles;
   prismic: SimplifiedPrismicData;
   consentStatus: ConsentStatusProps;
+  exhibitionExtras: Record<string, GalleryExhibitionData>;
 };
 
 export type ConsentStatusProps = {
   analytics: boolean;
   marketing: boolean;
   cookieExists: boolean;
+};
+
+export type GalleryExhibitionData = {
+  title: string;
+  url: string;
+  works: string[];
+  collectionClusters: { title: string; url: string }[];
+  stories: string[];
+};
+
+export type GalleryData = {
+  exhibitions: Record<string, GalleryExhibitionData>;
+};
+
+export const defaultExhibitionExtras: Record<string, GalleryExhibitionData> = {
+  'tenderness-and-rage': {
+    title: 'Tenderness and Rage',
+    url: '/exhibitions/tenderness-and-rage',
+    works: [
+      'eudv2vbg', // AZT on trial
+      'zeu8jvyg', // Retrovir packaging (NO IMAGE)
+      'hg2f7gth', // Wellcome AGM photo (NO IMAGE)
+      'jzshasa6', // Landmark poster
+      'p6sw94qt', // 'The Ward' photographs - John
+      'unwb3yh8', // 'The Ward' photographs - Ian
+      'vc57ua8p', // 'The Ward' photographs - Andre
+      'zxyeupbh', // Strutting to Stop Stigma (NO IMAGE)
+    ],
+    collectionClusters: [
+      {
+        title: 'What Would An HIV Doula Do (WWHIVDD), digital zines',
+        url: '/search/works?query=WWHIVDD',
+      },
+      {
+        title: 'HIV infections – Prevention',
+        url: '/concepts/jk93pkmw',
+      },
+      {
+        title: 'HIV Africa material',
+        url: '/search/images?query=HIV+africa',
+      },
+      {
+        title: 'Jordan Eagles, Blood Mirror',
+        url: '/search/works?query=Jordan+Eagles',
+      },
+      { title: 'ACT UP online material', url: '/concepts/kgrkehja' },
+      { title: 'World AIDS Day', url: '/concepts/z9pu3ktm' },
+      { title: 'Community centers', url: '/concepts/g2zph654' },
+      { title: 'HIV Seropositivity', url: '/concepts/j8ccram4' },
+      { title: 'The Ward Revisited (Film)', url: '/works/gr36peg6' },
+    ],
+    stories: [
+      'telling-scotland-about-aids',
+      'in-the-tracks-of-derek-jarman-s-tears',
+      'guerrilla-public-health',
+      'artists--activism-and-aids',
+      'aids-posters',
+      'what-are-zines-doing-in-a-museum',
+      'how-to-design-an-hiv-awareness-campaign',
+    ],
+  },
 };
 
 export const defaultServerData: SimplifiedServerData = {
@@ -36,6 +99,7 @@ export const defaultServerData: SimplifiedServerData = {
     marketing: false,
     cookieExists: false,
   },
+  exhibitionExtras: defaultExhibitionExtras,
 };
 
 /**

--- a/common/views/components/Caption/index.tsx
+++ b/common/views/components/Caption/index.tsx
@@ -2,8 +2,9 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createDefaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -47,6 +48,9 @@ const Caption: FunctionComponent<Props> = ({
   preCaptionNode,
   width,
 }: Props) => {
+  const { inGallery = false } = useToggles();
+  const htmlSerializer = createDefaultSerializer(inGallery);
+
   return (
     // In order to be valid html, a figcaption should appear as the first or
     // last element in a figure. We have previously made this happen
@@ -60,10 +64,7 @@ const Caption: FunctionComponent<Props> = ({
         <CaptionWrapper>
           {preCaptionNode}
           <CaptionText>
-            <PrismicHtmlBlock
-              html={caption}
-              htmlSerializer={defaultSerializer}
-            />
+            <PrismicHtmlBlock html={caption} htmlSerializer={htmlSerializer} />
           </CaptionText>
         </CaptionWrapper>
       </figcaption>

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { Venue } from '@weco/common/model/opening-hours';
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider';
 import FindUs from '@weco/common/views/components/FindUs';
@@ -14,7 +15,6 @@ import FooterA11y from './Footer.A11y';
 import FooterNav from './Footer.Nav';
 import FooterSocial from './Footer.Social';
 import FooterWellcomeLogo from './Footer.WellcomeLogo';
-
 type Props = {
   venues: Venue[];
 };
@@ -177,6 +177,7 @@ const BackToTopButton = styled.button.attrs({
 // Component
 const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
   const footer = useRef<HTMLDivElement>(null);
+  const { inGallery = false } = useToggles();
 
   const hasVenuesInfo = Array.isArray(venues) && venues.length > 0;
 
@@ -187,64 +188,67 @@ const Footer: FunctionComponent<Props> = ({ venues }: Props) => {
           <FooterWellcomeLogo />
         </h3>
 
-        <FooterNavigationContainer>
-          <FindUsContainer>
-            <FindUs hideAccessibility={true} />
-          </FindUsContainer>
+        {!inGallery && (
+          <>
+            <FooterNavigationContainer>
+              <FindUsContainer>
+                <FindUs hideAccessibility={true} />
+              </FindUsContainer>
 
-          <OpeningTimesContainer>
-            {/* Error pages do not receive serverData so should only display
+              <OpeningTimesContainer>
+                {/* Error pages do not receive serverData so should only display
             openingtimes link */}
-            {hasVenuesInfo && (
-              <>
-                <h4 className={font('sans-bold', -1)}>
-                  Today&rsquo;s opening times
-                </h4>
-                <OpeningTimes venues={venues} />
-              </>
-            )}
-            <Space
-              as="p"
-              $v={{
-                size: 'sm',
-                properties: hasVenuesInfo ? ['margin-top'] : [],
-              }}
-              style={{ marginBottom: 0 }}
-            >
-              <a href={`/visit-us/${prismicPageIds.openingTimes}`}>
-                Opening times
-              </a>
-            </Space>
-          </OpeningTimesContainer>
+                {hasVenuesInfo && (
+                  <>
+                    <h4 className={font('sans-bold', -1)}>
+                      Today&rsquo;s opening times
+                    </h4>
+                    <OpeningTimes venues={venues} />
+                  </>
+                )}
+                <Space
+                  as="p"
+                  $v={{
+                    size: 'sm',
+                    properties: hasVenuesInfo ? ['margin-top'] : [],
+                  }}
+                  style={{ marginBottom: 0 }}
+                >
+                  <a href={`/visit-us/${prismicPageIds.openingTimes}`}>
+                    Opening times
+                  </a>
+                </Space>
+              </OpeningTimesContainer>
 
-          <FooterA11y />
+              <FooterA11y />
 
-          <InternalNavigationContainer>
-            <FooterNav
-              type="InternalNavigation"
-              ariaLabel="Useful internal links"
-            />
-          </InternalNavigationContainer>
-        </FooterNavigationContainer>
+              <InternalNavigationContainer>
+                <FooterNav
+                  type="InternalNavigation"
+                  ariaLabel="Useful internal links"
+                />
+              </InternalNavigationContainer>
+            </FooterNavigationContainer>
 
-        <FullWidthDivider>
-          <Divider lineColor="neutral.700" />
-        </FullWidthDivider>
+            <FullWidthDivider>
+              <Divider lineColor="neutral.700" />
+            </FullWidthDivider>
 
-        <PoliciesAndSocials>
-          <PoliciesContainer>
-            <FooterNav
-              isInline
-              type="PoliciesNavigation"
-              ariaLabel="Policies navigation"
-            />
-          </PoliciesContainer>
+            <PoliciesAndSocials>
+              <PoliciesContainer>
+                <FooterNav
+                  isInline
+                  type="PoliciesNavigation"
+                  ariaLabel="Policies navigation"
+                />
+              </PoliciesContainer>
 
-          <SocialsContainer>
-            <FooterSocial />
-          </SocialsContainer>
-        </PoliciesAndSocials>
-
+              <SocialsContainer>
+                <FooterSocial />
+              </SocialsContainer>
+            </PoliciesAndSocials>
+          </>
+        )}
         <FooterBottom>
           <FooterLicense>
             Except where otherwise noted, content on this site is licensed under

--- a/common/views/components/GalleryInactivityRedirect/GalleryInactivityRedirect.styles.tsx
+++ b/common/views/components/GalleryInactivityRedirect/GalleryInactivityRedirect.styles.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const RedirectModalContent = styled.div`
+  padding: 24px;
+  text-align: center;
+
+  p {
+    margin: 16px 0;
+    font-size: 18px;
+    line-height: 1.5;
+  }
+`;
+
+export const RedirectModalTitle = styled.h2`
+  font-size: 32px;
+  font-weight: bold;
+  margin: 0 0 24px;
+`;
+
+export const CountdownText = styled.strong`
+  font-size: 24px;
+  font-weight: bold;
+`;

--- a/common/views/components/GalleryInactivityRedirect/index.tsx
+++ b/common/views/components/GalleryInactivityRedirect/index.tsx
@@ -1,0 +1,281 @@
+import { useRouter } from 'next/router';
+import {
+  FunctionComponent,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  ServerDataContext,
+  useToggles,
+} from '@weco/common/server-data/Context';
+import { GalleryExhibitionData } from '@weco/common/server-data/types';
+import Modal from '@weco/common/views/components/Modal';
+
+import {
+  CountdownText,
+  RedirectModalContent,
+  RedirectModalTitle,
+} from './GalleryInactivityRedirect.styles';
+
+const INACTIVITY_TIMEOUT = 1 * 60 * 1000; // 10 minutes in milliseconds
+const WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
+
+function findExhibitionIdFromUrl(
+  currentUrl: string,
+  exhibitionExtras: Record<string, GalleryExhibitionData>
+): string | null {
+  const normalizeUrl = (url: string) => {
+    try {
+      const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
+      return decoded.replace(/\/$/, '').toLowerCase();
+    } catch {
+      return url.replace(/\+/g, ' ').replace(/\/$/, '').toLowerCase();
+    }
+  };
+
+  const normalizedCurrentUrl = normalizeUrl(currentUrl);
+
+  for (const [exhibitionId, exhibition] of Object.entries(exhibitionExtras)) {
+    // Check stories
+    const hasStory = exhibition.stories.some(
+      storyId =>
+        normalizeUrl(`/stories/${storyId}`) === normalizedCurrentUrl ||
+        normalizedCurrentUrl.includes(storyId)
+    );
+    if (hasStory) return exhibitionId;
+
+    // Check works
+    const hasWork = exhibition.works.some(
+      workId =>
+        normalizeUrl(`/works/${workId}`) === normalizedCurrentUrl ||
+        normalizedCurrentUrl.includes(workId)
+    );
+    if (hasWork) return exhibitionId;
+
+    // Check collection clusters
+    const hasCluster = exhibition.collectionClusters.some(cluster => {
+      const normalizedClusterUrl = normalizeUrl(cluster.url);
+      return (
+        normalizedClusterUrl === normalizedCurrentUrl ||
+        normalizedClusterUrl.includes(normalizedCurrentUrl) ||
+        normalizedCurrentUrl.includes(normalizedClusterUrl)
+      );
+    });
+    if (hasCluster) return exhibitionId;
+  }
+  return null;
+}
+
+const GalleryInactivityRedirect: FunctionComponent = () => {
+  const { inGallery = false } = useToggles();
+  const serverData = useContext(ServerDataContext);
+  const router = useRouter();
+  const [isWarningActive, setIsWarningActive] = useState(false);
+  const [countdown, setCountdown] = useState(WARNING_COUNTDOWN);
+  const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const countdownTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const redirectTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const modalButtonRef = useRef<HTMLElement | null>(null);
+
+  // Determine which exhibition we're viewing
+  const currentExhibitionId = findExhibitionIdFromUrl(
+    router.asPath,
+    serverData.exhibitionExtras
+  );
+
+  // Don't run on the extras page (the redirect destination)
+  const isExtrasPage = router.pathname.includes('/extras');
+
+  const performRedirect = useCallback(() => {
+    // Close the modal before redirecting
+    setIsWarningActive(false);
+    if (currentExhibitionId) {
+      router.push(`/exhibitions/${currentExhibitionId}/extras`);
+    } else {
+      // Fallback to stories page if we can't determine the exhibition
+      router.push('/stories');
+    }
+  }, [router, currentExhibitionId]);
+
+  const resetInactivityTimer = useCallback(() => {
+    // Clear existing timer
+    if (inactivityTimerRef.current) {
+      clearTimeout(inactivityTimerRef.current);
+    }
+
+    // Don't start a new timer if we're already showing the warning
+    if (isWarningActive) return;
+
+    // Start a new inactivity timer
+    inactivityTimerRef.current = setTimeout(() => {
+      setIsWarningActive(true);
+      setCountdown(WARNING_COUNTDOWN);
+    }, INACTIVITY_TIMEOUT);
+  }, [isWarningActive]);
+
+  const handleCancelRedirect = useCallback(() => {
+    setIsWarningActive(false);
+    setCountdown(WARNING_COUNTDOWN);
+
+    // Clear countdown and redirect timers
+    if (countdownTimerRef.current) {
+      clearInterval(countdownTimerRef.current);
+      countdownTimerRef.current = null;
+    }
+    if (redirectTimerRef.current) {
+      clearTimeout(redirectTimerRef.current);
+      redirectTimerRef.current = null;
+    }
+
+    // Restart inactivity tracking
+    resetInactivityTimer();
+  }, [resetInactivityTimer]);
+
+  const handleUserActivity = useCallback(() => {
+    if (isWarningActive) {
+      // If warning is showing, cancel the redirect
+      handleCancelRedirect();
+    } else {
+      // Otherwise, just reset the inactivity timer
+      resetInactivityTimer();
+    }
+  }, [isWarningActive, handleCancelRedirect, resetInactivityTimer]);
+
+  // Effect to clean up modal state when route changes
+  useEffect(() => {
+    const handleRouteChange = () => {
+      setIsWarningActive(false);
+      setCountdown(WARNING_COUNTDOWN);
+
+      if (countdownTimerRef.current) {
+        clearInterval(countdownTimerRef.current);
+        countdownTimerRef.current = null;
+      }
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+        redirectTimerRef.current = null;
+      }
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+        inactivityTimerRef.current = null;
+      }
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router]);
+
+  // Effect to handle countdown and redirect when warning is active
+  useEffect(() => {
+    if (isWarningActive) {
+      // Start countdown
+      countdownTimerRef.current = setInterval(() => {
+        setCountdown(prev => {
+          if (prev <= 1) {
+            if (countdownTimerRef.current) {
+              clearInterval(countdownTimerRef.current);
+            }
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      // Set redirect timer
+      redirectTimerRef.current = setTimeout(() => {
+        performRedirect();
+      }, WARNING_COUNTDOWN * 1000);
+
+      return () => {
+        if (countdownTimerRef.current) {
+          clearInterval(countdownTimerRef.current);
+        }
+        if (redirectTimerRef.current) {
+          clearTimeout(redirectTimerRef.current);
+        }
+      };
+    }
+  }, [isWarningActive, performRedirect]);
+
+  // Effect to set up activity listeners
+  useEffect(() => {
+    // Don't run if not in gallery mode or if on the extras page
+    if (!inGallery || isExtrasPage) return;
+
+    // List of events that indicate user activity
+    const events = [
+      'mousedown',
+      'mousemove',
+      'keydown',
+      'scroll',
+      'touchstart',
+      'click',
+    ];
+
+    // Add event listeners
+    events.forEach(event => {
+      window.addEventListener(event, handleUserActivity, { passive: true });
+    });
+
+    // Start initial timer
+    resetInactivityTimer();
+
+    // Cleanup
+    return () => {
+      events.forEach(event => {
+        window.removeEventListener(event, handleUserActivity);
+      });
+
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+      if (countdownTimerRef.current) {
+        clearInterval(countdownTimerRef.current);
+      }
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+    };
+  }, [
+    inGallery,
+    isWarningActive,
+    isExtrasPage,
+    handleUserActivity,
+    resetInactivityTimer,
+  ]);
+
+  // Don't render anything if not in gallery mode or on the extras page
+  if (!inGallery || isExtrasPage) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isActive={isWarningActive}
+      setIsActive={handleCancelRedirect}
+      id="gallery-inactivity-warning"
+      dataTestId="gallery-inactivity-warning"
+      openButtonRef={modalButtonRef}
+      showOverlay={true}
+    >
+      <RedirectModalContent data-component="gallery-inactivity-redirect">
+        <RedirectModalTitle>Are you still there?</RedirectModalTitle>
+        <p>
+          Due to inactivity, you will be redirected to the extras page in{' '}
+          <CountdownText>{countdown}</CountdownText> second
+          {countdown !== 1 ? 's' : ''}.
+        </p>
+        <p>Move your mouse or tap the screen to stay on this page.</p>
+      </RedirectModalContent>
+    </Modal>
+  );
+};
+
+export default GalleryInactivityRedirect;

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -232,37 +232,39 @@ const getFirstStringChild = (node: unknown): string | undefined => {
   return undefined;
 };
 
-export const dropCapSerializer: JSXFunctionSerializer = (
-  type,
-  element,
-  content,
-  children,
-  key
-) => {
-  if (
-    type === prismic.RichTextNodeType.paragraph &&
-    children[0] !== undefined
-  ) {
-    const firstChild = children[0];
-    const firstCharacters = getFirstStringChild(firstChild);
+export const createDropCapSerializer = (
+  inGallery = false
+): JSXFunctionSerializer => {
+  const fallbackSerializer = createDefaultSerializer(inGallery);
 
-    if (!firstCharacters) {
-      return <p key={key}>{children}</p>;
+  return (type, element, content, children, key) => {
+    if (
+      type === prismic.RichTextNodeType.paragraph &&
+      children[0] !== undefined
+    ) {
+      const firstChild = children[0];
+      const firstCharacters = getFirstStringChild(firstChild);
+
+      if (!firstCharacters) {
+        return <p key={key}>{children}</p>;
+      }
+
+      const firstLetter = firstCharacters.charAt(0);
+      const cappedFirstLetter = (
+        <span key={key} className="drop-cap">
+          {firstLetter}
+        </span>
+      );
+      const newfirstCharacters = [cappedFirstLetter, firstCharacters.slice(1)];
+      const childrenWithDropCap = [newfirstCharacters, ...children.slice(1)];
+
+      return <p key={key}>{childrenWithDropCap}</p>;
     }
-
-    const firstLetter = firstCharacters.charAt(0);
-    const cappedFirstLetter = (
-      <span key={key} className="drop-cap">
-        {firstLetter}
-      </span>
-    );
-    const newfirstCharacters = [cappedFirstLetter, firstCharacters.slice(1)];
-    const childrenWithDropCap = [newfirstCharacters, ...children.slice(1)];
-
-    return <p key={key}>{childrenWithDropCap}</p>;
-  }
-  return defaultSerializer(type, element, content, children, key);
+    return fallbackSerializer(type, element, content, children, key);
+  };
 };
+
+export const dropCapSerializer = createDropCapSerializer(false);
 
 const ACCESSIBILITY_ICON_MAP: Record<string, IconSvg> = {
   bsl: bslSquare,
@@ -271,49 +273,53 @@ const ACCESSIBILITY_ICON_MAP: Record<string, IconSvg> = {
   'induction loops': inductionLoop,
 };
 
-export const accessibilitySerializer: JSXFunctionSerializer = (
-  type,
-  element,
-  content,
-  children,
-  key
-) => {
-  let icon: IconSvg | null = null;
-  const isH1 = element.type === prismic.RichTextNodeType.heading1;
-  const isH2 = element.type === prismic.RichTextNodeType.heading2;
-  const isH3 = element.type === prismic.RichTextNodeType.heading3;
+export const createAccessibilitySerializer = (
+  inGallery = false
+): JSXFunctionSerializer => {
+  const fallbackSerializer = createDefaultSerializer(inGallery);
 
-  // Only check text for heading elements
-  if (isH1 || isH2 || isH3) {
-    const text = element.text || '';
-    const lowerText = text.toLowerCase();
-    icon = ACCESSIBILITY_ICON_MAP[lowerText] || null;
+  return (type, element, content, children, key) => {
+    let icon: IconSvg | null = null;
+    const isH1 = element.type === prismic.RichTextNodeType.heading1;
+    const isH2 = element.type === prismic.RichTextNodeType.heading2;
+    const isH3 = element.type === prismic.RichTextNodeType.heading3;
 
-    const HeadingTag = isH1 ? 'h1' : isH2 ? 'h2' : 'h3';
-    const headingProps = isH1 ? { key } : { key, id: dasherize(element.text) };
+    // Only check text for heading elements
+    if (isH1 || isH2 || isH3) {
+      const text = element.text || '';
+      const lowerText = text.toLowerCase();
+      icon = ACCESSIBILITY_ICON_MAP[lowerText] || null;
 
-    return (
-      <HeadingTag {...headingProps}>
-        <ConditionalWrapper
-          condition={!!icon}
-          wrapper={children => (
-            <span
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: '8px',
-              }}
-            >
-              <Icon icon={icon!} sizeOverride="width: 32px; height: 32px;" />
-              <span>{children}</span>
-            </span>
-          )}
-        >
-          {children}
-        </ConditionalWrapper>
-      </HeadingTag>
-    );
-  }
+      const HeadingTag = isH1 ? 'h1' : isH2 ? 'h2' : 'h3';
+      const headingProps = isH1
+        ? { key }
+        : { key, id: dasherize(element.text) };
 
-  return defaultSerializer(type, element, content, children, key);
+      return (
+        <HeadingTag {...headingProps}>
+          <ConditionalWrapper
+            condition={!!icon}
+            wrapper={children => (
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                }}
+              >
+                <Icon icon={icon!} sizeOverride="width: 32px; height: 32px;" />
+                <span>{children}</span>
+              </span>
+            )}
+          >
+            {children}
+          </ConditionalWrapper>
+        </HeadingTag>
+      );
+    }
+
+    return fallbackSerializer(type, element, content, children, key);
+  };
 };
+
+export const accessibilitySerializer = createAccessibilitySerializer(false);

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -23,184 +23,195 @@ const DocumentType = styled.span`
   color: ${props => props.theme.color('neutral.600')};
 `;
 
-export const defaultSerializer: JSXFunctionSerializer = (
-  type,
-  element,
-  content,
-  children,
-  key
-) => {
-  switch (element.type) {
-    case prismic.RichTextNodeType.heading1:
-      return <h1 key={key}>{children}</h1>;
-    case prismic.RichTextNodeType.heading2:
-      return (
-        <h2 key={key} id={dasherize(element.text)}>
-          {children}
-        </h2>
-      );
-    case prismic.RichTextNodeType.heading3:
-      return (
-        <h3 key={key} id={dasherize(element.text)}>
-          {children}
-        </h3>
-      );
-    case prismic.RichTextNodeType.heading4:
-      return <h4 key={key}>{children}</h4>;
-    case prismic.RichTextNodeType.heading5:
-      return <h5 key={key}>{children}</h5>;
-    case prismic.RichTextNodeType.heading6:
-      return <h6 key={key}>{children}</h6>;
-    case prismic.RichTextNodeType.paragraph:
-      return <p key={key}>{children}</p>;
-    case prismic.RichTextNodeType.preformatted:
-      return <pre key={key}>{children}</pre>;
-    case prismic.RichTextNodeType.strong:
-      return <strong key={key}>{children}</strong>;
-    case prismic.RichTextNodeType.em:
-      return <em key={key}>{children}</em>;
-    case prismic.RichTextNodeType.listItem:
-      return <li key={key}>{children}</li>;
-    case prismic.RichTextNodeType.oListItem:
-      return <li key={key}>{children}</li>;
-    case prismic.RichTextNodeType.list:
-      return <ul key={key}>{children}</ul>;
-    case prismic.RichTextNodeType.oList:
-      return <ol key={key}>{children}</ol>;
-    case prismic.RichTextNodeType.image: {
-      const url = element.linkTo
-        ? prismic.asLink(element.linkTo, { linkResolver })
-        : null;
-      const linkTarget =
-        element.linkTo && 'target' in element.linkTo
-          ? element.linkTo.target
-          : undefined;
-      const linkRel = linkTarget ? 'noopener' : undefined;
-      const wrapperClassList = ['block-img'];
-      const img = <img src={element.url} alt={element.alt || ''} />;
-
-      return (
-        <p key={key} className={wrapperClassList.join(' ')}>
-          {url ? (
-            <a target={linkTarget} rel={linkRel} href={url}>
-              {img}
-            </a>
-          ) : (
-            img
-          )}
-        </p>
-      );
-    }
-
-    case prismic.RichTextNodeType.embed:
-      return (
-        <div
-          key={key}
-          data-oembed={element.oembed.embed_url}
-          data-oembed-type={element.oembed.type}
-          data-oembed-provider={element.oembed.provider_name}
-        >
-          {element.oembed.html}
-        </div>
-      );
-    case prismic.RichTextNodeType.hyperlink: {
-      const target =
-        'target' in element.data ? element.data.target || undefined : undefined;
-      const rel = target ? 'noopener' : undefined;
-      const linkUrl = prismic.asLink(element.data, { linkResolver }) || '';
-      const isDocument =
-        'kind' in element.data ? element.data.kind === 'document' : false;
-
-      const documentSize =
-        isDocument && 'size' in element.data
-          ? Math.round(parseInt(element.data.size) / 1000)
-          : '';
-
-      const isInPage = linkUrl.match(/^https:\/\/(#.*)/i);
-      const hashLink = isInPage && isInPage[1];
-      const isWorkLink = linkUrl.match(
-        /^https:\/\/wellcomecollection.org\/works/i
-      );
-
-      const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
-
-      const documentType =
-        fileExtension && fileExtension[0].substring(1).toUpperCase();
-
-      if (isWorkLink) {
+export const createDefaultSerializer =
+  (inGallery = false): JSXFunctionSerializer =>
+  (type, element, content, children, key) => {
+    switch (element.type) {
+      case prismic.RichTextNodeType.heading1:
+        return <h1 key={key}>{children}</h1>;
+      case prismic.RichTextNodeType.heading2:
         return (
-          <FeaturedWorkLink className="link-reset" link={linkUrl}>
+          <h2 key={key} id={dasherize(element.text)}>
             {children}
-            <span className="visually-hidden">(view in catalogue)</span>
-          </FeaturedWorkLink>
+          </h2>
+        );
+      case prismic.RichTextNodeType.heading3:
+        return (
+          <h3 key={key} id={dasherize(element.text)}>
+            {children}
+          </h3>
+        );
+      case prismic.RichTextNodeType.heading4:
+        return <h4 key={key}>{children}</h4>;
+      case prismic.RichTextNodeType.heading5:
+        return <h5 key={key}>{children}</h5>;
+      case prismic.RichTextNodeType.heading6:
+        return <h6 key={key}>{children}</h6>;
+      case prismic.RichTextNodeType.paragraph:
+        return <p key={key}>{children}</p>;
+      case prismic.RichTextNodeType.preformatted:
+        return <pre key={key}>{children}</pre>;
+      case prismic.RichTextNodeType.strong:
+        return <strong key={key}>{children}</strong>;
+      case prismic.RichTextNodeType.em:
+        return <em key={key}>{children}</em>;
+      case prismic.RichTextNodeType.listItem:
+        return <li key={key}>{children}</li>;
+      case prismic.RichTextNodeType.oListItem:
+        return <li key={key}>{children}</li>;
+      case prismic.RichTextNodeType.list:
+        return <ul key={key}>{children}</ul>;
+      case prismic.RichTextNodeType.oList:
+        return <ol key={key}>{children}</ol>;
+      case prismic.RichTextNodeType.image: {
+        const url = element.linkTo
+          ? prismic.asLink(element.linkTo, { linkResolver })
+          : null;
+        const linkTarget =
+          element.linkTo && 'target' in element.linkTo
+            ? element.linkTo.target
+            : undefined;
+        const linkRel = linkTarget ? 'noopener' : undefined;
+        const wrapperClassList = ['block-img'];
+        const img = <img src={element.url} alt={element.alt || ''} />;
+
+        return (
+          <p key={key} className={wrapperClassList.join(' ')}>
+            {url ? (
+              <a target={linkTarget} rel={linkRel} href={url}>
+                {img}
+              </a>
+            ) : (
+              img
+            )}
+          </p>
         );
       }
 
-      if (hashLink) {
+      case prismic.RichTextNodeType.embed:
         return (
-          <a key={key} target={target} rel={rel} href={hashLink}>
-            {children}
-          </a>
-        );
-      }
-
-      if (isDocument) {
-        return (
-          <DownloadLink
-            href={linkUrl}
-            format={
-              fileExtension
-                ? getMimeTypeFromExtension(
-                    fileExtension && fileExtension[0].substring(1)
-                  )
-                : undefined
-            }
+          <div
+            key={key}
+            data-oembed={element.oembed.embed_url}
+            data-oembed-type={element.oembed.type}
+            data-oembed-provider={element.oembed.provider_name}
           >
-            {children}{' '}
-            <span style={{ whiteSpace: 'nowrap' }}>
-              <DocumentType>
-                ({documentType} {documentSize}kb)
-              </DocumentType>
-            </span>
-          </DownloadLink>
+            {element.oembed.html}
+          </div>
         );
-      } else {
+      case prismic.RichTextNodeType.hyperlink: {
+        const target =
+          'target' in element.data
+            ? element.data.target || undefined
+            : undefined;
+        const rel = target ? 'noopener' : undefined;
+        const linkUrl = prismic.asLink(element.data, { linkResolver }) || '';
+        const isDocument =
+          'kind' in element.data ? element.data.kind === 'document' : false;
+
+        const documentSize =
+          isDocument && 'size' in element.data
+            ? Math.round(parseInt(element.data.size) / 1000)
+            : '';
+
+        const isInPage = linkUrl.match(/^https:\/\/(#.*)/i);
+        const hashLink = isInPage && isInPage[1];
+        const isWorkLink = linkUrl.match(
+          /^https:\/\/wellcomecollection.org\/works/i
+        );
+
+        const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
+
+        const documentType =
+          fileExtension && fileExtension[0].substring(1).toUpperCase();
+
+        // Check if this is an external link (not wellcomecollection.org and not in-page)
+        const isExternalLink =
+          !linkUrl.match(/^https:\/\/wellcomecollection.org/i) &&
+          !isInPage &&
+          linkUrl.startsWith('http');
+
+        // In gallery mode, render external links as plain text
+        if (inGallery && isExternalLink) {
+          return <Fragment key={key}>{children}</Fragment>;
+        }
+
+        if (isWorkLink) {
+          return (
+            <FeaturedWorkLink className="link-reset" link={linkUrl}>
+              {children}
+              <span className="visually-hidden">(view in catalogue)</span>
+            </FeaturedWorkLink>
+          );
+        }
+
+        if (hashLink) {
+          return (
+            <a key={key} target={target} rel={rel} href={hashLink}>
+              {children}
+            </a>
+          );
+        }
+
+        if (isDocument) {
+          return (
+            <DownloadLink
+              href={linkUrl}
+              format={
+                fileExtension
+                  ? getMimeTypeFromExtension(
+                      fileExtension && fileExtension[0].substring(1)
+                    )
+                  : undefined
+              }
+            >
+              {children}{' '}
+              <span style={{ whiteSpace: 'nowrap' }}>
+                <DocumentType>
+                  ({documentType} {documentSize}kb)
+                </DocumentType>
+              </span>
+            </DownloadLink>
+          );
+        } else {
+          return (
+            <a key={key} target={target} href={linkUrl}>
+              {children}
+            </a>
+          );
+        }
+      }
+
+      case prismic.RichTextNodeType.label: {
+        const labelClass = element.data.label || undefined;
         return (
-          <a key={key} target={target} href={linkUrl}>
+          <span key={key} className={labelClass}>
             {children}
-          </a>
+          </span>
         );
       }
+      case prismic.RichTextNodeType.span:
+        return content ? (
+          <Fragment key={key}>
+            {content
+              ? content.split('\n').reduce((acc, p) => {
+                  if (acc.length === 0) {
+                    return [p];
+                  } else {
+                    const brIndex = (acc.length + 1) / 2 - 1;
+                    const br = <br key={brIndex} />;
+                    return [...acc, br, p];
+                  }
+                }, [])
+              : null}
+          </Fragment>
+        ) : null;
+      default:
+        return null;
     }
+  };
 
-    case prismic.RichTextNodeType.label: {
-      const labelClass = element.data.label || undefined;
-      return (
-        <span key={key} className={labelClass}>
-          {children}
-        </span>
-      );
-    }
-    case prismic.RichTextNodeType.span:
-      return content ? (
-        <Fragment key={key}>
-          {content
-            ? content.split('\n').reduce((acc, p) => {
-                if (acc.length === 0) {
-                  return [p];
-                } else {
-                  const brIndex = (acc.length + 1) / 2 - 1;
-                  const br = <br key={brIndex} />;
-                  return [...acc, br, p];
-                }
-              }, [])
-            : null}
-        </Fragment>
-      ) : null;
-    default:
-      return null;
-  }
-};
+export const defaultSerializer = createDefaultSerializer(false);
 
 /**
  * Safely extract the first string child from a React node.

--- a/common/views/components/Header/Header.ExhibitionNav.tsx
+++ b/common/views/components/Header/Header.ExhibitionNav.tsx
@@ -1,0 +1,289 @@
+import Link from 'next/link';
+import { FunctionComponent, useContext } from 'react';
+import styled from 'styled-components';
+
+import { ServerDataContext } from '@weco/common/server-data/Context';
+import { GalleryExhibitionData } from '@weco/common/server-data/types';
+import { font } from '@weco/common/utils/classnames';
+
+const ExhibitionNavContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 ${props => props.theme.spacingUnit * 2}px;
+`;
+
+const NavButton = styled.a<{ $disabled?: boolean }>`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit}px
+    ${props => props.theme.spacingUnit * 2}px;
+  background-color: ${props => props.theme.color('black')};
+  color: ${props => props.theme.color('white')};
+  text-decoration: none;
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  font-size: 14px;
+
+  ${props =>
+    props.$disabled &&
+    `
+    background-color: ${props.theme.color('neutral.500')};
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.5;
+  `}
+
+  &:hover:not([disabled]) {
+    background-color: ${props => props.theme.color('neutral.700')};
+  }
+`;
+
+const ExhibitionInfo = styled.div`
+  text-align: center;
+  flex: 1;
+  margin: 0 ${props => props.theme.spacingUnit * 2}px;
+`;
+
+const ExhibitionTitle = styled.div`
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: ${props => props.theme.spacingUnit / 2}px;
+`;
+
+const Counter = styled.div`
+  font-size: 12px;
+  color: ${props => props.theme.color('neutral.600')};
+`;
+
+const CrossLinks = styled.div`
+  display: flex;
+  gap: ${props => props.theme.spacingUnit}px;
+  justify-content: center;
+  margin-top: ${props => props.theme.spacingUnit}px;
+`;
+
+const CrossLink = styled.a`
+  font-size: 12px;
+  color: ${props => props.theme.color('neutral.700')};
+  text-decoration: underline;
+
+  &:hover {
+    color: ${props => props.theme.color('black')};
+  }
+`;
+
+type ExhibitionContext = {
+  exhibition: GalleryExhibitionData;
+  exhibitionId: string;
+  currentIndex: number;
+  prevUrl?: string;
+  nextUrl?: string;
+  prevTitle?: string;
+  nextTitle?: string;
+  itemType: 'story' | 'work' | 'collection';
+  totalItems: number;
+};
+
+function findExhibitionContext(
+  currentUrl: string,
+  exhibitionExtras: Record<string, GalleryExhibitionData>
+): ExhibitionContext | null {
+  const normalizeUrl = (url: string) => {
+    try {
+      // Decode URL and replace + with space for consistent comparison
+      const decoded = decodeURIComponent(url.replace(/\+/g, ' '));
+      return decoded.replace(/\/$/, '').toLowerCase();
+    } catch {
+      return url.replace(/\+/g, ' ').replace(/\/$/, '').toLowerCase();
+    }
+  };
+
+  const normalizedCurrentUrl = normalizeUrl(currentUrl);
+
+  for (const [exhibitionId, exhibition] of Object.entries(exhibitionExtras)) {
+    // Check stories
+    const storyIndex = exhibition.stories.findIndex(
+      storyId =>
+        normalizeUrl(`/stories/${storyId}`) === normalizedCurrentUrl ||
+        normalizedCurrentUrl.includes(storyId)
+    );
+    if (storyIndex !== -1) {
+      const prevStoryId =
+        storyIndex > 0 ? exhibition.stories[storyIndex - 1] : undefined;
+      const nextStoryId =
+        storyIndex < exhibition.stories.length - 1
+          ? exhibition.stories[storyIndex + 1]
+          : undefined;
+
+      return {
+        exhibition,
+        exhibitionId,
+        currentIndex: storyIndex,
+        prevUrl: prevStoryId ? `/stories/${prevStoryId}` : undefined,
+        nextUrl: nextStoryId ? `/stories/${nextStoryId}` : undefined,
+        itemType: 'story',
+        totalItems: exhibition.stories.length,
+      };
+    }
+
+    // Check works
+    const workIndex = exhibition.works.findIndex(
+      workId =>
+        normalizeUrl(`/works/${workId}`) === normalizedCurrentUrl ||
+        normalizedCurrentUrl.includes(workId)
+    );
+    if (workIndex !== -1) {
+      const prevWorkId =
+        workIndex > 0 ? exhibition.works[workIndex - 1] : undefined;
+      const nextWorkId =
+        workIndex < exhibition.works.length - 1
+          ? exhibition.works[workIndex + 1]
+          : undefined;
+
+      return {
+        exhibition,
+        exhibitionId,
+        currentIndex: workIndex,
+        prevUrl: prevWorkId ? `/works/${prevWorkId}` : undefined,
+        nextUrl: nextWorkId ? `/works/${nextWorkId}` : undefined,
+        itemType: 'work',
+        totalItems: exhibition.works.length,
+      };
+    }
+
+    // Check collection clusters (concepts and searches)
+    const clusterIndex = exhibition.collectionClusters.findIndex(cluster => {
+      const normalizedClusterUrl = normalizeUrl(cluster.url);
+      return (
+        normalizedClusterUrl === normalizedCurrentUrl ||
+        normalizedClusterUrl.includes(normalizedCurrentUrl) ||
+        normalizedCurrentUrl.includes(normalizedClusterUrl)
+      );
+    });
+    if (clusterIndex !== -1) {
+      const prevCluster =
+        clusterIndex > 0
+          ? exhibition.collectionClusters[clusterIndex - 1]
+          : undefined;
+      const nextCluster =
+        clusterIndex < exhibition.collectionClusters.length - 1
+          ? exhibition.collectionClusters[clusterIndex + 1]
+          : undefined;
+
+      return {
+        exhibition,
+        exhibitionId,
+        currentIndex: clusterIndex,
+        prevUrl: prevCluster?.url,
+        nextUrl: nextCluster?.url,
+        prevTitle: prevCluster?.title,
+        nextTitle: nextCluster?.title,
+        itemType: 'collection',
+        totalItems: exhibition.collectionClusters.length,
+      };
+    }
+  }
+  return null;
+}
+
+type Props = {
+  currentUrl: string;
+};
+
+export const HeaderExhibitionNav: FunctionComponent<Props> = ({
+  currentUrl,
+}) => {
+  const serverData = useContext(ServerDataContext);
+  const { exhibitionExtras } = serverData;
+
+  // Return early if exhibitionExtras is not available
+  if (!exhibitionExtras) {
+    return null;
+  }
+
+  const context = findExhibitionContext(currentUrl, exhibitionExtras);
+
+  if (!context) {
+    return null;
+  }
+
+  const { exhibition, currentIndex, prevUrl, nextUrl, totalItems, itemType } =
+    context;
+
+  const itemLabel =
+    itemType === 'story'
+      ? 'story'
+      : itemType === 'work'
+        ? 'work'
+        : 'collection item';
+
+  // Get cross-links to other types
+  const firstWork =
+    itemType !== 'work' && exhibition.works[0]
+      ? `/works/${exhibition.works[0]}`
+      : undefined;
+  const firstStory =
+    itemType !== 'story' && exhibition.stories[0]
+      ? `/stories/${exhibition.stories[0]}`
+      : undefined;
+  const firstCluster =
+    itemType !== 'collection' && exhibition.collectionClusters[0]
+      ? exhibition.collectionClusters[0].url
+      : undefined;
+
+  const showCrossLinks = firstWork || firstStory || firstCluster;
+
+  return (
+    <ExhibitionNavContainer data-component="HeaderExhibitionNav">
+      <div>
+        {prevUrl ? (
+          <Link href={prevUrl} passHref legacyBehavior>
+            <NavButton>← Prev</NavButton>
+          </Link>
+        ) : (
+          <NavButton $disabled>← Prev</NavButton>
+        )}
+      </div>
+
+      <ExhibitionInfo>
+        <ExhibitionTitle className={font('brand-bold', -1)}>
+          {exhibition.title}
+        </ExhibitionTitle>
+        <Counter>
+          {itemLabel} {currentIndex + 1} of {totalItems}
+        </Counter>
+        {showCrossLinks && (
+          <CrossLinks>
+            {firstWork && (
+              <Link href={firstWork} passHref legacyBehavior>
+                <CrossLink>View works</CrossLink>
+              </Link>
+            )}
+            {firstStory && (
+              <Link href={firstStory} passHref legacyBehavior>
+                <CrossLink>View stories</CrossLink>
+              </Link>
+            )}
+            {firstCluster && (
+              <Link href={firstCluster} passHref legacyBehavior>
+                <CrossLink>View collection</CrossLink>
+              </Link>
+            )}
+          </CrossLinks>
+        )}
+      </ExhibitionInfo>
+
+      <div>
+        {nextUrl ? (
+          <Link href={nextUrl} passHref legacyBehavior>
+            <NavButton>Next →</NavButton>
+          </Link>
+        ) : (
+          <NavButton $disabled>Next →</NavButton>
+        )}
+      </div>
+    </ExhibitionNavContainer>
+  );
+};
+
+export default HeaderExhibitionNav;

--- a/common/views/components/Header/Header.styles.ts
+++ b/common/views/components/Header/Header.styles.ts
@@ -123,7 +123,7 @@ export const HeaderBrand = styled.div<{ $isMinimalHeader: boolean }>`
   `)}
 `}
 
-  a {
+  a, span {
     display: inline-block;
     margin: 0 auto;
   }

--- a/common/views/components/Header/index.tsx
+++ b/common/views/components/Header/index.tsx
@@ -9,9 +9,11 @@ import { searchLabelText } from '@weco/common/data/microcopy';
 import { cross, search } from '@weco/common/icons';
 import WellcomeCollectionBlack from '@weco/common/icons/wellcome_collection_black';
 import { SiteSection } from '@weco/common/model/site-section';
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
+import HeaderExhibitionNav from './Header.ExhibitionNav';
 import HeaderSearch from './Header.Search';
 import DesktopSignIn from './Header.SignIn.Desktop';
 import MobileSignIn from './Header.SignIn.Mobile';
@@ -46,6 +48,7 @@ type Props = {
   customNavLinks?: NavLink[];
   isMinimalHeader?: boolean;
   hasColorBackground?: boolean;
+  currentUrl?: string;
 };
 
 export const links: NavLink[] = [
@@ -95,11 +98,14 @@ const Header: FunctionComponent<Props> = ({
   hasColorBackground,
   // We don't display login and search on certain pages, e.g. exhibition guides
   isMinimalHeader = false,
+  currentUrl,
 }) => {
   const [burgerMenuIsActive, setBurgerMenuIsActive] = useState(false);
   const [searchDropdownIsActive, setSearchDropdownIsActive] = useState(false);
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const { isEnhanced } = useAppContext();
+  const { inGallery = false } = useToggles();
+  const displayMinimalHeader = isMinimalHeader || inGallery;
 
   return (
     <FocusTrap
@@ -135,38 +141,57 @@ const Header: FunctionComponent<Props> = ({
                   <span />
                 </BurgerTrigger>
               </Burger>
-              <HeaderBrand $isMinimalHeader={isMinimalHeader}>
-                <a href="/">
-                  <WellcomeCollectionBlack />
-                </a>
+              <HeaderBrand $isMinimalHeader={displayMinimalHeader}>
+                {!inGallery ? (
+                  <a href="/">
+                    <WellcomeCollectionBlack />
+                  </a>
+                ) : (
+                  <span>
+                    <WellcomeCollectionBlack />
+                  </span>
+                )}
               </HeaderBrand>
               <NavLoginWrapper>
-                <HeaderNav
-                  id="header-nav"
-                  aria-labelledby="header-burger-trigger"
-                  $burgerMenuisActive={burgerMenuIsActive}
-                  $hasColorBackground={hasColorBackground}
-                >
-                  <HeaderList className={font('brand-bold', -1)}>
-                    {(customNavLinks || links).map((link, i) => (
-                      <HeaderItem key={i}>
-                        <HeaderLink
-                          $burgerMenuisActive={link.siteSection === siteSection}
-                          href={link.href}
-                          {...(link.siteSection === siteSection
-                            ? { 'aria-current': true }
-                            : {})}
-                        >
-                          {link.title}
-                        </HeaderLink>
-                      </HeaderItem>
-                    ))}
-                  </HeaderList>
-                  {!isMinimalHeader && <MobileSignIn />}
-                </HeaderNav>
+                {inGallery && currentUrl ? (
+                  <HeaderNav
+                    id="header-nav"
+                    aria-labelledby="header-burger-trigger"
+                    $burgerMenuisActive={burgerMenuIsActive}
+                    $hasColorBackground={hasColorBackground}
+                  >
+                    <HeaderExhibitionNav currentUrl={currentUrl} />
+                  </HeaderNav>
+                ) : (
+                  <HeaderNav
+                    id="header-nav"
+                    aria-labelledby="header-burger-trigger"
+                    $burgerMenuisActive={burgerMenuIsActive}
+                    $hasColorBackground={hasColorBackground}
+                  >
+                    <HeaderList className={font('brand-bold', -1)}>
+                      {(customNavLinks || links).map((link, i) => (
+                        <HeaderItem key={i}>
+                          <HeaderLink
+                            $burgerMenuisActive={
+                              link.siteSection === siteSection
+                            }
+                            href={link.href}
+                            {...(link.siteSection === siteSection
+                              ? { 'aria-current': true }
+                              : {})}
+                          >
+                            {link.title}
+                          </HeaderLink>
+                        </HeaderItem>
+                      ))}
+                    </HeaderList>
+                    {!displayMinimalHeader && <MobileSignIn />}
+                  </HeaderNav>
+                )}
 
                 <HeaderActions>
-                  {!isMinimalHeader && (
+                  {!displayMinimalHeader && (
                     <>
                       {!isEnhanced ? (
                         <NextLink href="/search">
@@ -202,14 +227,14 @@ const Header: FunctionComponent<Props> = ({
                     </>
                   )}
 
-                  {!isMinimalHeader && <DesktopSignIn />}
+                  {!displayMinimalHeader && <DesktopSignIn />}
                 </HeaderActions>
               </NavLoginWrapper>
             </HeaderContainer>
           </div>
         </Wrapper>
 
-        {!isMinimalHeader && (
+        {!displayMinimalHeader && (
           <HeaderSearch
             isActive={searchDropdownIsActive}
             handleCloseModal={() => setSearchDropdownIsActive(false)}

--- a/common/views/components/PageHeader/PageHeader.Landing.tsx
+++ b/common/views/components/PageHeader/PageHeader.Landing.tsx
@@ -4,8 +4,9 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createDefaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import {
   ContaineredLayout,
   gridSize10,
@@ -38,6 +39,9 @@ const LandingPageHeader: FunctionComponent<Props> = ({
   introText,
   FeaturedMedia,
 }) => {
+  const { inGallery = false } = useToggles();
+  const htmlSerializer = createDefaultSerializer(inGallery);
+
   return (
     <>
       <ContaineredLayout gridSizes={gridSize12()}>
@@ -52,7 +56,7 @@ const LandingPageHeader: FunctionComponent<Props> = ({
                 <ContentWrapper>
                   <PrismicHtmlBlock
                     html={introText}
-                    htmlSerializer={defaultSerializer}
+                    htmlSerializer={htmlSerializer}
                   />
                 </ContentWrapper>
               </GridCell>

--- a/common/views/components/PageHeader/PagerHeader.Basic.tsx
+++ b/common/views/components/PageHeader/PagerHeader.Basic.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import AccessibilityProvision from '@weco/common/views/components/AccessibilityProvision';
 import Breadcrumb from '@weco/common/views/components/Breadcrumb';
@@ -94,6 +95,7 @@ const BasicPageHeader: FunctionComponent<Props> = ({
   ) : (
     <TitleWrapper>{title}</TitleWrapper>
   );
+  const { inGallery = false } = useToggles();
 
   const hasMedia = FeaturedMedia || HeroPicture;
 
@@ -120,7 +122,7 @@ const BasicPageHeader: FunctionComponent<Props> = ({
                   : ['margin-bottom', 'padding-bottom'],
             }}
           >
-            {hasBreadcrumbItems && (
+            {hasBreadcrumbItems && !inGallery && (
               // We need to keep some space below the breadcrumbs to prevent
               // 'highlighted' headings from being partially concealed
               <Space

--- a/common/views/layouts/PageLayout/index.tsx
+++ b/common/views/layouts/PageLayout/index.tsx
@@ -31,6 +31,7 @@ import ApiToolbar, {
   ApiToolbarLink,
 } from '@weco/common/views/components/ApiToolbar';
 import Footer from '@weco/common/views/components/Footer';
+import GalleryInactivityRedirect from '@weco/common/views/components/GalleryInactivityRedirect';
 import Header, { NavLink } from '@weco/common/views/components/Header';
 import InfoBanner from '@weco/common/views/components/InfoBanner';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
@@ -43,6 +44,7 @@ type HeaderProps = {
   customNavLinks?: NavLink[];
   isMinimalHeader?: boolean;
   hasColorBackground?: boolean;
+  currentUrl?: string;
 };
 
 type SkipToContentLink = {
@@ -284,7 +286,13 @@ const PageLayoutComponent: NextPage<Props> = ({
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>
-        {!hideHeader && <Header siteSection={siteSection} {...headerProps} />}
+        {!hideHeader && (
+          <Header
+            siteSection={siteSection}
+            {...headerProps}
+            currentUrl={urlString}
+          />
+        )}
         {issuesBanner && <InfoBanner variant="websiteIssues" />}
         {globalAlert.data.isShown === 'show' &&
           (!globalAlert.data.routeRegex ||
@@ -303,6 +311,7 @@ const PageLayoutComponent: NextPage<Props> = ({
             urlString.match(new RegExp(popupDialog.data.routeRegex))) && (
             <PopupDialog document={popupDialog} />
           )}
+        <GalleryInactivityRedirect />
         <div
           id="main"
           className="main"

--- a/common/views/slices/Text/index.tsx
+++ b/common/views/slices/Text/index.tsx
@@ -7,9 +7,9 @@ import { useToggles } from '@weco/common/server-data/Context';
 import { classNames } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import {
-  accessibilitySerializer,
+  createAccessibilitySerializer,
   createDefaultSerializer,
-  dropCapSerializer,
+  createDropCapSerializer,
 } from '@weco/common/views/components/HTMLSerializers';
 import { ContaineredLayout } from '@weco/common/views/components/Layout';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
@@ -33,6 +33,8 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
     options.pageUid === 'prototype-a11y-november-2025';
 
   const defaultSerializer = createDefaultSerializer(inGallery);
+  const dropCap = createDropCapSerializer(inGallery);
+  const accessibility = createAccessibilitySerializer(inGallery);
 
   return (
     <SpacingComponent $sliceType={slice.slice_type}>
@@ -54,14 +56,12 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
             <>
               <PrismicHtmlBlock
                 html={[slice.primary.text[0]] as prismic.RichTextField}
-                htmlSerializer={dropCapSerializer}
+                htmlSerializer={dropCap}
               />
               <PrismicHtmlBlock
                 html={slice.primary.text.slice(1) as prismic.RichTextField}
                 htmlSerializer={
-                  isAccessibilityPage
-                    ? accessibilitySerializer
-                    : defaultSerializer
+                  isAccessibilityPage ? accessibility : defaultSerializer
                 }
               />
             </>
@@ -69,9 +69,7 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
             <PrismicHtmlBlock
               html={slice.primary.text}
               htmlSerializer={
-                isAccessibilityPage
-                  ? accessibilitySerializer
-                  : defaultSerializer
+                isAccessibilityPage ? accessibility : defaultSerializer
               }
             />
           )}

--- a/common/views/slices/Text/index.tsx
+++ b/common/views/slices/Text/index.tsx
@@ -3,11 +3,12 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { TextSlice as RawTextSlice } from '@weco/common/prismicio-types';
+import { useToggles } from '@weco/common/server-data/Context';
 import { classNames } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import {
   accessibilitySerializer,
-  defaultSerializer,
+  createDefaultSerializer,
   dropCapSerializer,
 } from '@weco/common/views/components/HTMLSerializers';
 import { ContaineredLayout } from '@weco/common/views/components/Layout';
@@ -21,6 +22,7 @@ import {
 export type TextProps = SliceComponentProps<RawTextSlice, SliceZoneContext>;
 
 const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
+  const { inGallery = false } = useToggles();
   const options = { ...defaultContext, ...context };
   const shouldBeDroppedCap =
     options.firstTextSliceIndex === slice.id && options.isDropCapped;
@@ -29,6 +31,8 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
   const isAccessibilityPage =
     options.pageUid === 'accessibility' ||
     options.pageUid === 'prototype-a11y-november-2025';
+
+  const defaultSerializer = createDefaultSerializer(inGallery);
 
   return (
     <SpacingComponent $sliceType={slice.slice_type}>

--- a/content/webapp/pages/exhibitions/[exhibitionId]/extras.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/extras.tsx
@@ -1,0 +1,89 @@
+import { NextPage } from 'next';
+
+import { getServerData } from '@weco/common/server-data';
+import { looksLikePrismicId } from '@weco/common/services/prismic';
+import { serialiseProps } from '@weco/common/utils/json';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
+import {
+  ServerSideProps,
+  ServerSidePropsOrAppError,
+} from '@weco/common/views/pages/_app';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { fetchArticle } from '@weco/content/services/prismic/fetch/articles';
+import { fetchExhibition } from '@weco/content/services/prismic/fetch/exhibitions';
+import { transformArticle } from '@weco/content/services/prismic/transformers/articles';
+import { toWorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+import { getWork } from '@weco/content/services/wellcome/catalogue/works';
+import { cacheTTL, setCacheControl } from '@weco/content/utils/setCacheControl';
+import ExhibitionExtrasPage, {
+  Props as ExhibitionExtrasPageProps,
+} from '@weco/content/views/pages/exhibitions/exhibition/extras';
+
+/**
+ * Please note that the /exhibitions/{period} routes do not arrive here
+ * but instead are rewritten to the index file. Please observe
+ * this setup in the next.config file for this app
+ */
+const Page: NextPage<ExhibitionExtrasPageProps> = props => {
+  return <ExhibitionExtrasPage {...props} />;
+};
+
+type Props = ServerSideProps<ExhibitionExtrasPageProps>;
+
+export const getServerSideProps: ServerSidePropsOrAppError<
+  Props
+> = async context => {
+  setCacheControl(context.res, cacheTTL.events);
+  const { exhibitionId } = context.query;
+  const serverData = await getServerData(context);
+  if (
+    !looksLikePrismicId(exhibitionId) ||
+    !serverData.toggles.inGallery.value
+  ) {
+    return { notFound: true };
+  }
+
+  const client = createClient(context);
+  const exhibitionDocument = await fetchExhibition(client, exhibitionId);
+
+  if (!exhibitionDocument) {
+    return { notFound: true };
+  }
+
+  // Get exhibition data from serverData context
+  const exhibitionData = serverData.exhibitionExtras[exhibitionId];
+
+  // Fetch works from catalogue API
+  const worksPromises =
+    exhibitionData?.works?.map(async workId => {
+      const work = await getWork({
+        id: workId,
+        toggles: serverData.toggles,
+      });
+      return work.type === 'Error' || work.type === 'Redirect'
+        ? undefined
+        : toWorkBasic(work);
+    }) || [];
+  const worksResults = await Promise.all(worksPromises);
+  const works = worksResults.filter(isNotUndefined);
+
+  // Fetch stories from Prismic
+  const storiesPromises =
+    exhibitionData?.stories?.map(async storyId => {
+      const storyDocument = await fetchArticle(client, storyId);
+      return storyDocument ? transformArticle(storyDocument) : undefined;
+    }) || [];
+  const storiesResults = await Promise.all(storiesPromises);
+  const stories = storiesResults.filter(isNotUndefined);
+
+  return {
+    props: serialiseProps<Props>({
+      stories,
+      works,
+      exhibitionData: exhibitionData || null,
+      serverData,
+    }),
+  };
+};
+
+export default Page;

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -6,10 +6,11 @@ import styled from 'styled-components';
 import { officialLandingPagesUid } from '@weco/common/data/hardcoded-ids';
 import { ContentListSlice as RawContentListSlice } from '@weco/common/prismicio-types';
 import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
+import { useToggles } from '@weco/common/server-data/Context';
 import { classNames, font } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createDefaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import {
   ContaineredLayout,
   gridSize12,
@@ -142,6 +143,9 @@ const Body: FunctionComponent<Props> = ({
   contentType,
   bodySliceContexts,
 }: Props) => {
+  const { inGallery = false } = useToggles();
+  const htmlSerializer = createDefaultSerializer(inGallery);
+
   const filteredUntransformedBody = untransformedBody.filter(
     (slice: prismic.Slice) => slice.slice_type !== 'standfirst'
   );
@@ -335,7 +339,7 @@ const Body: FunctionComponent<Props> = ({
                 >
                   <FeaturedText
                     html={introText}
-                    htmlSerializer={defaultSerializer}
+                    htmlSerializer={htmlSerializer}
                   />
                 </Space>
               </div>

--- a/content/webapp/views/components/ExhibitionCollectionNavigation.tsx
+++ b/content/webapp/views/components/ExhibitionCollectionNavigation.tsx
@@ -1,0 +1,258 @@
+import Link from 'next/link';
+import { FunctionComponent, useContext } from 'react';
+import styled from 'styled-components';
+
+import {
+  ServerDataContext,
+  useToggles,
+} from '@weco/common/server-data/Context';
+import { GalleryExhibitionData } from '@weco/common/server-data/types';
+import { Container } from '@weco/common/views/components/styled/Container';
+import Space from '@weco/common/views/components/styled/Space';
+
+const ExhibitionNavWrapper = styled.div`
+  background-color: ${props => props.theme.color('warmNeutral.300')};
+  padding: ${props => props.theme.spacingUnit * 3}px 0;
+`;
+
+const NavGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: ${props => props.theme.spacingUnit * 2}px;
+  align-items: center;
+`;
+
+const NavButton = styled.a<{ $disabled?: boolean }>`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit * 2}px
+    ${props => props.theme.spacingUnit * 3}px;
+  background-color: ${props => props.theme.color('black')};
+  color: ${props => props.theme.color('white')};
+  text-decoration: none;
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  font-weight: bold;
+  text-align: center;
+
+  ${props =>
+    props.$disabled &&
+    `
+    background-color: ${props.theme.color('neutral.500')};
+    cursor: not-allowed;
+    pointer-events: none;
+  `}
+
+  &:hover:not([disabled]) {
+    background-color: ${props => props.theme.color('neutral.700')};
+  }
+`;
+
+const ExhibitionTitle = styled.h2`
+  font-size: 1.2rem;
+  margin: 0;
+  text-align: center;
+  font-weight: bold;
+`;
+
+const DescriptionText = styled.p`
+  margin: ${props => props.theme.spacingUnit * 2}px 0 0 0;
+  text-align: center;
+  font-size: 1rem;
+  line-height: 1.5;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+const RelatedLinks = styled.div`
+  margin-top: ${props => props.theme.spacingUnit * 3}px;
+  padding-top: ${props => props.theme.spacingUnit * 3}px;
+  border-top: 1px solid ${props => props.theme.color('neutral.400')};
+`;
+
+const RelatedTitle = styled.h3`
+  font-size: 1rem;
+  margin: 0 0 ${props => props.theme.spacingUnit * 2}px 0;
+  font-weight: bold;
+`;
+
+const RelatedLinksList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacingUnit}px;
+
+  ${props => props.theme.media('sm')`
+    flex-direction: row;
+    gap: 1rem;
+  `}
+`;
+
+const RelatedLink = styled.a`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit}px
+    ${props => props.theme.spacingUnit * 2}px;
+  background-color: ${props => props.theme.color('white')};
+  color: ${props => props.theme.color('black')};
+  text-decoration: none;
+  border: 2px solid ${props => props.theme.color('black')};
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  text-align: center;
+
+  &:hover {
+    background-color: ${props => props.theme.color('neutral.200')};
+  }
+`;
+
+type ExhibitionContext = {
+  exhibition: GalleryExhibitionData;
+  exhibitionId: string;
+  currentIndex: number;
+  prevUrl?: string;
+  nextUrl?: string;
+  prevTitle?: string;
+  nextTitle?: string;
+};
+
+function findExhibitionContext(
+  currentUrl: string,
+  exhibitionExtras: Record<string, GalleryExhibitionData>
+): ExhibitionContext | null {
+  // Normalize URLs for comparison by decoding and removing trailing slashes
+  const normalizeUrl = (url: string) => {
+    try {
+      const decoded = decodeURIComponent(url);
+      return decoded.replace(/\/$/, '').toLowerCase();
+    } catch {
+      return url.replace(/\/$/, '').toLowerCase();
+    }
+  };
+
+  const normalizedCurrentUrl = normalizeUrl(currentUrl);
+
+  for (const [exhibitionId, exhibition] of Object.entries(exhibitionExtras)) {
+    const currentIndex = exhibition.collectionClusters.findIndex(cluster => {
+      const normalizedClusterUrl = normalizeUrl(cluster.url);
+      // Check if the URLs match (for exact concept IDs or search queries)
+      return (
+        normalizedClusterUrl === normalizedCurrentUrl ||
+        normalizedClusterUrl.includes(normalizedCurrentUrl) ||
+        normalizedCurrentUrl.includes(normalizedClusterUrl)
+      );
+    });
+    if (currentIndex !== -1) {
+      const prevCluster =
+        currentIndex > 0
+          ? exhibition.collectionClusters[currentIndex - 1]
+          : undefined;
+      const nextCluster =
+        currentIndex < exhibition.collectionClusters.length - 1
+          ? exhibition.collectionClusters[currentIndex + 1]
+          : undefined;
+
+      return {
+        exhibition,
+        exhibitionId,
+        currentIndex,
+        prevUrl: prevCluster?.url,
+        nextUrl: nextCluster?.url,
+        prevTitle: prevCluster?.title,
+        nextTitle: nextCluster?.title,
+      };
+    }
+  }
+  return null;
+}
+
+type Props = {
+  currentUrl: string;
+};
+
+export const ExhibitionCollectionNavigation: FunctionComponent<Props> = ({
+  currentUrl,
+}) => {
+  const { inGallery = false } = useToggles();
+  const serverData = useContext(ServerDataContext);
+  const { exhibitionExtras } = serverData;
+
+  if (!inGallery) {
+    return null;
+  }
+
+  const context = findExhibitionContext(currentUrl, exhibitionExtras);
+
+  if (!context) {
+    return null;
+  }
+
+  const {
+    exhibition,
+    exhibitionId,
+    currentIndex,
+    prevUrl,
+    nextUrl,
+    prevTitle,
+    nextTitle,
+  } = context;
+  const firstStory = exhibition.stories[0];
+
+  return (
+    <ExhibitionNavWrapper data-component="ExhibitionCollectionNavigation">
+      <Container>
+        <Space
+          $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+        >
+          <ExhibitionTitle>
+            Related to {exhibition.title || exhibitionId}
+          </ExhibitionTitle>
+          <DescriptionText>
+            The exhibition curators for {exhibition.title || exhibitionId} have
+            identified this, and several other topics, as exploring the themes
+            of the exhibition.
+          </DescriptionText>
+
+          <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+            <NavGrid>
+              <div style={{ textAlign: 'left' }}>
+                {prevUrl ? (
+                  <Link href={prevUrl} passHref legacyBehavior>
+                    <NavButton title={prevTitle}>← Previous</NavButton>
+                  </Link>
+                ) : (
+                  <NavButton $disabled>← Previous</NavButton>
+                )}
+              </div>
+
+              <div style={{ textAlign: 'center' }}>
+                <span>
+                  {currentIndex + 1} of {exhibition.collectionClusters.length}
+                </span>
+              </div>
+
+              <div style={{ textAlign: 'right' }}>
+                {nextUrl ? (
+                  <Link href={nextUrl} passHref legacyBehavior>
+                    <NavButton title={nextTitle}>Next →</NavButton>
+                  </Link>
+                ) : (
+                  <NavButton $disabled>Next →</NavButton>
+                )}
+              </div>
+            </NavGrid>
+          </Space>
+
+          {firstStory && (
+            <RelatedLinks>
+              <RelatedTitle>You may be interested in</RelatedTitle>
+              <RelatedLinksList>
+                <Link href={`/stories/${firstStory}`} passHref legacyBehavior>
+                  <RelatedLink>Related stories</RelatedLink>
+                </Link>
+              </RelatedLinksList>
+            </RelatedLinks>
+          )}
+        </Space>
+      </Container>
+    </ExhibitionNavWrapper>
+  );
+};
+
+export default ExhibitionCollectionNavigation;

--- a/content/webapp/views/components/TextAndImageOrIcons/index.tsx
+++ b/content/webapp/views/components/TextAndImageOrIcons/index.tsx
@@ -3,7 +3,8 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { ImageType } from '@weco/common/model/image';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { useToggles } from '@weco/common/server-data/Context';
+import { createDefaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -90,6 +91,9 @@ export type Props = {
 };
 
 const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
+  const { inGallery = false } = useToggles();
+  const htmlSerializer = createDefaultSerializer(inGallery);
+
   // Icons can be added indefinitely without necessarily having an image, so we are filtering it here
   const icons: ImageType[] = [];
   if (item.type === 'icons') {
@@ -122,10 +126,7 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
           </ImageOrIcons>
         )}
         <Text>
-          <PrismicHtmlBlock
-            html={item.text}
-            htmlSerializer={defaultSerializer}
-          />
+          <PrismicHtmlBlock html={item.text} htmlSerializer={htmlSerializer} />
         </Text>
       </MediaAndTextWrap>
     </DividingLine>

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.BeingHuman.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.BeingHuman.tsx
@@ -4,10 +4,11 @@ import { FunctionComponent } from 'react';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { arrow, download } from '@weco/common/icons';
+import { useToggles } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createDefaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
@@ -64,6 +65,9 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
   accessResourceLinks,
   exhibitionFormat,
 }) => {
+  const { inGallery = false } = useToggles();
+  const htmlSerializer = createDefaultSerializer(inGallery);
+
   const hasResources = Boolean(
     exhibition.accessResourcesText ||
     exhibition.accessResourcesPdfs.length > 0 ||
@@ -140,7 +144,7 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
           {exhibition.accessResourcesText && (
             <PrismicHtmlBlock
               html={exhibition.accessResourcesText}
-              htmlSerializer={defaultSerializer}
+              htmlSerializer={htmlSerializer}
             />
           )}
         </>

--- a/content/webapp/views/pages/exhibitions/exhibition/extras.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/extras.tsx
@@ -1,0 +1,87 @@
+import { NextPage } from 'next';
+
+import { GalleryExhibitionData } from '@weco/common/server-data/types';
+import { JsonLdObj } from '@weco/common/views/components/JsonLd';
+import { Container } from '@weco/common/views/components/styled/Container';
+import PlainList from '@weco/common/views/components/styled/PlainList';
+import Space from '@weco/common/views/components/styled/Space';
+import PageLayout from '@weco/common/views/layouts/PageLayout';
+import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+import { ArticleBasic } from '@weco/content/types/articles';
+import { Exhibition as ExhibitionType } from '@weco/content/types/exhibitions';
+import StoryCard from '@weco/content/views/components/StoryCard';
+import WorkCards from '@weco/content/views/components/WorkCards';
+
+export type Props = {
+  exhibition?: ExhibitionType;
+  stories: ArticleBasic[];
+  works: WorkBasic[];
+  exhibitionData: GalleryExhibitionData | null;
+  jsonLd?: JsonLdObj;
+};
+
+const ExhibitionExtrasPage: NextPage<Props> = ({
+  exhibition,
+  stories,
+  works,
+  exhibitionData,
+  jsonLd,
+}) => {
+  const exhibitionTitle =
+    exhibitionData?.title || exhibition?.title || 'Exhibition';
+
+  return (
+    <PageLayout
+      title={`${exhibitionTitle} - Extras`}
+      description={
+        exhibition?.promo?.caption ||
+        `Explore more works and stories related to ${exhibitionTitle}`
+      }
+      url={{ pathname: `/exhibitions/${exhibition?.id || 'extras'}/extras` }}
+      jsonLd={jsonLd || { '@type': 'WebPage' }}
+      openGraphType="website"
+      siteSection="whats-on"
+      image={exhibition?.promo?.image}
+    >
+      <Container>
+        <Space
+          $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+        >
+          <h1>{exhibitionTitle} - Extras</h1>
+
+          {works.length > 0 && (
+            <Space
+              $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}
+            >
+              <h2>Related Works</h2>
+              <WorkCards works={works} />
+            </Space>
+          )}
+
+          {stories.length > 0 && (
+            <Space
+              $v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}
+            >
+              <h2>Related Stories</h2>
+              <PlainList>
+                {stories.map(story => (
+                  <li key={story.id}>
+                    <Space $v={{ size: 'lg', properties: ['margin-bottom'] }}>
+                      <StoryCard variant="prismic" article={story} />
+                    </Space>
+                  </li>
+                ))}
+              </PlainList>
+            </Space>
+          )}
+
+          {stories.length === 0 && works.length === 0 && (
+            <p>No extras available for this exhibition.</p>
+          )}
+        </Space>
+      </Container>
+    </PageLayout>
+  );
+};
+
+export default ExhibitionExtrasPage;

--- a/content/webapp/views/pages/stories/story/ExhibitionStoryNavigation.tsx
+++ b/content/webapp/views/pages/stories/story/ExhibitionStoryNavigation.tsx
@@ -1,0 +1,241 @@
+import Link from 'next/link';
+import { FunctionComponent, useContext } from 'react';
+import styled from 'styled-components';
+
+import {
+  ServerDataContext,
+  useToggles,
+} from '@weco/common/server-data/Context';
+import { GalleryExhibitionData } from '@weco/common/server-data/types';
+import { Container } from '@weco/common/views/components/styled/Container';
+import Space from '@weco/common/views/components/styled/Space';
+
+const ExhibitionNavWrapper = styled.div`
+  background-color: ${props => props.theme.color('warmNeutral.300')};
+  padding: ${props => props.theme.spacingUnit * 3}px 0;
+`;
+
+const NavGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: ${props => props.theme.spacingUnit * 2}px;
+  align-items: center;
+`;
+
+const NavButton = styled.a<{ $disabled?: boolean }>`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit * 2}px
+    ${props => props.theme.spacingUnit * 3}px;
+  background-color: ${props => props.theme.color('black')};
+  color: ${props => props.theme.color('white')};
+  text-decoration: none;
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  font-weight: bold;
+  text-align: center;
+
+  ${props =>
+    props.$disabled &&
+    `
+    background-color: ${props.theme.color('neutral.500')};
+    cursor: not-allowed;
+    pointer-events: none;
+  `}
+
+  &:hover:not([disabled]) {
+    background-color: ${props => props.theme.color('neutral.700')};
+  }
+`;
+
+const ExhibitionTitle = styled.h2`
+  font-size: 1.2rem;
+  margin: 0;
+  text-align: center;
+  font-weight: bold;
+`;
+
+const DescriptionText = styled.p`
+  margin: ${props => props.theme.spacingUnit * 2}px 0 0 0;
+  text-align: center;
+  font-size: 1rem;
+  line-height: 1.5;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+const RelatedLinks = styled.div`
+  margin-top: ${props => props.theme.spacingUnit * 3}px;
+  padding-top: ${props => props.theme.spacingUnit * 3}px;
+  border-top: 1px solid ${props => props.theme.color('neutral.400')};
+`;
+
+const RelatedTitle = styled.h3`
+  font-size: 1rem;
+  margin: 0 0 ${props => props.theme.spacingUnit * 2}px 0;
+  font-weight: bold;
+`;
+
+const RelatedLinksList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacingUnit}px;
+
+  ${props => props.theme.media('sm')`
+    flex-direction: row;
+    gap: 1rem;
+  `}
+`;
+
+const RelatedLink = styled.a`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit}px
+    ${props => props.theme.spacingUnit * 2}px;
+  background-color: ${props => props.theme.color('white')};
+  color: ${props => props.theme.color('black')};
+  text-decoration: none;
+  border: 2px solid ${props => props.theme.color('black')};
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  text-align: center;
+
+  &:hover {
+    background-color: ${props => props.theme.color('neutral.200')};
+  }
+`;
+
+type ExhibitionContext = {
+  exhibition: GalleryExhibitionData;
+  exhibitionId: string;
+  currentIndex: number;
+  prevStoryId?: string;
+  nextStoryId?: string;
+};
+
+function findExhibitionContext(
+  storyId: string,
+  exhibitionExtras: Record<string, GalleryExhibitionData>
+): ExhibitionContext | null {
+  for (const [exhibitionId, exhibition] of Object.entries(exhibitionExtras)) {
+    const currentIndex = exhibition.stories.indexOf(storyId);
+    if (currentIndex !== -1) {
+      const prevStoryId =
+        currentIndex > 0 ? exhibition.stories[currentIndex - 1] : undefined;
+      const nextStoryId =
+        currentIndex < exhibition.stories.length - 1
+          ? exhibition.stories[currentIndex + 1]
+          : undefined;
+
+      return {
+        exhibition,
+        exhibitionId,
+        currentIndex,
+        prevStoryId,
+        nextStoryId,
+      };
+    }
+  }
+  return null;
+}
+
+type Props = {
+  storyId: string;
+};
+
+export const ExhibitionStoryNavigation: FunctionComponent<Props> = ({
+  storyId,
+}) => {
+  const { inGallery = false } = useToggles();
+  const serverData = useContext(ServerDataContext);
+  const { exhibitionExtras } = serverData;
+
+  if (!inGallery) {
+    return null;
+  }
+
+  const context = findExhibitionContext(storyId, exhibitionExtras);
+
+  if (!context) {
+    return null;
+  }
+
+  const { exhibition, exhibitionId, currentIndex, prevStoryId, nextStoryId } =
+    context;
+  const firstWork = exhibition.works[0];
+  const firstCluster = exhibition.collectionClusters[0];
+
+  return (
+    <ExhibitionNavWrapper data-component="ExhibitionStoryNavigation">
+      <Container>
+        <Space
+          $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+        >
+          <ExhibitionTitle>
+            Related to {exhibition.title || exhibitionId}
+          </ExhibitionTitle>
+          <DescriptionText>
+            The exhibition curators for {exhibition.title || exhibitionId} have
+            identified this, and several other stories, as exploring the themes
+            of the exhibition.
+          </DescriptionText>
+
+          <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+            <NavGrid>
+              <div style={{ textAlign: 'left' }}>
+                {prevStoryId ? (
+                  <Link
+                    href={`/stories/${prevStoryId}`}
+                    passHref
+                    legacyBehavior
+                  >
+                    <NavButton>← Previous story</NavButton>
+                  </Link>
+                ) : (
+                  <NavButton $disabled>← Previous story</NavButton>
+                )}
+              </div>
+
+              <div style={{ textAlign: 'center' }}>
+                <span>
+                  {currentIndex + 1} of {exhibition.stories.length}
+                </span>
+              </div>
+
+              <div style={{ textAlign: 'right' }}>
+                {nextStoryId ? (
+                  <Link
+                    href={`/stories/${nextStoryId}`}
+                    passHref
+                    legacyBehavior
+                  >
+                    <NavButton>Next story →</NavButton>
+                  </Link>
+                ) : (
+                  <NavButton $disabled>Next story →</NavButton>
+                )}
+              </div>
+            </NavGrid>
+          </Space>
+
+          {(firstWork || firstCluster) && (
+            <RelatedLinks>
+              <RelatedTitle>You may be interested in</RelatedTitle>
+              <RelatedLinksList>
+                {firstWork && (
+                  <Link href={`/works/${firstWork}`} passHref legacyBehavior>
+                    <RelatedLink>Related works</RelatedLink>
+                  </Link>
+                )}
+                {firstCluster && (
+                  <Link href={firstCluster.url} passHref legacyBehavior>
+                    <RelatedLink>More works like this</RelatedLink>
+                  </Link>
+                )}
+              </RelatedLinksList>
+            </RelatedLinks>
+          )}
+        </Space>
+      </Container>
+    </ExhibitionNavWrapper>
+  );
+};
+
+export default ExhibitionStoryNavigation;

--- a/content/webapp/views/pages/works/work/ExhibitionNavigation.tsx
+++ b/content/webapp/views/pages/works/work/ExhibitionNavigation.tsx
@@ -1,0 +1,230 @@
+import Link from 'next/link';
+import { FunctionComponent, useContext } from 'react';
+import styled from 'styled-components';
+
+import {
+  ServerDataContext,
+  useToggles,
+} from '@weco/common/server-data/Context';
+import { GalleryExhibitionData } from '@weco/common/server-data/types';
+import { Container } from '@weco/common/views/components/styled/Container';
+import Space from '@weco/common/views/components/styled/Space';
+
+const ExhibitionNavWrapper = styled.div`
+  background-color: ${props => props.theme.color('warmNeutral.300')};
+  padding: ${props => props.theme.spacingUnit * 3}px 0;
+`;
+
+const NavGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: ${props => props.theme.spacingUnit * 2}px;
+  align-items: center;
+`;
+
+const NavButton = styled.a<{ $disabled?: boolean }>`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit * 2}px
+    ${props => props.theme.spacingUnit * 3}px;
+  background-color: ${props => props.theme.color('black')};
+  color: ${props => props.theme.color('white')};
+  text-decoration: none;
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  font-weight: bold;
+  text-align: center;
+
+  ${props =>
+    props.$disabled &&
+    `
+    background-color: ${props.theme.color('neutral.500')};
+    cursor: not-allowed;
+    pointer-events: none;
+  `}
+
+  &:hover:not([disabled]) {
+    background-color: ${props => props.theme.color('neutral.700')};
+  }
+`;
+
+const ExhibitionTitle = styled.h2`
+  font-size: 1.2rem;
+  margin: 0;
+  text-align: center;
+  font-weight: bold;
+`;
+
+const DescriptionText = styled.p`
+  margin: ${props => props.theme.spacingUnit * 2}px 0 0 0;
+  text-align: center;
+  font-size: 1rem;
+  line-height: 1.5;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+const RelatedLinks = styled.div`
+  margin-top: ${props => props.theme.spacingUnit * 3}px;
+  padding-top: ${props => props.theme.spacingUnit * 3}px;
+  border-top: 1px solid ${props => props.theme.color('neutral.400')};
+`;
+
+const RelatedTitle = styled.h3`
+  font-size: 1rem;
+  margin: 0 0 ${props => props.theme.spacingUnit * 2}px 0;
+  font-weight: bold;
+`;
+
+const RelatedLinksList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${props => props.theme.spacingUnit}px;
+
+  ${props => props.theme.media('sm')`
+    flex-direction: row;
+    gap: 1rem;
+  `}
+`;
+
+const RelatedLink = styled.a`
+  display: inline-block;
+  padding: ${props => props.theme.spacingUnit}px
+    ${props => props.theme.spacingUnit * 2}px;
+  background-color: ${props => props.theme.color('white')};
+  color: ${props => props.theme.color('black')};
+  text-decoration: none;
+  border: 2px solid ${props => props.theme.color('black')};
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  text-align: center;
+
+  &:hover {
+    background-color: ${props => props.theme.color('neutral.200')};
+  }
+`;
+
+type ExhibitionContext = {
+  exhibition: GalleryExhibitionData;
+  exhibitionId: string;
+  currentIndex: number;
+  prevWorkId?: string;
+  nextWorkId?: string;
+};
+
+function findExhibitionContext(
+  workId: string,
+  exhibitionExtras: Record<string, GalleryExhibitionData>
+): ExhibitionContext | null {
+  for (const [exhibitionId, exhibition] of Object.entries(exhibitionExtras)) {
+    const currentIndex = exhibition.works.indexOf(workId);
+    if (currentIndex !== -1) {
+      const prevWorkId =
+        currentIndex > 0 ? exhibition.works[currentIndex - 1] : undefined;
+      const nextWorkId =
+        currentIndex < exhibition.works.length - 1
+          ? exhibition.works[currentIndex + 1]
+          : undefined;
+
+      return {
+        exhibition,
+        exhibitionId,
+        currentIndex,
+        prevWorkId,
+        nextWorkId,
+      };
+    }
+  }
+  return null;
+}
+
+type Props = {
+  workId: string;
+};
+
+export const ExhibitionNavigation: FunctionComponent<Props> = ({ workId }) => {
+  const { inGallery = false } = useToggles();
+  const serverData = useContext(ServerDataContext);
+  const { exhibitionExtras } = serverData;
+
+  if (!inGallery) {
+    return null;
+  }
+
+  const context = findExhibitionContext(workId, exhibitionExtras);
+
+  if (!context) {
+    return null;
+  }
+
+  const { exhibition, exhibitionId, currentIndex, prevWorkId, nextWorkId } =
+    context;
+  const firstStory = exhibition.stories[0];
+  const firstCluster = exhibition.collectionClusters[0];
+
+  return (
+    <ExhibitionNavWrapper data-component="ExhibitionNavigation">
+      <Container>
+        <Space
+          $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+        >
+          <ExhibitionTitle>
+            Featured in {exhibition.title || exhibitionId}
+          </ExhibitionTitle>
+          <DescriptionText>
+            This work is part of the {exhibition.title || exhibitionId}{' '}
+            exhibition.
+          </DescriptionText>
+
+          <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+            <NavGrid>
+              <div style={{ textAlign: 'left' }}>
+                {prevWorkId ? (
+                  <Link href={`/works/${prevWorkId}`} passHref legacyBehavior>
+                    <NavButton>← Previous work</NavButton>
+                  </Link>
+                ) : (
+                  <NavButton $disabled>← Previous work</NavButton>
+                )}
+              </div>
+
+              <div style={{ textAlign: 'center' }}>
+                <span>
+                  {currentIndex + 1} of {exhibition.works.length}
+                </span>
+              </div>
+
+              <div style={{ textAlign: 'right' }}>
+                {nextWorkId ? (
+                  <Link href={`/works/${nextWorkId}`} passHref legacyBehavior>
+                    <NavButton>Next work →</NavButton>
+                  </Link>
+                ) : (
+                  <NavButton $disabled>Next work →</NavButton>
+                )}
+              </div>
+            </NavGrid>
+          </Space>
+
+          {(firstStory || firstCluster) && (
+            <RelatedLinks>
+              <RelatedTitle>You may be interested in</RelatedTitle>
+              <RelatedLinksList>
+                {firstStory && (
+                  <Link href={`/stories/${firstStory}`} passHref legacyBehavior>
+                    <RelatedLink>Related stories</RelatedLink>
+                  </Link>
+                )}
+                {firstCluster && (
+                  <Link href={firstCluster.url} passHref legacyBehavior>
+                    <RelatedLink>More works like this</RelatedLink>
+                  </Link>
+                )}
+              </RelatedLinksList>
+            </RelatedLinks>
+          )}
+        </Space>
+      </Container>
+    </ExhibitionNavWrapper>
+  );
+};
+
+export default ExhibitionNavigation;


### PR DESCRIPTION
- For #13039

## What does this change?

Here's what's on the in-gallery branch:

- Add exhibitions data to serverData context — includes mock data for it
- Remove footer content if inGallery toggle is enabled
- Add component for navigating between curated items/stories
- Add a potential landing page for the curated content
– Add component for redirecting after no interaction (idle timeout)
- Add components for navigating between curated pages
- Show different navigation based on inGallery toggle
- Don't render external links if inGallery
- Pass inGallery to default serialiser
- Make sure dropCap also uses inGallery value

In short: a proof-of-concept for an "in gallery" kiosk mode — toggled via a feature flag — that strips external links, swaps navigation for curated page navigation, hides the footer, adds an idle redirect, and provides a landing page for curated content.


## How to test

Proof on concept in [inGallery branch](https://github.com/wellcomecollection/wellcomecollection.org/tree/in-gallery)

Can start journey from https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/extras


## Have we considered potential risks?

⚠️ This PR is not to be merged ⚠️  so no risk 