### PR TITLE
Re-add the download button on work pages

### DIFF
--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -120,10 +120,14 @@ const ItemPageLink = ({
   const { userIsStaffWithRestricted } = useUserContext();
   const { extendedViewer } = useToggles();
 
-  // TODO can remove when we move over to extendedViewer permanently
   const isDownloadable =
     digitalLocationInfo?.accessCondition !== 'open-with-advisory' &&
     downloadOptions.length > 0;
+
+  const canDownload =
+    isDownloadable &&
+    (digitalLocationInfo?.accessCondition !== 'restricted' ||
+      userIsStaffWithRestricted);
 
   const isWorkVisibleWithPermission =
     digitalLocationInfo?.accessCondition === 'restricted' &&
@@ -193,7 +197,7 @@ const ItemPageLink = ({
           </ConditionalWrapper>
         )}
 
-        {(itemUrl || (isDownloadable && !extendedViewer)) && (
+        {(itemUrl || canDownload) && (
           <Space
             $v={{ size: 'xs', properties: ['margin-top'] }}
             style={{ display: 'flex' }}
@@ -211,14 +215,12 @@ const ItemPageLink = ({
                 />
               </Space>
             )}
-            {isDownloadable &&
-              !extendedViewer &&
-              !userIsStaffWithRestricted && (
-                <Download
-                  ariaControlsId="itemDownloads"
-                  downloadOptions={downloadOptions}
-                />
-              )}
+            {canDownload && (
+              <Download
+                ariaControlsId="itemDownloads"
+                downloadOptions={downloadOptions}
+              />
+            )}
           </Space>
         )}
       </ConditionalWrapper>


### PR DESCRIPTION
- For #13072 

## What does this change?

Reintroduces functionality that accidentally got removed in [this PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/12769/changes/e8ab23a3e103b12ae4b18508039b3f919914972e).

## How to test

- Check [unrestricted work](https://www-dev.wellcomecollection.org/works/euzx4wfr) displays download button
- Check [restricted whole item items page](https://www-dev.wellcomecollection.org/works/rp9jnamu/items) is only accessible when logged in with the relevant permissions

## Have we considered potential risks?

Things like [this](https://www-dev.wellcomecollection.org/works/zu2q4k2w) have a confusing download behaviour, but we know about it
