### PR TITLE
Change conditionals for new Exhibition section

### DIFF
--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -47,7 +47,9 @@ const ExhibitionCollectionsContent = ({
   const { verticalVideos } = useToggles();
 
   const shouldDisplay =
-    shouldDisplayStories || shouldDisplayThemes || videos.length > 0;
+    shouldDisplayStories ||
+    shouldDisplayThemes ||
+    (videos.length > 0 && verticalVideos);
 
   if (!shouldDisplay) return null;
 


### PR DESCRIPTION
- For #

## What does this change?

The section displays if the document has a video, even if the toggle is turned off. When there are no stories or Themes, it looks off. It's unlikely to affect any exhibitions really but might as well.


## How to test

Only have [this toggle on](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection), add a video to an exhibition without themes or stories and see if it displays or not.

## Have we considered potential risks?
NA