### PR TITLE
Reading room stories kiosk prototype

### DIFF
--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -1,0 +1,52 @@
+import { NextPage } from 'next';
+
+import { getServerData } from '@weco/common/server-data';
+import { serialiseProps } from '@weco/common/utils/json';
+import { isNotUndefined } from '@weco/common/utils/type-guards';
+import {
+  ServerSideProps,
+  ServerSidePropsOrAppError,
+} from '@weco/common/views/pages/_app';
+import { createClient } from '@weco/content/services/prismic/fetch';
+import { fetchPage } from '@weco/content/services/prismic/fetch/pages';
+import { transformPage } from '@weco/content/services/prismic/transformers/pages';
+import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import KioskStoriesListingPage, {
+  Props as KioskStoriesListingPageProps,
+} from '@weco/content/views/pages/stories/kiosk';
+
+const Page: NextPage<KioskStoriesListingPageProps> = props => {
+  return <KioskStoriesListingPage {...props} />;
+};
+
+type Props = ServerSideProps<KioskStoriesListingPageProps>;
+
+export const getServerSideProps: ServerSidePropsOrAppError<
+  Props
+> = async context => {
+  setCacheControl(context.res);
+  const serverData = await getServerData(context);
+
+  if (!serverData.toggles.storiesKiosk.value) {
+    return { notFound: true };
+  }
+
+  const client = createClient(context);
+
+  const pageDocument = await fetchPage(client, 'reading-room-stories');
+
+  if (isNotUndefined(pageDocument)) {
+    const page = transformPage(pageDocument);
+
+    return {
+      props: serialiseProps<Props>({
+        page,
+        serverData,
+      }),
+    };
+  }
+
+  return { notFound: true };
+};
+
+export default Page;

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -9,7 +9,12 @@ import {
 } from '@weco/common/views/pages/_app';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import { fetchPage } from '@weco/content/services/prismic/fetch/pages';
+import { fetchSeriesById } from '@weco/content/services/prismic/fetch/series';
 import { transformPage } from '@weco/content/services/prismic/transformers/pages';
+import {
+  transformSeries,
+  transformSeriesToSeriesBasic,
+} from '@weco/content/services/prismic/transformers/series';
 import { setCacheControl } from '@weco/content/utils/setCacheControl';
 import KioskStoriesListingPage, {
   Props as KioskStoriesListingPageProps,
@@ -38,9 +43,23 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   if (isNotUndefined(pageDocument)) {
     const page = transformPage(pageDocument);
 
+    const pickingSkinSeries = await fetchSeriesById(
+      client,
+      'ZlgpmhEAACIAr-YE',
+      'series'
+    );
+    const beautyBoardroomSeries = await fetchSeriesById(
+      client,
+      'ZS5vzRIAACcAM_SF',
+      'series'
+    );
+
     return {
       props: serialiseProps<Props>({
         page,
+        hardCodedSeries: [pickingSkinSeries, beautyBoardroomSeries]
+          .filter(isNotUndefined)
+          .map(doc => transformSeriesToSeriesBasic(transformSeries(doc))),
         serverData,
       }),
     };

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -43,16 +43,10 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   if (isNotUndefined(pageDocument)) {
     const page = transformPage(pageDocument);
 
-    const pickingSkinSeries = await fetchSeriesById(
-      client,
-      'ZlgpmhEAACIAr-YE',
-      'series'
-    );
-    const beautyBoardroomSeries = await fetchSeriesById(
-      client,
-      'ZS5vzRIAACcAM_SF',
-      'series'
-    );
+    const [pickingSkinSeries, beautyBoardroomSeries] = await Promise.all([
+      fetchSeriesById(client, 'ZlgpmhEAACIAr-YE', 'series'),
+      fetchSeriesById(client, 'ZS5vzRIAACcAM_SF', 'series'),
+    ]);
 
     return {
       props: serialiseProps<Props>({

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -32,7 +32,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.storiesKiosk.value) {
+  if (!serverData.toggles.storiesKiosk?.value) {
     return { notFound: true };
   }
 

--- a/content/webapp/services/prismic/fetch/series.ts
+++ b/content/webapp/services/prismic/fetch/series.ts
@@ -23,14 +23,19 @@ const seriesFetcher = (contentType: 'webcomic-series' | 'series') =>
 
 export const fetchSeries = seriesFetcher('series').getByType;
 
-export const fetchSeriesById = async (
+type SeriesContentTypeMap = {
+  series: RawSeriesDocument;
+  'webcomic-series': RawWebcomicSeriesDocument;
+};
+
+export async function fetchSeriesById<T extends keyof SeriesContentTypeMap>(
   client: GetServerSidePropsPrismicClient,
   id: string,
-  contentType: 'webcomic-series' | 'series'
-): Promise<RawSeriesDocument | RawWebcomicSeriesDocument | undefined> => {
+  contentType: T
+): Promise<SeriesContentTypeMap[T] | undefined> {
   const seriesDocument =
     (await seriesFetcher(contentType).getByUid(client, id)) ||
     (await seriesFetcher(contentType).getById(client, id));
 
-  return seriesDocument;
-};
+  return seriesDocument as SeriesContentTypeMap[T] | undefined;
+}

--- a/content/webapp/views/pages/stories/kiosk/index.tsx
+++ b/content/webapp/views/pages/stories/kiosk/index.tsx
@@ -1,19 +1,72 @@
-import { SliceZone } from '@prismicio/react';
+import styled from 'styled-components';
 
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader';
+import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
+import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
+import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import PageLayout from '@weco/common/views/layouts/PageLayout';
-import { components } from '@weco/common/views/slices';
+import { transformContentListSlice } from '@weco/content/services/prismic/transformers/body';
+import { ArticleBasic } from '@weco/content/types/articles';
+import { isContentList } from '@weco/content/types/body';
+import { convertItemToCardProps } from '@weco/content/types/card';
 import { Page } from '@weco/content/types/pages';
+import { SeriesBasic } from '@weco/content/types/series';
+import Card from '@weco/content/views/components/Card';
+import SectionHeader from '@weco/content/views/components/SectionHeader';
+import StoryCard from '@weco/content/views/components/StoryCard';
 
 export type Props = {
   page: Page;
+  hardCodedSeries: SeriesBasic[];
 };
 
-const KioskStoriesListingPage = ({ page }: Props) => {
+const CardGridWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: ${props => props.theme.spacingUnit * 4}px;
+`;
+
+type StorySectionProps = {
+  title: string;
+  articles: ArticleBasic[];
+};
+
+const StorySection = ({ title, articles }: StorySectionProps) => {
+  if (articles.length === 0) return null;
+
+  return (
+    <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
+      <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
+        <SectionHeader title={title} gridSize={gridSize12()} />
+      </Space>
+
+      <Container>
+        <SpacingComponent>
+          <CardGridWrapper>
+            {articles.map(article => (
+              <StoryCard
+                key={article.id}
+                variant="prismic"
+                article={article}
+                showAllLabels
+              />
+            ))}
+          </CardGridWrapper>
+        </SpacingComponent>
+      </Container>
+    </Space>
+  );
+};
+
+const KioskStoriesListingPage = ({ page, hardCodedSeries }: Props) => {
   const introText = page.introText;
+  const contentLists = page.untransformedBody
+    .filter(isContentList)
+    .map(transformContentListSlice)
+    .slice(0, 2);
 
   return (
     <PageLayout
@@ -34,11 +87,44 @@ const KioskStoriesListingPage = ({ page }: Props) => {
       <PageHeader variant="landing" title={page.title} introText={introText} />
 
       <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
-        <SliceZone
-          slices={page.untransformedBody}
-          components={components}
-          context={{ gridSizes: gridSize12() }}
-        />
+        {contentLists[0] && (
+          <StorySection
+            title={contentLists[0].value.title || ''}
+            articles={contentLists[0].value.items.filter(
+              (item): item is ArticleBasic => item.type === 'articles'
+            )}
+          />
+        )}
+
+        {hardCodedSeries.length > 0 && (
+          <SpacingSection>
+            <SpacingComponent>
+              <SectionHeader title="Series" gridSize={gridSize12()} />
+            </SpacingComponent>
+
+            <SpacingComponent>
+              <Container>
+                <CardGridWrapper>
+                  {hardCodedSeries.map(series => (
+                    <Card
+                      key={series.id}
+                      item={convertItemToCardProps(series)}
+                    />
+                  ))}
+                </CardGridWrapper>
+              </Container>
+            </SpacingComponent>
+          </SpacingSection>
+        )}
+
+        {contentLists[1] && (
+          <StorySection
+            title={contentLists[1].value.title || ''}
+            articles={contentLists[1].value.items.filter(
+              (item): item is ArticleBasic => item.type === 'articles'
+            )}
+          />
+        )}
       </Space>
     </PageLayout>
   );

--- a/content/webapp/views/pages/stories/kiosk/index.tsx
+++ b/content/webapp/views/pages/stories/kiosk/index.tsx
@@ -1,4 +1,11 @@
+import { SliceZone } from '@prismicio/react';
+
+import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
+import { gridSize12 } from '@weco/common/views/components/Layout';
+import PageHeader from '@weco/common/views/components/PageHeader';
+import Space from '@weco/common/views/components/styled/Space';
 import PageLayout from '@weco/common/views/layouts/PageLayout';
+import { components } from '@weco/common/views/slices';
 import { Page } from '@weco/content/types/pages';
 
 export type Props = {
@@ -6,6 +13,8 @@ export type Props = {
 };
 
 const KioskStoriesListingPage = ({ page }: Props) => {
+  const introText = page.introText;
+
   return (
     <PageLayout
       openGraphType={'website' as const}
@@ -15,16 +24,22 @@ const KioskStoriesListingPage = ({ page }: Props) => {
       description={page.metadataDescription || page.promo?.caption || ''}
       url={{ pathname: '/stories/kiosk' }}
       image={page.image}
-      apiToolbarLinks={[]} // TODO add Edit Prismic page
-      headerProps={{ hasColorBackground: true }}
+      apiToolbarLinks={[createPrismicLink(page.id)]}
       clipOverflowX
       hideNewsletterPromo
       hideFooter
       hideHeader
       isNoIndex
     >
-      <h1>Kiosk Stories Listing Page</h1>
-      {/* Content for listing kiosk stories goes here */}
+      <PageHeader variant="landing" title={page.title} introText={introText} />
+
+      <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
+        <SliceZone
+          slices={page.untransformedBody}
+          components={components}
+          context={{ gridSizes: gridSize12() }}
+        />
+      </Space>
     </PageLayout>
   );
 };

--- a/content/webapp/views/pages/stories/kiosk/index.tsx
+++ b/content/webapp/views/pages/stories/kiosk/index.tsx
@@ -1,0 +1,32 @@
+import PageLayout from '@weco/common/views/layouts/PageLayout';
+import { Page } from '@weco/content/types/pages';
+
+export type Props = {
+  page: Page;
+};
+
+const KioskStoriesListingPage = ({ page }: Props) => {
+  return (
+    <PageLayout
+      openGraphType={'website' as const}
+      jsonLd={[]}
+      siteSection="stories"
+      title={page.title}
+      description={page.metadataDescription || page.promo?.caption || ''}
+      url={{ pathname: '/stories/kiosk' }}
+      image={page.image}
+      apiToolbarLinks={[]} // TODO add Edit Prismic page
+      headerProps={{ hasColorBackground: true }}
+      clipOverflowX
+      hideNewsletterPromo
+      hideFooter
+      hideHeader
+      isNoIndex
+    >
+      <h1>Kiosk Stories Listing Page</h1>
+      {/* Content for listing kiosk stories goes here */}
+    </PageLayout>
+  );
+};
+
+export default KioskStoriesListingPage;

--- a/content/webapp/views/pages/stories/kiosk/index.tsx
+++ b/content/webapp/views/pages/stories/kiosk/index.tsx
@@ -37,11 +37,15 @@ type StorySectionProps = {
 const StorySection = ({ title, articles }: StorySectionProps) => {
   if (articles.length === 0) return null;
 
+  const hasTitle = title.trim().length > 0;
+
   return (
     <Space $v={{ size: 'xl', properties: ['padding-bottom'] }}>
-      <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
-        <SectionHeader title={title} gridSize={gridSize12()} />
-      </Space>
+      {hasTitle && (
+        <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
+          <SectionHeader title={title} gridSize={gridSize12()} />
+        </Space>
+      )}
 
       <Container>
         <SpacingComponent>

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-typescript": "^7.28.5",
+    "@eslint/js": "^10.0.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.0",
     "@testing-library/react": "^16.3.0",
@@ -55,7 +56,6 @@
     "@types/prompts": "^2.4.4",
     "@types/react": "19.2.2",
     "@types/react-window": "^1.8.5",
-    "@eslint/js": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^8.59.2",
     "@typescript-eslint/parser": "^8.59.2",
     "babel-core": "^7.0.0-bridge.0",
@@ -73,7 +73,6 @@
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "typescript-eslint": "^8.59.2",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
@@ -88,6 +87,7 @@
     "ts-jest": "29.4.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.59.2",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {


### PR DESCRIPTION
- For #13076 

## What does this change?

Adds a new `/stories/kiosk` page for the Reading Room in-venue digital experience. This is a prototype landing page designed for iPad kiosks that displays curated story content to visitors.

The page:
- Is gated behind the `storiesKiosk` toggle so it's not publicly accessible
- Is marked `noindex` so search engines won't crawl it
- Hides the site header and footer for a kiosk-friendly layout
- Pulls content from a Prismic page document (`reading-room-stories`), rendering up to two content list sections as article cards in a two-column grid
- Displays hardcoded series (currently "Picking at the skin of...​" and "From the beauty counter to the boardroom") as cards between the content lists
- Uses existing components (`StoryCard`, `Card`, `SectionHeader`) for consistency

Also refactors `fetchSeriesById` to use a generic with a `SeriesContentTypeMap` so the return type is correctly narrowed based on the `contentType` argument, removing the need for overloads. I thought, if we have to specify 'series' or 'webcomic-series' already, it should return the relevant type only.

> [!NOTE]
> Lots is missing from the prototype yet, but gotta start somewhere (see ticket for more info)

## How to test

1. Enable the [`storiesKiosk` toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=storiesKiosk)
2. Navigate to https://www-dev.wellcomecollection.org/stories/kiosk
3. Verify the page renders with a header, content list sections with article cards, and a series section with series cards
4. Verify the page has no site header/footer
5. Verify the page is not accessible when the toggle is off (returns 404)

## Have we considered potential risks?

Low risk — this is a new page behind a toggle with no impact on existing functionality. The `fetchSeriesById` refactor maintains the same behaviour with better type narrowing; existing call sites are unaffected.
