### PR TITLE
Move OCR text from alt to aria-describedby element

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
@@ -34,7 +34,7 @@ type Props = {
   srcSet: string | undefined;
   sizes: string | undefined;
   alt: string;
-  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
   lang?: string;
   clickHandler?: () => void | Promise<void>;
   loadHandler?: () => void | Promise<void>;
@@ -53,7 +53,7 @@ const IIIFViewerImage = (
     srcSet,
     sizes,
     alt,
-    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribeddBy,
     lang,
     clickHandler,
     loadHandler,
@@ -75,7 +75,7 @@ const IIIFViewerImage = (
         ref={ref}
         tabIndex={tabIndex}
         lang={lang}
-        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribeddBy}
         width={width}
         height={height}
         className="image"

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
@@ -34,7 +34,7 @@ type Props = {
   srcSet: string | undefined;
   sizes: string | undefined;
   alt: string;
-  'aria-describedby'?: string;
+  ariaDescribedBy?: string;
   lang?: string;
   clickHandler?: () => void | Promise<void>;
   loadHandler?: () => void | Promise<void>;
@@ -53,7 +53,7 @@ const IIIFViewerImage = (
     srcSet,
     sizes,
     alt,
-    'aria-describedby': ariaDescribeddBy,
+    ariaDescribedBy,
     lang,
     clickHandler,
     loadHandler,
@@ -75,7 +75,7 @@ const IIIFViewerImage = (
         ref={ref}
         tabIndex={tabIndex}
         lang={lang}
-        aria-describedby={ariaDescribeddBy}
+        aria-describedby={ariaDescribedBy}
         width={width}
         height={height}
         className="image"

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
@@ -34,6 +34,7 @@ type Props = {
   srcSet: string | undefined;
   sizes: string | undefined;
   alt: string;
+  'aria-labelledby'?: string;
   lang?: string;
   clickHandler?: () => void | Promise<void>;
   loadHandler?: () => void | Promise<void>;
@@ -52,6 +53,7 @@ const IIIFViewerImage = (
     srcSet,
     sizes,
     alt,
+    'aria-labelledby': ariaLabelledBy,
     lang,
     clickHandler,
     loadHandler,
@@ -73,6 +75,7 @@ const IIIFViewerImage = (
         ref={ref}
         tabIndex={tabIndex}
         lang={lang}
+        aria-labelledby={ariaLabelledBy}
         width={width}
         height={height}
         className="image"

--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
@@ -150,7 +150,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
         lang={work.languageId}
         aria-describedby={`image-${index + 1}`}
-        alt={`image ${index + 1}`}
+        alt={`digitised image ${index + 1}`}
         clickHandler={() => {
           setShowZoomed(true);
         }}

--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
@@ -149,7 +149,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         srcSet={imageSrcSet}
         sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
         lang={work.languageId}
-        aria-describedby={`image-${index + 1}`}
+        aria-describedby={alt ? `image-${index + 1}` : undefined}
         alt={`digitised image ${index + 1}`}
         clickHandler={() => {
           setShowZoomed(true);
@@ -160,9 +160,11 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         errorHandler={errorHandler}
         zoomOnClick={true}
       />
-      <span className="visually-hidden" id={`image-${index + 1}`}>
-        {alt}
-      </span>
+      {alt ? (
+        <span className="visually-hidden" id={`image-${index + 1}`}>
+          {alt}
+        </span>
+      ) : null}
     </ImageWrapper>
   );
 };

--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
@@ -149,7 +149,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         srcSet={imageSrcSet}
         sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
         lang={work.languageId}
-        aria-describedby={alt ? `image-${index + 1}` : undefined}
+        ariaDescribedBy={alt ? `image-${index + 1}` : undefined}
         alt={`digitised image ${index + 1}`}
         clickHandler={() => {
           setShowZoomed(true);

--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
@@ -150,7 +150,8 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         srcSet={imageSrcSet}
         sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
         lang={work.languageId}
-        alt={alt}
+        aria-labelledby={`image-${index}`}
+        alt=""
         clickHandler={() => {
           setShowZoomed(true);
         }}
@@ -160,6 +161,9 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         errorHandler={errorHandler}
         zoomOnClick={true}
       />
+      <span className="visually-hidden" id={`image-${index}`}>
+        {alt}
+      </span>
     </ImageWrapper>
   );
 };

--- a/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ImageViewer.tsx
@@ -21,7 +21,6 @@ const ImageWrapper = styled.div<{
 
   img {
     margin: 10px auto;
-    overflow: scroll; /* for alt text, which can be long */
     width: unset;
     height: revert-layer;
     display: block;
@@ -150,8 +149,8 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         srcSet={imageSrcSet}
         sizes="(min-width: 860px) 800px, calc(92.59vw + 22px)"
         lang={work.languageId}
-        aria-labelledby={`image-${index}`}
-        alt=""
+        aria-describedby={`image-${index + 1}`}
+        alt={`image ${index + 1}`}
         clickHandler={() => {
           setShowZoomed(true);
         }}
@@ -161,7 +160,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         errorHandler={errorHandler}
         zoomOnClick={true}
       />
-      <span className="visually-hidden" id={`image-${index}`}>
+      <span className="visually-hidden" id={`image-${index + 1}`}>
         {alt}
       </span>
     </ImageWrapper>

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -252,8 +252,8 @@ test('(15) | The location of the search results should be displayed', async ({
 
 test('(16) | Images should have unique alt text', async ({ page, context }) => {
   await itemWithAltText({ canvasNumber: 2 }, context, page);
-  await expect(page.getByAltText('22102033982')).toBeVisible();
-  expect(await page.getByAltText('22102033982').count()).toEqual(1);
+  await expect(page.getByAltText('digitised image 2')).toBeVisible();
+  expect(await page.getByAltText('digitised image 2').count()).toEqual(1);
 });
 
 test('(17) | An item with only open access items will not display a modal and display the content', async ({
@@ -587,4 +587,16 @@ test('(39) | Mobile pagination updates content in main viewer', async ({
     await previousLink.click();
     await checkPageIndicator(page, '1/27', 'bottombar');
   }
+});
+test('(40) | OCR text should be accessible to screenreaders', async ({
+  page,
+  context,
+}) => {
+  await itemWithAltText({ canvasNumber: 2 }, context, page);
+  const img = page.getByAltText('digitised image 2');
+  await expect(img).toBeVisible();
+
+  const describedById = await img.getAttribute('aria-describedby');
+  expect(describedById).toBeTruthy();
+  await expect(page.locator(`#${describedById}`)).toContainText('22102033982');
 });


### PR DESCRIPTION
- For #12644

## What does this change?

Moves the OCR text from the `alt` attribute into a visually-hidden element that is still accessible to screenreaders (linked by `aria-describedby`).

`alt` is semantically wrong for long text and only appropriate for a brief description. In this case it is still important to include _something_ for the `alt` attribute (the images aren't decorative), and `"digitised image {x}"` felt reasonable given the available (i.e. not much) data.

## How to test

Honestly not too sure, but I've been doing

1. Launch VoiceOver
2. Visit [a page with OCR-ed text](https://www-dev.wellcomecollection.org/works/wuumj5c8/items?canvas=30)
3. Press ctrl-option-U to bring up the Web Rotor
4. Use left/right arrows to get to the Form Controls menu
5. Down arrow to get to images, check screenreader reads e.g. 'digitised image x', followed by the OCR content of the page

## Have we considered potential risks?

We don't have a good handle on how screenreader users would interact with this content for real, so we're not sure if this is a good experience or not. Hopefully this could be tested.
