### PR TITLE
Restructure toggles so it's an umbrella term for "feature flags" and "A/B tests"

### DIFF
--- a/common/server-data/Context.tsx
+++ b/common/server-data/Context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 
-import { TestId, ToggleId } from '@weco/toggles';
+import { FeatureFlagId, TestId } from '@weco/toggles';
 
 import { SimplifiedPrismicData } from './prismic';
 import { defaultServerData, SimplifiedServerData } from './types';
@@ -16,20 +16,32 @@ export const ServerDataContext =
  * These are convenience methods to access properties off ServerData
  * without having to decontruct it. i.e.
  * This:
- * `const { toggleName } = useToggles()`
+ * `const { featureFlagName } = useFeatureFlags()`
  * Over:
- * `const { toggles: { toggleName } } = useContext(ServerDataContext)`
+ * `const { toggles: { featureFlagName } } = useContext(ServerDataContext)`
  */
 
-type ClientToggleValues = Record<ToggleId | TestId, boolean | undefined>;
+type FeatureFlagValue = Record<FeatureFlagId, boolean | undefined>;
+type ABTestValue = Record<TestId, boolean | undefined>;
 
-export const useToggles = (): ClientToggleValues => {
+export const useFeatureFlags = (): FeatureFlagValue => {
   const data = useContext(ServerDataContext);
-  const toggles = Object.keys(data.toggles).reduce((acc, key) => {
-    acc[key] = data.toggles[key].value;
-    return acc;
-  }, {});
-  return toggles;
+  return Object.keys(data.toggles)
+    .filter(key => data.toggles[key].type !== 'test')
+    .reduce((acc, key) => {
+      acc[key as FeatureFlagId] = data.toggles[key].value;
+      return acc;
+    }, {} as FeatureFlagValue);
+};
+
+export const useABTest = (): ABTestValue => {
+  const data = useContext(ServerDataContext);
+  return Object.keys(data.toggles)
+    .filter(key => data.toggles[key].type === 'test')
+    .reduce((acc, key) => {
+      acc[key as TestId] = data.toggles[key].value;
+      return acc;
+    }, {} as ABTestValue);
 };
 
 export const usePrismicData = (): SimplifiedPrismicData => {

--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -1,0 +1,66 @@
+import { IncomingMessage } from 'http';
+
+import { TogglesResp } from '@weco/toggles';
+
+import { Context, getTogglesFromContext } from './toggles';
+
+const mockContext: Context = {
+  req: {
+    cookies: {},
+  } as IncomingMessage & { cookies: Partial<Record<string, string>> },
+};
+
+Object.defineProperty(mockContext.req, 'headers', {
+  value: { host: 'www.wellcomecollection.org' },
+});
+
+const stagingApiFlag = {
+  id: 'stagingApi',
+  title: 'Staging API',
+  defaultValue: false,
+  description: 'Use the staging catalogue API',
+  type: 'permanent' as const,
+};
+
+describe('getTogglesFromContext', () => {
+  it('supports the new JSON format with featureFlags field', () => {
+    const togglesResp: TogglesResp = {
+      featureFlags: [stagingApiFlag],
+      tests: [],
+    };
+
+    const result = getTogglesFromContext(togglesResp, mockContext);
+
+    expect(result).toEqual({
+      stagingApi: { value: false, type: 'permanent' },
+    });
+  });
+
+  it('supports the old JSON format with toggles field', () => {
+    // Simulates the old S3 JSON shape before the rename
+    const togglesResp = {
+      toggles: [stagingApiFlag],
+      tests: [],
+    } as unknown as TogglesResp;
+
+    const result = getTogglesFromContext(togglesResp, mockContext);
+
+    expect(result).toEqual({
+      stagingApi: { value: false, type: 'permanent' },
+    });
+  });
+
+  it('prefers featureFlags over toggles if both are present', () => {
+    const togglesResp = {
+      featureFlags: [stagingApiFlag],
+      toggles: [Object.assign({}, stagingApiFlag, { id: 'oldField' })],
+      tests: [],
+    } as unknown as TogglesResp;
+
+    const result = getTogglesFromContext(togglesResp, mockContext);
+
+    expect(result).toEqual({
+      stagingApi: { value: false, type: 'permanent' },
+    });
+  });
+});

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -5,7 +5,7 @@ import { Toggles, TogglesResp } from '@weco/toggles';
 
 import { Handler } from './';
 
-const defaultValue = { toggles: [], tests: [] };
+const defaultValue = { featureFlags: [], tests: [] };
 
 async function fetchToggles(): Promise<TogglesResp> {
   const resp = await fetch(
@@ -20,7 +20,7 @@ const togglesHandler: Handler<TogglesResp, TogglesResp> = {
   fetch: fetchToggles,
 };
 
-type Context = {
+export type Context = {
   req: IncomingMessage & {
     cookies: Partial<{
       [key: string]: string;
@@ -39,7 +39,13 @@ export function getTogglesFromContext(
 ): Toggles {
   const isStage = context.req.headers.host?.startsWith('www-stage');
   const allCookies = getCookies(context);
-  const toggles = [...togglesResp.toggles]
+  // Support both old ({ toggles: [...] }) and new ({ featureFlags: [...] }) JSON formats
+  const featureFlagsList =
+    togglesResp.featureFlags ??
+    (togglesResp as unknown as { toggles: TogglesResp['featureFlags'] })
+      .toggles ??
+    [];
+  const featureFlags = featureFlagsList
     .filter(toggle => {
       return !(!isStage && toggle.type === 'stage');
     })
@@ -56,7 +62,7 @@ export function getTogglesFromContext(
       }),
       {} as Toggles
     );
-  const tests = [...togglesResp.tests].reduce((acc, test) => {
+  const tests = togglesResp.tests.reduce((acc, test) => {
     function testToggleValue(Id: string): boolean | undefined {
       const cookieValue = allCookies[`toggle_${Id}`];
       switch (cookieValue) {
@@ -76,7 +82,7 @@ export function getTogglesFromContext(
       },
     };
   }, {} as Toggles);
-  return { ...toggles, ...tests } as Toggles;
+  return { ...featureFlags, ...tests } as Toggles;
 }
 
 export default togglesHandler;

--- a/common/utils/cookies.ts
+++ b/common/utils/cookies.ts
@@ -1,4 +1,4 @@
-// You possibly/probably want `useToggles` instead of this. This function
+// You possibly/probably want `useFeatureFlags` instead of this. This function
 // returns an array of strings denoting which toggles a user has active/inactive.
 // Inactive toggles are prefixed with a !
 // This output is useful for display purposes (to show someone what they have turned

--- a/common/views/layouts/ErrorPage/index.tsx
+++ b/common/views/layouts/ErrorPage/index.tsx
@@ -59,7 +59,7 @@ const MessageBar = styled(Space).attrs({
  */
 const TogglesMessage: FunctionComponent = () => {
   // Note: we use this slightly non-standard construction rather than
-  // useToggles() because we don't have access to the server data context
+  // useFeatureFlags() because we don't have access to the server data context
   // here -- we can't use getServerSideProps on an error page.
   // See https://nextjs.org/docs/messages/404-get-initial-props
   const [toggles, setToggles] = useState<string[]>([]);
@@ -74,11 +74,16 @@ const TogglesMessage: FunctionComponent = () => {
 
       // Get the readable name
       if (activeTogglesInBrowser.length > 0) {
-        const allToggles = [...togglesList.toggles, ...togglesList.tests];
+        const flattenedTogglesList = [
+          ...togglesList.featureFlags,
+          ...togglesList.tests,
+        ];
         const activeToggleNames = activeTogglesInBrowser
           .map(
             id =>
-              Object.values(allToggles).find(toggle => toggle.id === id)?.title
+              Object.values(flattenedTogglesList).find(
+                toggle => toggle.id === id
+              )?.title
           )
           .filter(f => f);
         return activeToggleNames as string[];

--- a/common/views/layouts/PageLayout/index.tsx
+++ b/common/views/layouts/PageLayout/index.tsx
@@ -16,7 +16,10 @@ import { wellcomeCollectionGallery } from '@weco/common/data/organization';
 import { getCrop, ImageType } from '@weco/common/model/image';
 import { Url } from '@weco/common/model/link-props';
 import { SiteSection } from '@weco/common/model/site-section';
-import { usePrismicData, useToggles } from '@weco/common/server-data/Context';
+import {
+  useFeatureFlags,
+  usePrismicData,
+} from '@weco/common/server-data/Context';
 import { getVenueById } from '@weco/common/services/prismic/opening-times';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
@@ -90,7 +93,7 @@ const PageLayoutComponent: NextPage<Props> = ({
   clipOverflowX = false,
   isNoIndex = false,
 }) => {
-  const { apiToolbar, issuesBanner } = useToggles();
+  const { apiToolbar, issuesBanner } = useFeatureFlags();
   const urlString = convertUrlToString(url);
   const fullTitle =
     title !== ''

--- a/content/webapp/pages/api/works/[workId].tsx
+++ b/content/webapp/pages/api/works/[workId].tsx
@@ -19,7 +19,7 @@ const WorksApi = async (
   // this is a mega hack to get this working so we can remove toggles from the query
   // TODO : get toggles working here
   const togglesResp: TogglesResp = {
-    toggles: [
+    featureFlags: [
       {
         id: 'stagingApi',
         title: 'Staging API',

--- a/content/webapp/pages/api/works/items/[workId].tsx
+++ b/content/webapp/pages/api/works/items/[workId].tsx
@@ -60,7 +60,7 @@ const ItemsApi = async (
   // this is a mega hack to get this working so we can remove toggles from the query
   // TODO : get toggles working here
   const togglesResp: TogglesResp = {
-    toggles: [
+    featureFlags: [
       {
         id: 'stagingApi',
         title: 'Staging API',

--- a/content/webapp/views/components/ContentPage/index.tsx
+++ b/content/webapp/views/components/ContentPage/index.tsx
@@ -6,7 +6,7 @@ import {
   commissioningEditorRoleId,
   officialLandingPagesUid,
 } from '@weco/common/data/hardcoded-ids';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { ContentApiType } from '@weco/common/services/prismic/content-types';
 import { ElementFromComponent } from '@weco/common/utils/utility-types';
 import {
@@ -73,7 +73,7 @@ const ContentPage = ({
   showStaticLinkedWorks,
   contentApiType,
 }: Props): ReactElement => {
-  const { stagingApi } = useToggles();
+  const { stagingApi } = useFeatureFlags();
 
   const [linkedWorks, setLinkedWorks] = useState<ContentApiLinkedWork[]>([]);
 

--- a/content/webapp/views/components/PrototypeSearchSelects/index.tsx
+++ b/content/webapp/views/components/PrototypeSearchSelects/index.tsx
@@ -2,7 +2,7 @@ import { Router } from 'next/router';
 import { FunctionComponent } from 'react';
 import { useEffect, useState } from 'react';
 
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { SEARCH_PAGES_FORM_ID } from '@weco/common/utils/search';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
@@ -32,7 +32,8 @@ const PrototypeSearchSelects: FunctionComponent<Props> = ({
   currentApiSelection,
   showAllResultsOption = false,
 }) => {
-  const { semanticSearchPrototype, semanticSearchComparison } = useToggles();
+  const { semanticSearchPrototype, semanticSearchComparison } =
+    useFeatureFlags();
   const defaultApiSelection = showAllResultsOption ? 'all' : 'alternative1';
   const handleChange = () => {
     const form = document.getElementById(SEARCH_PAGES_FORM_ID);

--- a/content/webapp/views/layouts/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/views/layouts/SearchPageLayout/SearchNavigation.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { searchLabelText } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { capitalize } from '@weco/common/utils/grammar';
@@ -49,7 +49,7 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
 }) => {
   const router = useRouter();
   const { conceptsSearch, semanticSearchPrototype, semanticSearchComparison } =
-    useToggles();
+    useFeatureFlags();
 
   // Variable naming note:
   //

--- a/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Header.tsx
+++ b/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Header.tsx
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 import styled from 'styled-components';
 
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Breadcrumb, {
   getBreadcrumbItems,
@@ -38,7 +38,7 @@ const ThematicBrowsingHeader = ({
   introText?: string | prismic.RichTextField;
   extraBreadcrumbs?: { url: string; text: string }[];
 }) => {
-  const { thematicBrowsingSubCategory } = useToggles();
+  const { thematicBrowsingSubCategory } = useFeatureFlags();
 
   return (
     <>

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState } from 'react';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { ThemeCardsListSlice as RawThemeCardsListSlice } from '@weco/common/prismicio-types';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { dasherize, pluralize } from '@weco/common/utils/grammar';
 import {
   ContaineredLayout,
@@ -68,7 +68,7 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
   gridSizes,
   themeCardsListSlices,
 }) => {
-  const { thematicBrowsing } = useToggles();
+  const { thematicBrowsing } = useFeatureFlags();
 
   // Transform slices but ensure we only keep valid ones (valid title + concept IDs)
   const transformedThemeCardsListSlices = themeCardsListSlices

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { thematicBrowsingPaths } from '@weco/common/data/hardcoded-ids';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -106,7 +106,7 @@ const ThemeHeader: FunctionComponent<{
   concept: Concept;
   hasImages?: boolean;
 }> = ({ concept, hasImages }) => {
-  const { themePagesAllFields, thematicBrowsing } = useToggles();
+  const { themePagesAllFields, thematicBrowsing } = useFeatureFlags();
   const { config } = useConceptPageContext();
 
   const { narrowerThan, fieldsOfWork, people, relatedTo, broaderThan } =

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useTheme } from 'styled-components';
 
 import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -48,7 +48,7 @@ const ConceptPage: NextPage<Props> = ({
         .flat(),
     [sectionsData]
   );
-  const { themePagesAllFields } = useToggles();
+  const { themePagesAllFields } = useFeatureFlags();
   const [expandedImage, setExpandedImage] = useExpandedImage(allImages);
   const { config } = useConceptPageContext();
   const theme = useTheme();

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -2,7 +2,7 @@ import { SliceZone } from '@prismicio/react';
 import styled from 'styled-components';
 
 import { PortraitVideoListSlice } from '@weco/common/prismicio-types';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -44,7 +44,7 @@ const ExhibitionCollectionsContent = ({
     themeCardsListSlice && themeCardsListSlice.value.conceptIds.length > 0
   );
 
-  const { verticalVideos } = useToggles();
+  const { verticalVideos } = useFeatureFlags();
 
   const shouldDisplay =
     shouldDisplayStories ||

--- a/content/webapp/views/pages/exhibitions/exhibition/index.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/index.tsx
@@ -5,7 +5,7 @@ import {
   ExhibitionHighlightToursDocument,
   ExhibitionTextsDocument,
 } from '@weco/common/prismicio-types';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
@@ -55,7 +55,7 @@ const ExhibitionPage: NextPage<Props> = ({
     AboutThisExhibitionContent[]
   >([]);
 
-  const { exhibitionAndCollection } = useToggles();
+  const { exhibitionAndCollection } = useFeatureFlags();
 
   useEffect(() => {
     let isMounted = true;

--- a/content/webapp/views/pages/search/index.tsx
+++ b/content/webapp/views/pages/search/index.tsx
@@ -5,7 +5,7 @@ import { useSearchContext } from '@weco/common/contexts/SearchContext';
 import { arrow } from '@weco/common/icons';
 import {
   ServerDataContext,
-  useToggles,
+  useFeatureFlags,
 } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { formatNumber } from '@weco/common/utils/grammar';
@@ -65,7 +65,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
     const { query: queryString } = query;
     const { extraApiToolbarLinks, setExtraApiToolbarLinks } =
       useSearchContext();
-    const { apiToolbar } = useToggles();
+    const { apiToolbar } = useFeatureFlags();
     const params = fromQuery(query);
     const data = useContext(ServerDataContext);
     const { setLink } = useSearchContext();

--- a/content/webapp/views/pages/search/works.tsx/index.tsx
+++ b/content/webapp/views/pages/search/works.tsx/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { useSearchContext } from '@weco/common/contexts/SearchContext';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import { formatNumber, pluralize } from '@weco/common/utils/grammar';
 import { linkResolver, SEARCH_PAGES_FORM_ID } from '@weco/common/utils/search';
@@ -53,7 +53,8 @@ const SortPaginationWrapper = styled.div`
 const WorksSearchPage: NextPage<Props> = withSearchLayout(
   ({ works, works2, works3, worksRouteProps, query }) => {
     const { query: queryString } = query;
-    const { semanticSearchPrototype, semanticSearchComparison } = useToggles();
+    const { semanticSearchPrototype, semanticSearchComparison } =
+      useFeatureFlags();
 
     // Extract error messages if works2/works3 are errors
     const works2Error =

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { getFileLabel } from '@weco/content/utils/works';
 
 import IIIFItemDownload from './IIIFItem.Download';
@@ -30,7 +30,7 @@ const IIIFItemPdf: FunctionComponent<Props> = ({
   format,
 }: Props) => {
   const { isMobileOrTabletDevice } = useAppContext();
-  const { extendedViewer } = useToggles();
+  const { extendedViewer } = useFeatureFlags();
   const substituteTitle = 'unknown title';
   const displayLabel = getFileLabel(label, substituteTitle);
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
 import ItemViewerContext from '@weco/content/contexts/ItemViewerContext';
@@ -234,7 +234,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     shouldScrollToCanvas = true,
     query = '',
   } = useMemo(() => fromQuery(router.query), [router.query]);
-  const { extendedViewer } = useToggles();
+  const { extendedViewer } = useFeatureFlags();
   const [gridVisible, setGridVisible] = useState(false);
   const { isFullSupportBrowser } = useAppContext();
   const viewerRef = useRef<HTMLDivElement>(null);

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
@@ -3,7 +3,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { sierraAccessMethodtoNewLabel } from '@weco/common/data/microcopy';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import StackingTable from '@weco/common/views/components/StackingTable';
@@ -76,7 +76,7 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
   isLast,
 }) => {
   const { state: userState } = useUserContext();
-  const { disableRequesting } = useToggles();
+  const { disableRequesting } = useFeatureFlags();
   const isArchive = useIsArchiveContext();
   const theme = useTheme();
   const requestButtonRef = useRef<HTMLButtonElement | null>(null);

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -8,7 +8,7 @@ import { bornDigitalMessage } from '@weco/common/data/microcopy';
 import { eye } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { LinkProps } from '@weco/common/model/link-props';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
@@ -118,7 +118,7 @@ const ItemPageLink = ({
   itemsStatus,
 }: ItemPageLinkProps) => {
   const { userIsStaffWithRestricted } = useUserContext();
-  const { extendedViewer } = useToggles();
+  const { extendedViewer } = useFeatureFlags();
 
   const isDownloadable =
     digitalLocationInfo?.accessCondition !== 'open-with-advisory' &&
@@ -251,7 +251,7 @@ const WorkDetailsAvailableOnline = ({
     rendering,
   } = { ...transformedManifest };
 
-  const { extendedViewer } = useToggles();
+  const { extendedViewer } = useFeatureFlags();
   const { userIsStaffWithRestricted } = useUserContext();
   const tokenService = getIframeTokenSrc({
     workId: work.id,

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.LibraryMembersBar.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.LibraryMembersBar.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { requestingDisabled } from '@weco/common/data/microcopy';
 import { memberCard } from '@weco/common/icons';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -74,7 +74,7 @@ const Reload: FunctionComponent<ReloadProps> = ({ reload }) => {
 
 const LibraryMembersBar: FunctionComponent = () => {
   const { state, reload } = useUserContext();
-  const { disableRequesting } = useToggles();
+  const { disableRequesting } = useFeatureFlags();
   if (disableRequesting) {
     return (
       <StyledComponent>

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Divider from '@weco/common/views/components/Divider';
@@ -63,7 +63,7 @@ export const WorkPage: NextPage<Props> = ({
   transformedManifest,
   serverData,
 }) => {
-  const { extendedViewer } = useToggles();
+  const { extendedViewer } = useFeatureFlags();
   const { userIsStaffWithRestricted } = useUserContext();
   const isArchive = !!(
     work.parts.length || getArchiveAncestorArray(work).length > 0

--- a/content/webapp/views/pages/works/work/items.tsx
+++ b/content/webapp/views/pages/works/work/items.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import Button from '@weco/common/views/components/Buttons';
@@ -88,7 +88,7 @@ const WorkItemPage: NextPage<Props> = ({
   const canvas = routerCanvas || serverCanvas;
 
   const { userIsStaffWithRestricted } = useUserContext();
-  const { extendedViewer } = useToggles();
+  const { extendedViewer } = useFeatureFlags();
   const transformedManifest =
     compressedTransformedManifest &&
     fromCompressedManifest(compressedTransformedManifest);

--- a/dash/webapp/views/pages/index.tsx
+++ b/dash/webapp/views/pages/index.tsx
@@ -66,16 +66,16 @@ const Dashboard: FunctionComponent = () => {
         <PageHeader>
           <PageTitle>Dashboard</PageTitle>
           <PageDescription>
-            Monitor site health, manage feature toggles, and access key tools.
+            Monitor site health, manage toggles, and access key tools.
           </PageDescription>
         </PageHeader>
 
         <main id="main-content">
           <CardsGrid role="list">
             <Card href="/toggles" role="listitem">
-              <CardTitle>Feature Toggles</CardTitle>
+              <CardTitle>Toggles</CardTitle>
               <CardDescription>
-                Manage and test feature flags across environments.
+                Manage and test feature flags and A/B tests.
               </CardDescription>
               <CardStatus $type="neutral">View all toggles →</CardStatus>
             </Card>

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -274,7 +274,7 @@ const TogglesPage: FunctionComponent = () => {
             <h2 id="general">
               Feature flags for general use
               <a href="#general" aria-label="Link to this section">
-                #
+                <span aria-hidden="true">#</span>
               </a>
             </h2>
             <ListOfToggles
@@ -292,7 +292,7 @@ const TogglesPage: FunctionComponent = () => {
             <h2 id="permanent">
               Feature flags for Digital team - Permanent
               <a href="#permanent" aria-label="Link to this section">
-                #
+                <span aria-hidden="true">#</span>
               </a>
             </h2>
             <ListOfToggles
@@ -310,7 +310,7 @@ const TogglesPage: FunctionComponent = () => {
             <h2 id="wip">
               Feature flags for Digital team - Work in progress
               <a href="#wip" aria-label="Link to this section">
-                #
+                <span aria-hidden="true">#</span>
               </a>
             </h2>
             <ListOfToggles
@@ -328,7 +328,7 @@ const TogglesPage: FunctionComponent = () => {
             <h2 id="staging">
               Feature flags for Digital team - Staging
               <a href="#staging" aria-label="Link to this section">
-                #
+                <span aria-hidden="true">#</span>
               </a>
             </h2>
             <ListOfToggles

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -92,7 +92,7 @@ const TogglesPage: FunctionComponent = () => {
             [toggleId]: true,
           }));
           setMessage({
-            text: `✅ Toggle "${toggleId}" has been successfully enabled!`,
+            text: `✅ Feature flag "${toggleId}" has been successfully enabled!`,
             isError: false,
             isEnabled: true,
           });
@@ -104,14 +104,14 @@ const TogglesPage: FunctionComponent = () => {
             [toggleId]: toggle?.defaultValue ?? false,
           }));
           setMessage({
-            text: `🔵 Toggle "${toggleId}" has been reset to its default value.`,
+            text: `🔵 Feature flag "${toggleId}" has been reset to its default value.`,
             isError: false,
             isEnabled: false,
           });
         }
       } else {
         setMessage({
-          text: `❌ Toggle "${toggleId}" does not exist.`,
+          text: `❌ Feature flag "${toggleId}" does not exist.`,
           isError: true,
         });
       }
@@ -153,7 +153,7 @@ const TogglesPage: FunctionComponent = () => {
     if (resetToggles !== undefined) {
       reset();
       setMessage({
-        text: '🔄 All toggles have been reset to their default values.',
+        text: '🔄 All feature flags have been reset to their default values.',
         isError: false,
       });
     } else if (enableToggle) {
@@ -210,11 +210,11 @@ const TogglesPage: FunctionComponent = () => {
       <Header activePath="/toggles" />
       <PageContainer>
         <PageHeader>
-          <PageTitle>Feature Toggles</PageTitle>
+          <PageTitle>Toggles</PageTitle>
           <PageDescription>
-            Manage and test feature flags; changes only affect your own browser.
-            Toggles also have a public status which is set for 100% of users,
-            which is done through devs running a script.
+            Manage and test feature flags and A/B tests; changes only affect
+            your own browser. Feature flags also have a public status which is
+            set for 100% of users, which is done through devs running a script.
           </PageDescription>
         </PageHeader>
 
@@ -253,13 +253,13 @@ const TogglesPage: FunctionComponent = () => {
               onClick={() => {
                 reset();
                 setMessage({
-                  text: '🔄 All toggles have been reset to their default values.',
+                  text: '🔄 All feature flags have been reset to their default values.',
                   isError: false,
                 });
               }}
-              aria-label="Reset all feature toggles to default values"
+              aria-label="Reset all feature flags to default values"
             >
-              Reset toggles to defaults
+              Reset feature flags to defaults
             </ResetButton>
           </div>
         </main>
@@ -268,7 +268,12 @@ const TogglesPage: FunctionComponent = () => {
       {(generalToggles.length > 0 || !searchQuery) && (
         <Section $background="default" $hasNoTopPadding>
           <SectionInner>
-            <h2>Toggles for general use</h2>
+            <h2 id="general">
+              Feature flags for general use
+              <a href="#general" aria-label="Link to this section">
+                #
+              </a>
+            </h2>
             <ListOfToggles
               toggles={generalToggles}
               toggleStates={toggleStates}
@@ -281,7 +286,12 @@ const TogglesPage: FunctionComponent = () => {
       {(restOfPermanentToggles.length > 0 || !searchQuery) && (
         <Section $background="light">
           <SectionInner>
-            <h2>Toggles for Digital team - Permanent</h2>
+            <h2 id="permanent">
+              Feature flags for Digital team - Permanent
+              <a href="#permanent" aria-label="Link to this section">
+                #
+              </a>
+            </h2>
             <ListOfToggles
               toggles={restOfPermanentToggles}
               toggleStates={toggleStates}
@@ -294,7 +304,12 @@ const TogglesPage: FunctionComponent = () => {
       {(experimentalToggles.length > 0 || !searchQuery) && (
         <Section $background="alt">
           <SectionInner>
-            <h2>Toggles for Digital team - Work in progress</h2>
+            <h2 id="wip">
+              Feature flags for Digital team - Work in progress
+              <a href="#wip" aria-label="Link to this section">
+                #
+              </a>
+            </h2>
             <ListOfToggles
               toggles={experimentalToggles}
               toggleStates={toggleStates}
@@ -307,7 +322,12 @@ const TogglesPage: FunctionComponent = () => {
       {(stageToggles.length > 0 || !searchQuery) && (
         <Section $background="light">
           <SectionInner>
-            <h2>Toggles for Digital team - Staging</h2>
+            <h2 id="staging">
+              Feature flags for Digital team - Staging
+              <a href="#staging" aria-label="Link to this section">
+                #
+              </a>
+            </h2>
             <ListOfToggles
               toggles={stageToggles}
               toggleStates={toggleStates}

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -48,14 +48,17 @@ const TogglesPage: FunctionComponent = () => {
     fetch('https://toggles.wellcomecollection.org/toggles.json')
       .then(resp => resp.json())
       .then(json => {
-        setToggles(json.toggles);
-        setAbTests(json.tests);
+        const featureFlags: Toggle[] = json.featureFlags ?? json.toggles ?? [];
+        const tests: AbTest[] = json.tests ?? [];
+
+        setToggles(featureFlags);
+        setAbTests(tests);
 
         const cookies = getCookies();
         const initialStates: ToggleStates = {};
 
         // Toggles: cookie value or default
-        for (const toggle of json.toggles as Toggle[]) {
+        for (const toggle of featureFlags) {
           const cookieKey = `toggle_${toggle.id}`;
           initialStates[toggle.id] =
             cookieKey in cookies
@@ -64,7 +67,7 @@ const TogglesPage: FunctionComponent = () => {
         }
 
         // AB tests: cookie value or undefined (= randomly allocate)
-        for (const test of json.tests as AbTest[]) {
+        for (const test of tests) {
           const cookieKey = `toggle_${test.id}`;
           if (cookieKey in cookies) {
             initialStates[test.id] = cookies[cookieKey] === 'true';

--- a/dash/webapp/views/pages/toggles/toggles.ABTests.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.ABTests.tsx
@@ -60,7 +60,12 @@ const ABTests = ({
           alignItems: 'center',
         }}
       >
-        <h2>A/B tests</h2>
+        <h2 id="ab-tests">
+          A/B tests
+          <a href="#ab-tests" aria-label="Link to this section">
+            #
+          </a>
+        </h2>
         <ResetButton
           onClick={onReset}
           aria-label="Reset all A/B tests to random allocation"

--- a/dash/webapp/views/pages/toggles/toggles.styles.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.styles.tsx
@@ -84,9 +84,13 @@ export const SectionInner = styled.div`
     scroll-margin-top: 60px;
 
     a {
-      color: inherit;
+      color: ${tokens.colors.info.main};
       text-decoration: none;
       margin-left: ${tokens.spacing.xs};
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 `;

--- a/dash/webapp/views/pages/toggles/toggles.styles.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.styles.tsx
@@ -82,6 +82,22 @@ export const SectionInner = styled.div`
     margin-bottom: ${tokens.spacing.md};
     font-size: ${tokens.typography.fontSize.h4};
     scroll-margin-top: 60px;
+
+    a {
+      color: inherit;
+      text-decoration: none;
+      opacity: 0;
+      margin-left: ${tokens.spacing.xs};
+      transition: opacity 0.15s;
+    }
+
+    &:hover a {
+      opacity: 0.4;
+    }
+
+    a:hover {
+      opacity: 1;
+    }
   }
 `;
 

--- a/dash/webapp/views/pages/toggles/toggles.styles.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.styles.tsx
@@ -86,17 +86,7 @@ export const SectionInner = styled.div`
     a {
       color: inherit;
       text-decoration: none;
-      opacity: 0;
       margin-left: ${tokens.spacing.xs};
-      transition: opacity 0.15s;
-    }
-
-    &:hover a {
-      opacity: 0.4;
-    }
-
-    a:hover {
-      opacity: 1;
     }
   }
 `;

--- a/toggles/README.md
+++ b/toggles/README.md
@@ -3,19 +3,27 @@
 We use toggles across our services to be able to release features to
 different cohorts of people and stakeholders safely and incrementally.
 
+"Toggles" is the umbrella term for all the different categories below.
+
 There is [a great article by Martin Fowler][martin-fowler-feature-toggles] on the subject.
 
 ## Categories
-We currently use three categories of toggles:
+We currently use two categories of toggles:
 
-### 1. Feature development toggle
+### 1. Feature flags
 
-Used to release a feature early, generally internally. We then develop the feature until
-we are happy for it to be released to the public.
+Feature flags control the visibility of features. They have a `defaultValue` (true/false)
+that determines whether the feature is on or off for the public.
 
+Types of feature flag:
+- **Experimental** — used to release a feature early, generally internally, while it's being developed.
+- **Permanent** — used to make certain features available to people, but generally turned off for the public (e.g. an API toolbar).
+- **Stage** — only applied on the staging environment.
+
+To add a new feature flag:
 * Go to `toggles/webapp/toggles.ts`.
-* Create new toggle with `initialValue: false`.
-* log in to AWS and run `yarn deploy`. This will make it available on the [toggles dashboard](https://dash.wellcomecollection.org/toggles/).
+* Add a new entry to the `featureFlags` array with `initialValue: false`.
+* Log in to AWS and run `yarn deploy`. This will make it available on the [toggles dashboard](https://dash.wellcomecollection.org/toggles/).
 * If required, create a PR. Ensure you merge your code in `main`.
 * Let internal users know they can turn this feature on via the [toggles dashboard](https://dash.wellcomecollection.org/toggles/).
 * Iterate!
@@ -23,22 +31,37 @@ we are happy for it to be released to the public.
 * If anything goes wrong, you can run `yarn setDefaultValueFor --{toggle_id}=false`.
 * Once you're completely happy with it, remove the toggle from the code.
 
-### 2. Feature toggle
-
-Used to make certain permanent features available to people, but are generally turned off
-for the public.
-
-e.g. An API toolbar adding more context to works for internal users.
-
-### 3. A/B tests
+### 2. A/B tests
 
 This is to serve different content to different cohorts of people randomly based on a toggle.
+A/B tests don't have a `defaultValue` — values are randomly assigned to users.
 
 The implementation for A/B testing is contained within the [cache directory of this repo](../cache).
 You can read more about it there.
 
 We replicate the tests in [the Lambda@Edge](../cache/edge_lambdas/src/toggler.ts) here to allow
 people to explicitly set which cohort they would like to be in.
+
+## Accessing toggles in code
+
+Client-side, use the following hooks:
+- `useFeatureFlags()` — returns feature flag values
+- `useABTest()` — returns A/B test values
+
+These are exported from `@weco/common/server-data/Context`.
+
+Server-side, the toggles JSON is fetched from S3 and merged with the user's cookies
+automatically as part of the server data pipeline. In `getServerSideProps`, access
+toggle values via `serverData.toggles`:
+
+```typescript
+if (serverData.toggles.someFeatureFlag.value) {
+  // feature is enabled
+}
+```
+
+The `serverData.toggles` object is also passed to services that need it
+(e.g. catalogue API clients).
 
 
 ## Deployment

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -50,10 +50,17 @@ export const withDefaultValuesUnmodified = (
 export async function deploy(client: S3Client): Promise<void> {
   const remoteToggles = await getTogglesObject(client);
 
-  const featureFlagsToDeploy = withDefaultValuesUnmodified(
-    remoteToggles.featureFlags,
-    [...localToggles.featureFlags]
-  );
+  // Backward compat: S3 may still have the old shape ({ toggles: [...] })
+  // until this deploy writes the new format.
+  const remoteFeatureFlags =
+    remoteToggles.featureFlags ??
+    (remoteToggles as unknown as { toggles: TogglesResp['featureFlags'] })
+      .toggles ??
+    [];
+
+  const featureFlagsToDeploy = withDefaultValuesUnmodified(remoteFeatureFlags, [
+    ...localToggles.featureFlags,
+  ]);
 
   // We don't bother looking at the `.tests` during deployments as the `defaultValue`s
   // don't do anything as values are randomly assigned.

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -50,21 +50,22 @@ export const withDefaultValuesUnmodified = (
 export async function deploy(client: S3Client): Promise<void> {
   const remoteToggles = await getTogglesObject(client);
 
-  const togglesToDeploy = withDefaultValuesUnmodified(remoteToggles.toggles, [
-    ...localToggles.toggles,
-  ]);
+  const featureFlagsToDeploy = withDefaultValuesUnmodified(
+    remoteToggles.featureFlags,
+    [...localToggles.featureFlags]
+  );
 
   // We don't bother looking at the `.tests` during deployments as the `defaultValue`s
   // don't do anything as values are randomly assigned.
   // We should probably look at the structure of features vs tests.
-  const togglesAndTests: TogglesResp = {
-    toggles: togglesToDeploy,
+  const toggles: TogglesResp = {
+    featureFlags: featureFlagsToDeploy,
     tests: localToggles.tests,
   };
 
   // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en
   // So instead of sending the whole toggles JSON blob we send a concatenated string of only the toggle names (preceeded with a ! if the toggle is false).
-  const potentialToggleString = togglesAndTests.tests
+  const potentialToggleString = toggles.tests
     .map(toggle => `!${toggle.id}`) // replicating the condition of all toggles being false gives the longest possible string.
     .join(',');
 
@@ -81,7 +82,7 @@ export async function deploy(client: S3Client): Promise<void> {
 
   const { $metadata: putObjectResponseMetadata } = await putTogglesObject(
     client,
-    togglesAndTests
+    toggles
   );
 
   if (putObjectResponseMetadata.httpStatusCode === 200) {

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -1,11 +1,20 @@
-import toggleConfig, { ABTest, PublishedToggle, ToggleTypes } from './toggles';
+import toggleConfig, {
+  ABTest,
+  PublishedFeatureFlag,
+  ToggleTypes,
+} from './toggles';
 
-export type ToggleId = (typeof toggleConfig.toggles)[number]['id'];
+export type FeatureFlagId = (typeof toggleConfig.featureFlags)[number]['id'];
 export type TestId = (typeof toggleConfig.tests)[number]['id'];
+// Backward compatibility alias
+export type ToggleId = FeatureFlagId;
 
 // As togglesConfig is what is served at https://toggles.wellcomecollection.org/toggles.json
 // This allows methods fetching that URL to type the data fetched
-export type TogglesResp = { toggles: PublishedToggle[]; tests: ABTest[] };
+export type TogglesResp = {
+  featureFlags: PublishedFeatureFlag[];
+  tests: ABTest[];
+};
 
 // Don't be tempted to make the keys on this optional - keeping them
 // as required means we catch dead code left over from removed toggles

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -9,7 +9,9 @@ const argv = yargs(hideBin(process.argv)).parseSync();
 export async function setDefaultValueFor(client: S3Client): Promise<void> {
   const remoteToggles = await getTogglesObject(client);
 
-  const toggles = remoteToggles.toggles.map(toggle => {
+  // Only feature flags have a defaultValue that can be overridden.
+  // A/B tests are randomly assigned to users, so they have no default to set.
+  const featureFlags = remoteToggles.featureFlags.map(toggle => {
     const arg = argv[toggle.id];
     if (arg && (arg === 'true' || arg === 'false')) {
       const defaultValue = arg === 'true';
@@ -21,14 +23,14 @@ export async function setDefaultValueFor(client: S3Client): Promise<void> {
     return toggle;
   });
 
-  const togglesAndTests = {
-    toggles,
+  const toggles = {
+    featureFlags,
     tests: remoteToggles.tests,
   };
 
   const { $metadata: putObjectResponseMetadata } = await putTogglesObject(
     client,
-    togglesAndTests
+    toggles
   );
 
   if (putObjectResponseMetadata.httpStatusCode === 200) {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -8,13 +8,17 @@ type ToggleBase = {
   documentationLink?: string;
 };
 
-export type ToggleDefinition = ToggleBase & {
+export type FeatureFlagDefinition = ToggleBase & {
   initialValue: boolean;
 };
 
-export type PublishedToggle = ToggleBase & {
+export type PublishedFeatureFlag = ToggleBase & {
   defaultValue: boolean;
 };
+
+// Backward compatibility aliases
+export type ToggleDefinition = FeatureFlagDefinition;
+export type PublishedToggle = PublishedFeatureFlag;
 
 export type ABTest = {
   id: string;
@@ -23,10 +27,10 @@ export type ABTest = {
   range: [number, number];
 };
 
-const toggles = {
-  // This should probably be called `features` as we have feature toggles, and a/b testing toggles.
+const toggleConfig = {
+  // Feature flags (permanent toggles, experiments, stage toggles)
   // Toggles of type 'stage' will only be applied on stage
-  toggles: [
+  featureFlags: [
     {
       id: 'apiToolbar',
       title: 'API toolbar',
@@ -166,4 +170,4 @@ const toggles = {
   tests: [] as ABTest[],
 };
 
-export default toggles;
+export default toggleConfig;


### PR DESCRIPTION
The toggles system conflated two distinct concepts under the single name "toggles": feature flags and A/B tests. This made the codebase harder to reason about — when you saw `useToggles()` it wasn't clear whether you were dealing with a feature flag or a test (although we rarely use those). There was a 5 year old comment from James about renaming those, and as I'm considering adding a third type of cookie, I thought it was time.

This PR clarifies the naming so that "toggles" is the umbrella term for the system, while the two categories are explicitly named:

- **Feature flags** — boolean switches that enable/disable functionality
- **A/B tests** — experiments that split users into groups

### Changes

**New hooks:**
- `useFeatureFlags()` — returns only feature flag values
- `useABTest()` — returns only A/B test values

**Removed:**
- `useToggles()` — all ~20 call sites migrated to `useFeatureFlags()` (since we currently have no active A/B tests, all callers were accessing feature flags)

**Type renames (with backward compat aliases):**
- `ToggleDefinition` → `FeatureFlagDefinition`
- `PublishedToggle` → `PublishedFeatureFlag`

**Config field rename:**
- `toggleConfig.toggles` → `toggleConfig.featureFlags`
- `TogglesResp.toggles` → `TogglesResp.featureFlags`

**Deployment safety:**
- `getTogglesFromContext()` has a fallback that reads from `toggles` if `featureFlags` is not present in the S3 JSON, so the app continues to work during the window between deploying the app and updating the S3 config

**Documentation:**
- Rewrote `toggles/README.md` to explain the two categories and how to access them

**Tests:**
- Added `common/server-data/toggles.test.ts` to verify backward compatibility with the old JSON format

**Dash**
- We've also updated Dash to match the new structure.
- Natalie once asked for anchors or headings ([here](https://github.com/wellcomecollection/wellcomecollection.org/issues/12615#issuecomment-3921363253)) so I added them.

## How to test

1. Run `yarn tsc` from root — should pass with no errors
2. Run `cd common && yarn jest server-data/toggles.test.ts --no-coverage` — 3 tests pass
3. Run the content app locally (`yarn content`) and verify feature flags still work (e.g. check a page that uses a flag like `stagingApi`)

1. Run dash (`cd dash/webapp && yarn && yarn dev`) and see if the heading make sense.
2. Check out the new anchors in headings

## Have we considered potential risks?

The main risk is the S3 JSON rename (`toggles` → `featureFlags`). There's a window during deployment where the new app code is live but the S3 file still has the old field name. This is mitigated by the fallback chain in `getTogglesFromContext()` which reads from either field.

The backward compat type aliases (`ToggleDefinition`, `PublishedToggle`, `ToggleId`) mean any code we missed won't break at compile time.
