### PR TITLE
Tenderness and Rage tracking

### DIFF
--- a/content/webapp/hooks/useVimeoTracking.ts
+++ b/content/webapp/hooks/useVimeoTracking.ts
@@ -29,11 +29,17 @@ export function useVimeoTracking({
 
     let isCurrent = true;
     let player: import('@vimeo/player').default | undefined;
+    const firedMilestones = new Set<number>();
+    const progressMilestones = [10, 25, 50, 75, 90];
 
-    const trackEvent = (eventName: string) => {
+    const trackEvent = (
+      eventName: string,
+      extraParams?: Record<string, unknown>
+    ) => {
       gtag('event', eventName, {
         video_title: title,
         video_provider: 'Vimeo',
+        ...extraParams,
       });
     };
 
@@ -43,6 +49,15 @@ export function useVimeoTracking({
       player.on('play', () => trackEvent('video_start'));
       player.on('pause', () => trackEvent('video_pause'));
       player.on('ended', () => trackEvent('video_complete'));
+      player.on('timeupdate', ({ percent }) => {
+        const percentComplete = percent * 100;
+        for (const milestone of progressMilestones) {
+          if (percentComplete >= milestone && !firedMilestones.has(milestone)) {
+            firedMilestones.add(milestone);
+            trackEvent('video_progress', { video_percent: milestone });
+          }
+        }
+      });
     });
 
     return () => {
@@ -50,6 +65,7 @@ export function useVimeoTracking({
       player?.off('play');
       player?.off('pause');
       player?.off('ended');
+      player?.off('timeupdate');
       player?.destroy().catch(() => undefined);
     };
   }, [isVimeo, hasAnalyticsConsent, activeIndex, title]);

--- a/content/webapp/hooks/useVimeoTracking.ts
+++ b/content/webapp/hooks/useVimeoTracking.ts
@@ -29,34 +29,26 @@ export function useVimeoTracking({
 
     let isCurrent = true;
     let player: import('@vimeo/player').default | undefined;
-    const firedMilestones = new Set<number>();
-    const progressMilestones = [10, 25, 50, 75, 90];
+    let didStart = false;
 
-    const trackEvent = (
-      eventName: string,
-      extraParams?: Record<string, unknown>
-    ) => {
+    const trackEvent = (eventName: string) => {
       gtag('event', eventName, {
         video_title: title,
         video_provider: 'Vimeo',
-        ...extraParams,
       });
     };
 
     import('@vimeo/player').then(({ default: Player }) => {
       if (!isCurrent || !iframeRef.current) return;
       player = new Player(iframeRef.current);
-      player.on('play', () => trackEvent('video_start'));
-      player.on('pause', () => trackEvent('video_pause'));
-      player.on('ended', () => trackEvent('video_complete'));
-      player.on('timeupdate', ({ percent }) => {
-        const percentComplete = percent * 100;
-        for (const milestone of progressMilestones) {
-          if (percentComplete >= milestone && !firedMilestones.has(milestone)) {
-            firedMilestones.add(milestone);
-            trackEvent('video_progress', { video_percent: milestone });
-          }
-        }
+      player.on('play', () => {
+        if (didStart) return;
+        didStart = true;
+        trackEvent('video_start');
+      });
+      player.on('ended', () => {
+        trackEvent('video_complete');
+        didStart = false;
       });
     });
 
@@ -65,7 +57,6 @@ export function useVimeoTracking({
       player?.off('play');
       player?.off('pause');
       player?.off('ended');
-      player?.off('timeupdate');
       player?.destroy().catch(() => undefined);
     };
   }, [isVimeo, hasAnalyticsConsent, activeIndex, title]);

--- a/content/webapp/hooks/useVimeoTracking.ts
+++ b/content/webapp/hooks/useVimeoTracking.ts
@@ -1,0 +1,56 @@
+import { RefObject, useEffect } from 'react';
+
+import { getConsentState } from '@weco/common/services/app/civic-uk';
+
+type Options = {
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  activeIndex: number | null;
+  title?: string;
+  isVimeo: boolean;
+};
+
+export function useVimeoTracking({
+  iframeRef,
+  activeIndex,
+  title,
+  isVimeo,
+}: Options): void {
+  const hasAnalyticsConsent = getConsentState('analytics');
+
+  useEffect(() => {
+    if (
+      !isVimeo ||
+      !hasAnalyticsConsent ||
+      activeIndex === null ||
+      !iframeRef.current
+    ) {
+      return;
+    }
+
+    let isCurrent = true;
+    let player: import('@vimeo/player').default | undefined;
+
+    const trackEvent = (eventName: string) => {
+      gtag('event', eventName, {
+        video_title: title,
+        video_provider: 'Vimeo',
+      });
+    };
+
+    import('@vimeo/player').then(({ default: Player }) => {
+      if (!isCurrent || !iframeRef.current) return;
+      player = new Player(iframeRef.current);
+      player.on('play', () => trackEvent('video_start'));
+      player.on('pause', () => trackEvent('video_pause'));
+      player.on('ended', () => trackEvent('video_complete'));
+    });
+
+    return () => {
+      isCurrent = false;
+      player?.off('play');
+      player?.off('pause');
+      player?.off('ended');
+      player?.destroy().catch(() => undefined);
+    };
+  }, [isVimeo, hasAnalyticsConsent, activeIndex, title]);
+}

--- a/content/webapp/hooks/useVimeoTracking.ts
+++ b/content/webapp/hooks/useVimeoTracking.ts
@@ -1,3 +1,4 @@
+import Player from '@vimeo/player';
 import { RefObject, useEffect } from 'react';
 
 import { getConsentState } from '@weco/common/services/app/civic-uk';
@@ -27,8 +28,6 @@ export function useVimeoTracking({
       return;
     }
 
-    let isCurrent = true;
-    let player: import('@vimeo/player').default | undefined;
     let didStart = false;
 
     const trackEvent = (eventName: string) => {
@@ -38,26 +37,21 @@ export function useVimeoTracking({
       });
     };
 
-    import('@vimeo/player').then(({ default: Player }) => {
-      if (!isCurrent || !iframeRef.current) return;
-      player = new Player(iframeRef.current);
-      player.on('play', () => {
-        if (didStart) return;
-        didStart = true;
-        trackEvent('video_start');
-      });
-      player.on('ended', () => {
-        trackEvent('video_complete');
-        didStart = false;
-      });
+    const player = new Player(iframeRef.current);
+    player.on('play', () => {
+      if (didStart) return;
+      didStart = true;
+      trackEvent('video_start');
+    });
+    player.on('ended', () => {
+      trackEvent('video_complete');
+      didStart = false;
     });
 
     return () => {
-      isCurrent = false;
-      player?.off('play');
-      player?.off('pause');
-      player?.off('ended');
-      player?.destroy().catch(() => undefined);
+      player.off('play');
+      player.off('ended');
+      player.destroy().catch(() => undefined);
     };
   }, [isVimeo, hasAnalyticsConsent, activeIndex, title]);
 }

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -11,11 +11,12 @@
   },
   "dependencies": {
     "@iiif/presentation-3": "^2.1.3",
+    "@koa/router": "^15.2.0",
+    "@vimeo/player": "^2.25.1",
     "@weco/common": "1.0.0",
     "@weco/toggles": "1.0.0",
     "google-maps": "^4.3.3",
     "koa": "^3.1.1",
-    "@koa/router": "^15.2.0",
     "lodash.flattendeep": "^4.4.0",
     "lodash.throttle": "^4.1.1",
     "next": "15.5.18",

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@weco/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import { SizeMap } from '@weco/common/views/components/styled/Grid';
+import { useVimeoTracking } from '@weco/content/hooks/useVimeoTracking';
 import ScrollContainer from '@weco/content/views/components/ScrollContainer';
 import { ListItem } from '@weco/content/views/components/ScrollContainer/ScrollContainer.styles';
 
@@ -49,6 +50,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const activeItem = activeIndex !== null ? items[activeIndex] : null;
   const hasPrev = activeIndex !== null && activeIndex > 0;
@@ -58,10 +60,17 @@ const PortraitVideoList: FunctionComponent<Props> = ({
   );
 
   // Hook must be called unconditionally; passes empty string when no item is active
-  const { videoSrc, uid } = useVideoEmbed(
+  const { videoSrc, uid, isVimeo } = useVideoEmbed(
     activeItem?.embedUrl ?? '',
     activeItem?.videoProvider
   );
+
+  useVimeoTracking({
+    iframeRef,
+    activeIndex,
+    title: activeItem?.title,
+    isVimeo,
+  });
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -186,6 +195,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
           {activeIndex !== null && videoSrc && (
             <VideoIframe
               key={activeIndex}
+              ref={iframeRef}
               title={activeItem?.title || 'Video'}
               allowFullScreen={true}
               allow="autoplay; picture-in-picture"

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -166,6 +166,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
                 onClick={() => setTranscriptOpen(prev => !prev)}
                 aria-expanded={transcriptOpen}
                 aria-controls={uid}
+                data-gtm-trigger={`video_modal_${transcriptOpen ? 'hide' : 'show'}_transcript`}
               >
                 {transcriptOpen ? 'Hide transcript' : 'Show transcript'}
               </TranscriptButton>

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -117,7 +117,12 @@ const PortraitVideoList: FunctionComponent<Props> = ({
         }
       >
         {items.map((item, i) => (
-          <ListItem key={i} $usesShim={useShim} $cols={3}>
+          <ListItem
+            key={i}
+            $usesShim={useShim}
+            $cols={3}
+            data-gtm-position-in-list={i + 1}
+          >
             <PortraitVideoEmbed
               posterImage={item.posterImage}
               duration={item.duration}

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -144,6 +144,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               type="button"
               onClick={() => navigate(-1)}
               disabled={!hasPrev}
+              data-gtm-trigger="video_modal_nav_left"
             >
               <span className="visually-hidden">{prevLabel}</span>
               <Icon icon={chevron} rotate={90} iconColor="white" />
@@ -152,6 +153,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               type="button"
               onClick={() => navigate(1)}
               disabled={!hasNext}
+              data-gtm-trigger="video_modal_nav_right"
             >
               <span className="visually-hidden">{nextLabel}</span>
               <Icon icon={chevron} rotate={270} iconColor="white" />

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -127,7 +127,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
       >
         {items.map((item, i) => (
           <ListItem
-            key={i}
+            key={item.title}
             $usesShim={useShim}
             $cols={3}
             data-gtm-position-in-list={i + 1}

--- a/content/webapp/views/components/StoryCard/StoryCard.Prismic.tsx
+++ b/content/webapp/views/components/StoryCard/StoryCard.Prismic.tsx
@@ -38,12 +38,14 @@ export type Props = {
   hidePromoText?: boolean;
   sizesQueries?: string;
   showAllLabels?: boolean;
+  positionInList?: number;
 };
 
 const StoryCard: FunctionComponent<Props> = ({
   article,
   showAllLabels,
   hidePromoText = false,
+  positionInList,
 }) => {
   const image = article.promo?.image;
   const url = linkResolver(article);
@@ -62,7 +64,7 @@ const StoryCard: FunctionComponent<Props> = ({
           .map(text => ({ text }));
 
   return (
-    <CardOuter href={url}>
+    <CardOuter href={url} data-gtm-position-in-list={positionInList}>
       <CardImageWrapper>
         {isNotUndefined(image) && (
           <PrismicImage

--- a/content/webapp/views/components/VideoPlayer/index.tsx
+++ b/content/webapp/views/components/VideoPlayer/index.tsx
@@ -53,9 +53,7 @@ const VideoPlayer: FunctionComponent<Props> = ({
   return (
     <StyledVideo
       data-component="video-player"
-      onPlay={event => {
-        trackPlay(event);
-      }}
+      onPlay={trackPlay}
       onEnded={trackEnded}
       onTimeUpdate={trackTimeUpdate}
       controlsList={!showDownloadOptions ? 'nodownload' : undefined}

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -71,7 +71,7 @@ const ExhibitionCollectionsContent = ({
             </Space>
 
             <Grid className="card-theme card-theme--transparent">
-              {aboutThisExhibitionContent.map(item => (
+              {aboutThisExhibitionContent.map((item, index) => (
                 <GridCell key={item.id} $sizeMap={{ m: [6], l: [4], xl: [4] }}>
                   <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
                     {item.type === 'articles' && (
@@ -79,6 +79,7 @@ const ExhibitionCollectionsContent = ({
                         variant="prismic"
                         article={item}
                         showAllLabels
+                        positionInList={index + 1}
                       />
                     )}
                     {item.type === 'series' && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4817,6 +4817,14 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@vimeo/player@^2.25.1":
+  version "2.30.4"
+  resolved "https://registry.yarnpkg.com/@vimeo/player/-/player-2.30.4.tgz#27f21001fc97ddd095255c7650380e9046c7c876"
+  integrity sha512-M8m1UAhJSb+KCWuXDLWHViwj+3YY/0ogwFquRfMHs9e9LYjXT9iB7n+sOCKwUusbiXuU2HKmXx+FEGHtYZfUSg==
+  dependencies:
+    native-promise-only "0.8.1"
+    weakmap-polyfill "2.0.4"
+
 "@vitest/expect@3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
@@ -9576,6 +9584,11 @@ napi-postinstall@^0.3.0:
   resolved "https://registry.yarnpkg.com/napi-postinstall/-/napi-postinstall-0.3.4.tgz#7af256d6588b5f8e952b9190965d6b019653bbb9"
   integrity sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==
 
+native-promise-only@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+  integrity sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -12300,6 +12313,11 @@ watchpack@^2.5.1:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+weakmap-polyfill@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz#bcc301e4c8eb4eda3e406f08f1a691093e407884"
+  integrity sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==
 
 web-streams-polyfill@^3.0.3:
   version "3.3.3"


### PR DESCRIPTION
- For #13084

## What does this change?
- [x] Add `data-gtm-position-in-list` to related stories cards
- [x] Add `data-gtm-position-in-list` to videos cards
- [x] Add triggers to the left/right nav buttons on the video modal: `video_modal_nav_left` and `video_modal_nav_right` respectively
- [x] Add trigger to show transcript button: `video_modal_{show/hide}_transcript`
- [x] Add tracking for video start/~video pause~/video complete on Vimeo videos (reuse pre-existing `video_start`, `video_complete`, ~and `video_pause`~)

__Edit:__ `video_pause` isn't part of the [enhanced measurement events](https://support.google.com/analytics/answer/9216061?hl=en) that get sent to GA by YouTube videos by default, so we chose not to implement it for Vimeo for consistency

## How to test

- Turn on [Prismic stage](https://dash.wellcomecollection.org/toggles/?enableToggle=prismicStage), [Exhibition pages and collections content](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection) and [Vertical videos](https://dash.wellcomecollection.org/toggles/?enableToggle=verticalVideos) toggles
- Check related stories cards have `data-gtm-position-in-list` attributes
- Check Portrait video list items have `data-gtm-position-in-list` attributes
- Check show/hide transcript button has `data-gtm-trigger="video_modal_{show/hide}_transcript"`
- Preview Vimeo video in GTM and check `video_start` and `video_complete` events firing (only once per time through the video)
- 

## Have we considered potential risks?

Added a new package for Vimeo tracking, but it's the recommended approach
