### PR TITLE
Toggles refactor part 2: flatten values, simplify service layer

### DIFF
--- a/common/server-data/Context.tsx
+++ b/common/server-data/Context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 
-import { FeatureFlagId, TestId } from '@weco/toggles';
+import { FeatureFlags, Tests } from '@weco/toggles';
 
 import { SimplifiedPrismicData } from './prismic';
 import { defaultServerData, SimplifiedServerData } from './types';
@@ -21,27 +21,14 @@ export const ServerDataContext =
  * `const { toggles: { featureFlagName } } = useContext(ServerDataContext)`
  */
 
-type FeatureFlagValue = Record<FeatureFlagId, boolean | undefined>;
-type ABTestValue = Record<TestId, boolean | undefined>;
-
-export const useFeatureFlags = (): FeatureFlagValue => {
+export const useFeatureFlags = (): FeatureFlags => {
   const data = useContext(ServerDataContext);
-  return Object.keys(data.toggles)
-    .filter(key => data.toggles[key].type !== 'test')
-    .reduce((acc, key) => {
-      acc[key as FeatureFlagId] = data.toggles[key].value;
-      return acc;
-    }, {} as FeatureFlagValue);
+  return data.toggles.featureFlags;
 };
 
-export const useABTest = (): ABTestValue => {
+export const useABTest = (): Tests => {
   const data = useContext(ServerDataContext);
-  return Object.keys(data.toggles)
-    .filter(key => data.toggles[key].type === 'test')
-    .reduce((acc, key) => {
-      acc[key as TestId] = data.toggles[key].value;
-      return acc;
-    }, {} as ABTestValue);
+  return data.toggles.tests;
 };
 
 export const usePrismicData = (): SimplifiedPrismicData => {

--- a/common/server-data/__mocks__/index.ts
+++ b/common/server-data/__mocks__/index.ts
@@ -5,6 +5,7 @@ import {
   emptyPopupDialog,
   emptyPrismicQuery,
 } from '@weco/common/services/prismic/documents';
+import { FeatureFlags, Tests } from '@weco/toggles';
 
 export async function init(): Promise<void> {
   // we avoid writing to the filesystem so we can run this in CI
@@ -16,7 +17,10 @@ export function clear(): void {
 
 export async function getServerData(): Promise<ServerData> {
   return {
-    toggles: {},
+    toggles: {
+      featureFlags: {} as FeatureFlags,
+      tests: {} as Tests,
+    },
     prismic: {
       globalAlert: emptyGlobalAlert(),
       popupDialog: emptyPopupDialog(),

--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -19,6 +19,7 @@ import path from 'path';
 
 import { getAllConsentStates } from '@weco/common/services/app/civic-uk';
 import { simplifyServerData } from '@weco/common/services/prismic/transformers/server-data';
+import { Toggles } from '@weco/toggles';
 
 import prismicHandler from './prismic';
 import togglesHandler, { getTogglesFromContext } from './toggles';
@@ -117,27 +118,42 @@ export function clear(): void {
 export const getServerData = async (
   context: GetServerSidePropsContext
 ): Promise<SimplifiedServerData> => {
+  // Read the cached toggles and prismic data from disk (refreshed every minute)
   const togglesResp = await read('toggles', handlers.toggles.defaultValue);
   const prismic = await read('prismic', handlers.prismic.defaultValue);
-  const { toggle } = context.query;
 
+  // Support ?toggle=someToggleName in the URL to enable a toggle via query param
+  const { toggle } = context.query;
   const enableToggle: string | undefined =
     typeof toggle === 'string' ? toggle : undefined;
 
-  const toggles = getTogglesFromContext(togglesResp, context);
+  // Resolve toggle values from the cached config + user's cookies
+  const { featureFlags, tests } = getTogglesFromContext(togglesResp, context);
 
-  const isEnableToggleValid = Object.keys(toggles).some(
-    id => id === enableToggle
-  );
+  // If a valid toggle was requested via query param, set a cookie and enable it
+  const allToggleIds = [...Object.keys(featureFlags), ...Object.keys(tests)];
+  const isEnableToggleValid = allToggleIds.some(id => id === enableToggle);
 
   if (enableToggle && isEnableToggleValid) {
     context.res.setHeader('Set-Cookie', `toggle_${enableToggle}=true; Path=/`);
-    toggles[enableToggle].value = true;
+    if (enableToggle in featureFlags) {
+      featureFlags[enableToggle] = true;
+    } else {
+      tests[enableToggle] = true;
+    }
   }
 
+  // Read cookie consent status (analytics, marketing)
   const consentStatus = getAllConsentStates(context);
 
-  const serverData = { toggles, prismic, consentStatus };
+  const toggles: Toggles = { featureFlags, tests };
 
+  const serverData = {
+    toggles,
+    prismic,
+    consentStatus,
+  };
+
+  // Strip prismic data down to only what's needed client-side
   return simplifyServerData(serverData);
 };

--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -1,19 +1,36 @@
+/**
+ * @jest-environment node
+ */
 import { IncomingMessage } from 'http';
 
 import { TogglesResp } from '@weco/toggles';
 
 import { Context, getTogglesFromContext } from './toggles';
 
-const mockContext: Context = {
-  req: {
-    cookies: {},
-  } as IncomingMessage & { cookies: Partial<Record<string, string>> },
-};
+function createContext(
+  cookies?: Record<string, string>,
+  host?: string
+): Context {
+  const cookieString = cookies
+    ? Object.entries(cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ')
+    : '';
 
-Object.defineProperty(mockContext.req, 'headers', {
-  value: { host: 'www.wellcomecollection.org' },
-});
+  return {
+    req: {
+      cookies: cookies || {},
+      headers: {
+        host: host || 'www.wellcomecollection.org',
+        cookie: cookieString,
+      },
+    } as unknown as IncomingMessage & {
+      cookies: Partial<Record<string, string>>;
+    },
+  };
+}
 
+// Use real toggle IDs from the config so TypeScript is happy
 const stagingApiFlag = {
   id: 'stagingApi',
   title: 'Staging API',
@@ -22,45 +39,207 @@ const stagingApiFlag = {
   type: 'permanent' as const,
 };
 
+const thematicBrowsingFlag = {
+  id: 'thematicBrowsing',
+  title: 'Thematic Browsing',
+  defaultValue: true,
+  description: 'Enable thematic browsing',
+  type: 'permanent' as const,
+};
+
+// Use a real stage-type flag to test stage filtering
+const stageOnlyFlag = {
+  id: 'stagingApi',
+  title: 'Staging API (stage only variant)',
+  defaultValue: false,
+  description: 'Stage-only flag for testing',
+  type: 'stage' as const,
+};
+
 describe('getTogglesFromContext', () => {
-  it('supports the new JSON format with featureFlags field', () => {
-    const togglesResp: TogglesResp = {
-      featureFlags: [stagingApiFlag],
-      tests: [],
-    };
+  describe('featureFlags', () => {
+    it('returns defaultValue when no cookie is set', () => {
+      const togglesResp: TogglesResp = {
+        featureFlags: [stagingApiFlag, thematicBrowsingFlag],
+        tests: [],
+      };
 
-    const result = getTogglesFromContext(togglesResp, mockContext);
+      const result = getTogglesFromContext(togglesResp, createContext());
 
-    expect(result).toEqual({
-      stagingApi: { value: false, type: 'permanent' },
+      expect(result.featureFlags.stagingApi).toBe(false);
+      expect(result.featureFlags.thematicBrowsing).toBe(true);
+    });
+
+    it('returns true when cookie is "true"', () => {
+      const togglesResp: TogglesResp = {
+        featureFlags: [stagingApiFlag],
+        tests: [],
+      };
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_stagingApi: 'true' })
+      );
+
+      expect(result.featureFlags.stagingApi).toBe(true);
+    });
+
+    it('returns defaultValue when cookie is "false" (not false)', () => {
+      const togglesResp: TogglesResp = {
+        featureFlags: [stagingApiFlag],
+        tests: [],
+      };
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_stagingApi: 'false' })
+      );
+
+      // Cookie "false" doesn't match "true", so falls back to defaultValue
+      expect(result.featureFlags.stagingApi).toBe(false);
+    });
+
+    it('returns defaultValue when cookie is any non-"true" string', () => {
+      const togglesResp: TogglesResp = {
+        featureFlags: [thematicBrowsingFlag],
+        tests: [],
+      };
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_thematicBrowsing: 'banana' })
+      );
+
+      expect(result.featureFlags.thematicBrowsing).toBe(true);
+    });
+
+    it('excludes stage-only flags on non-stage hosts', () => {
+      const togglesResp: TogglesResp = {
+        featureFlags: [stageOnlyFlag],
+        tests: [],
+      };
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext(undefined, 'www.wellcomecollection.org')
+      );
+
+      // Stage-only flag is filtered out on non-stage hosts
+      expect(result.featureFlags.stagingApi).toBeUndefined();
+    });
+
+    it('includes stage-only flags on stage hosts', () => {
+      const togglesResp: TogglesResp = {
+        featureFlags: [stageOnlyFlag],
+        tests: [],
+      };
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext(
+          { toggle_stagingApi: 'true' },
+          'www-stage.wellcomecollection.org'
+        )
+      );
+
+      expect(result.featureFlags.stagingApi).toBe(true);
     });
   });
 
-  it('supports the old JSON format with toggles field', () => {
-    // Simulates the old S3 JSON shape before the rename
-    const togglesResp = {
-      toggles: [stagingApiFlag],
-      tests: [],
-    } as unknown as TogglesResp;
+  describe('tests', () => {
+    // getTogglesFromContext uses the test IDs dynamically, so we cast
+    // the result to access arbitrary keys
+    it('returns true when cookie is "true"', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [
+          { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
+        ],
+      } as unknown as TogglesResp;
 
-    const result = getTogglesFromContext(togglesResp, mockContext);
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_sampleTest: 'true' })
+      );
 
-    expect(result).toEqual({
-      stagingApi: { value: false, type: 'permanent' },
+      expect((result.tests as Record<string, unknown>).sampleTest).toBe(true);
+    });
+
+    it('returns false when cookie is "false"', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [
+          { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
+        ],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_sampleTest: 'false' })
+      );
+
+      expect((result.tests as Record<string, unknown>).sampleTest).toBe(false);
+    });
+
+    it('returns undefined when no cookie is set', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [
+          { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
+        ],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(togglesResp, createContext());
+
+      expect(
+        (result.tests as Record<string, unknown>).sampleTest
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when cookie is any non-boolean string', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [
+          { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
+        ],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_sampleTest: 'maybe' })
+      );
+
+      expect(
+        (result.tests as Record<string, unknown>).sampleTest
+      ).toBeUndefined();
     });
   });
 
-  it('prefers featureFlags over toggles if both are present', () => {
-    const togglesResp = {
-      featureFlags: [stagingApiFlag],
-      toggles: [Object.assign({}, stagingApiFlag, { id: 'oldField' })],
-      tests: [],
-    } as unknown as TogglesResp;
+  describe('backward compatibility', () => {
+    it('supports the old JSON format with toggles field', () => {
+      const togglesResp = {
+        toggles: [stagingApiFlag],
+        tests: [],
+      } as unknown as TogglesResp;
 
-    const result = getTogglesFromContext(togglesResp, mockContext);
+      const result = getTogglesFromContext(togglesResp, createContext());
 
-    expect(result).toEqual({
-      stagingApi: { value: false, type: 'permanent' },
+      expect(result.featureFlags.stagingApi).toBe(false);
+    });
+
+    it('prefers featureFlags over toggles if both are present', () => {
+      const togglesResp = {
+        featureFlags: [stagingApiFlag],
+        toggles: [{ ...stagingApiFlag, id: 'oldField' }],
+        tests: [],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(togglesResp, createContext());
+
+      expect(result.featureFlags.stagingApi).toBe(false);
+      expect(
+        (result.featureFlags as Record<string, unknown>).oldField
+      ).toBeUndefined();
     });
   });
 });

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -1,7 +1,7 @@
 import { getCookies } from 'cookies-next';
 import { IncomingMessage } from 'http';
 
-import { Toggles, TogglesResp } from '@weco/toggles';
+import { FeatureFlags, Tests, TogglesResp } from '@weco/toggles';
 
 import { Handler } from './';
 
@@ -36,7 +36,7 @@ export type Context = {
 export function getTogglesFromContext(
   togglesResp: TogglesResp,
   context: Context
-): Toggles {
+): { featureFlags: FeatureFlags; tests: Tests } {
   const isStage = context.req.headers.host?.startsWith('www-stage');
   const allCookies = getCookies(context);
   // Support both old ({ toggles: [...] }) and new ({ featureFlags: [...] }) JSON formats
@@ -52,15 +52,12 @@ export function getTogglesFromContext(
     .reduce(
       (acc, toggle) => ({
         ...acc,
-        [toggle.id]: {
-          value:
-            allCookies[`toggle_${toggle.id}`] === 'true'
-              ? true
-              : toggle.defaultValue,
-          type: toggle.type,
-        },
+        [toggle.id]:
+          allCookies[`toggle_${toggle.id}`] === 'true'
+            ? true
+            : toggle.defaultValue,
       }),
-      {} as Toggles
+      {} as FeatureFlags
     );
   const tests = togglesResp.tests.reduce((acc, test) => {
     function testToggleValue(Id: string): boolean | undefined {
@@ -76,13 +73,10 @@ export function getTogglesFromContext(
     }
     return {
       ...acc,
-      [test.id]: {
-        value: testToggleValue(test.id),
-        type: 'test',
-      },
+      [test.id]: testToggleValue(test.id),
     };
-  }, {} as Toggles);
-  return { ...featureFlags, ...tests } as Toggles;
+  }, {} as Tests);
+  return { featureFlags, tests };
 }
 
 export default togglesHandler;

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -1,7 +1,7 @@
 import { getCookies } from 'cookies-next';
 import { IncomingMessage } from 'http';
 
-import { FeatureFlags, Tests, TogglesResp } from '@weco/toggles';
+import { FeatureFlags, Tests, Toggles, TogglesResp } from '@weco/toggles';
 
 import { Handler } from './';
 
@@ -36,7 +36,7 @@ export type Context = {
 export function getTogglesFromContext(
   togglesResp: TogglesResp,
   context: Context
-): { featureFlags: FeatureFlags; tests: Tests } {
+): Toggles {
   const isStage = context.req.headers.host?.startsWith('www-stage');
   const allCookies = getCookies(context);
   // Support both old ({ toggles: [...] }) and new ({ featureFlags: [...] }) JSON formats

--- a/common/server-data/types.ts
+++ b/common/server-data/types.ts
@@ -3,7 +3,7 @@ import {
   defaultValue as prismicDefaultValue,
   SimplifiedPrismicData,
 } from '@weco/common/server-data/prismic';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags, Tests, Toggles } from '@weco/toggles';
 
 /**
  * The type is stored here rather than with the service because
@@ -29,7 +29,10 @@ export type ConsentStatusProps = {
 };
 
 export const defaultServerData: SimplifiedServerData = {
-  toggles: {},
+  toggles: {
+    featureFlags: {} as FeatureFlags,
+    tests: {} as Tests,
+  },
   prismic: prismicDefaultValue,
   consentStatus: {
     analytics: false,

--- a/common/services/app/analytics-scripts/google-analytics.tsx
+++ b/common/services/app/analytics-scripts/google-analytics.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { ConsentStatusProps } from '@weco/common/server-data/types';
-import { Toggles } from '@weco/toggles';
+import { Tests, Toggles } from '@weco/toggles';
 
 // Don't use the next/script `Script` component for these as in
 // Next.js v11 it does not work when inside a `Head` component
@@ -16,36 +16,28 @@ type Props = {
 // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en
 // So instead of sending the whole toggles JSON blob, we only look at the "test" typed toggles and send a concatenated string made of the toggles' name
 // , preceeded with a! if its value is false.
-function createABToggleString(toggles: Toggles | undefined): string | null {
-  const testToggles = toggles
-    ? Object.keys(toggles).reduce((acc, key) => {
-        if (toggles?.[key].type === 'test') {
-          acc[key] = toggles?.[key].value;
-        }
-        return acc;
-      }, {})
-    : null;
-  return testToggles
-    ? Object.keys(testToggles)
-        .map(toggle => {
-          switch (testToggles[toggle]) {
-            case true:
-              return toggle;
-            case false:
-              return `!${toggle}`;
-            default:
-              return null;
-          }
-        })
-        .join(',')
-    : null;
+function createABToggleString(tests?: Tests): string | null {
+  if (!tests) return null;
+  const entries = Object.keys(tests)
+    .map(key => {
+      switch (tests[key]) {
+        case true:
+          return key;
+        case false:
+          return `!${key}`;
+        default:
+          return null;
+      }
+    })
+    .filter(Boolean);
+  return entries.length > 0 ? entries.join(',') : null;
 }
 
 export const Ga4DataLayer: FunctionComponent<Props> = ({
   data,
   consentStatus,
 }) => {
-  const abTestsToggleString = createABToggleString(data.toggles);
+  const abTestsToggleString = createABToggleString(data.toggles?.tests);
 
   return (
     <script

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -25,10 +25,7 @@ import CivicUK from '@weco/common/views/components/CivicUK';
 import GlobalSvgDefinitions from '@weco/common/views/components/GlobalSvgDefinitions';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator';
 import ErrorPage from '@weco/common/views/layouts/ErrorPage';
-import {
-  createThemeValues,
-  GlobalStyle,
-} from '@weco/common/views/themes/default';
+import themeValues, { GlobalStyle } from '@weco/common/views/themes/default';
 
 // Error pages can't send anything via the data fetching methods as
 // the page needs to be rendered as soon as the error happens.
@@ -159,13 +156,11 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
     <>
       <ApmContextProvider>
         <ServerDataContext.Provider value={serverData}>
-          <ThemeProvider
-            theme={createThemeValues(serverData.toggles.featureFlags)}
-          >
+          <ThemeProvider theme={themeValues}>
             <UserContextProvider>
               <AppContextProvider>
                 <SearchContextProvider>
-                  <GlobalStyle toggles={serverData.toggles.featureFlags} />
+                  <GlobalStyle />
 
                   <GlobalSvgDefinitions />
                   <LoadingIndicator />

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -159,11 +159,13 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
     <>
       <ApmContextProvider>
         <ServerDataContext.Provider value={serverData}>
-          <ThemeProvider theme={createThemeValues(serverData.toggles)}>
+          <ThemeProvider
+            theme={createThemeValues(serverData.toggles.featureFlags)}
+          >
             <UserContextProvider>
               <AppContextProvider>
                 <SearchContextProvider>
-                  <GlobalStyle toggles={serverData.toggles} />
+                  <GlobalStyle toggles={serverData.toggles.featureFlags} />
 
                   <GlobalSvgDefinitions />
                   <LoadingIndicator />

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -1,6 +1,6 @@
 import { createGlobalStyle, css } from 'styled-components';
 
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { fonts } from './base/fonts';
 import { layout } from './base/layout';
@@ -46,7 +46,7 @@ const cls = {
 } as unknown as Classes & SizedClasses;
 
 export type GlobalStyleProps = {
-  toggles?: Toggles;
+  toggles?: FeatureFlags;
 };
 
 const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
@@ -86,7 +86,7 @@ const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
 
 // Theme factory that creates a theme with appropriate color function based on toggles
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const createThemeValues = (toggles: Toggles) => {
+export const createThemeValues = (toggles: FeatureFlags) => {
   // Manipulate themeValues with toggles here
 
   return {

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -1,7 +1,5 @@
 import { createGlobalStyle, css } from 'styled-components';
 
-import { FeatureFlags } from '@weco/toggles';
-
 import { fonts } from './base/fonts';
 import { layout } from './base/layout';
 import { normalize } from './base/normalize';
@@ -45,11 +43,7 @@ const cls = {
   ...sizesClasses,
 } as unknown as Classes & SizedClasses;
 
-export type GlobalStyleProps = {
-  toggles?: FeatureFlags;
-};
-
-const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
+const GlobalStyle = createGlobalStyle`
   ${css`
     .${cls.displayBlock} {
       display: block;
@@ -84,20 +78,8 @@ const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
   ${typography}
 `;
 
-// Theme factory that creates a theme with appropriate color function based on toggles
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const createThemeValues = (toggles: FeatureFlags) => {
-  // Manipulate themeValues with toggles here
-
-  return {
-    ...themeValues,
-    // Overrides here
-  };
-};
-
 // Static theme instance for backward compatibility
 // Used by: TypeScript type definitions (styled.d.ts), test utilities, and Storybook configuration
-// Production code should use ThemeProvider with createThemeValues(toggles) for toggle-aware themes
 export default themeValues;
 export { GlobalStyle, cls };
 

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -1,8 +1,6 @@
 import { theme as designSystemTheme } from '@wellcometrust/wellcome-design-system/theme';
 import { css } from 'styled-components';
 
-import { GlobalStyleProps } from './default';
-
 // Note: the design system font sizing uses vw units and clamp so that there is
 // a gradated change across viewport widths without a need for breakpoint changes.
 // We have considered the utility of a similar container query based approach using
@@ -17,9 +15,7 @@ const fontFamilies = {
   mono: designSystemTheme.font.family.mono,
 };
 
-const fontSizeMixin = (
-  size: -2 | -1 | 0 | 1 | 2 | 4 | 5
-) => css<GlobalStyleProps>`
+const fontSizeMixin = (size: -2 | -1 | 0 | 1 | 2 | 4 | 5) => css`
   font-size: ${designSystemTheme.font.size[`f${size}`]};
 `;
 type FontFamily = keyof typeof fontFamilies;
@@ -40,7 +36,7 @@ export const fontFamilyMixin = (
   `;
 };
 
-export const typography = css<GlobalStyleProps>`
+export const typography = css`
   .font-sans-bold {
     ${fontFamilyMixin('sans', true)};
   }
@@ -274,7 +270,7 @@ export const typography = css<GlobalStyleProps>`
   }
 `;
 
-export const makeFontSizeClasses = () => css<GlobalStyleProps>`
+export const makeFontSizeClasses = () => css`
   ${Object.entries(designSystemTheme.font.size)
     .map(([key, value]) => {
       return `.font-size-${key} {font-size: ${value}}`;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -1,7 +1,5 @@
 import { css } from 'styled-components';
 
-import { GlobalStyleProps } from './default';
-
 export const visuallyHiddenStyles = css`
   border: 0;
   clip: rect(0 0 0 0);
@@ -16,7 +14,7 @@ export const visuallyHiddenStyles = css`
 
 // Spring 2023: we went through utility classes and decided to only
 // keep the ones that had to do with display status/visibility.
-export const utilityClasses = css<GlobalStyleProps>`
+export const utilityClasses = css`
   .is-hidden {
     display: none !important;
   }

--- a/content/webapp/hooks/useConceptImageUrls.ts
+++ b/content/webapp/hooks/useConceptImageUrls.ts
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { ServerDataContext } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import {
   convertIiifImageUri,
   iiifImageTemplate,
@@ -8,7 +8,6 @@ import {
 import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import type { Concept } from '@weco/content/services/wellcome/catalogue/types';
 import { queryParams } from '@weco/content/utils/concepts';
-import { FeatureFlags } from '@weco/toggles';
 
 /**
  * If displayImages is empty,
@@ -28,10 +27,14 @@ async function fetchImagesBySection(
   sectionName: string,
   concept: Concept,
   limit: number,
-  featureFlags: FeatureFlags
+  shouldUseStagingApi?: boolean
 ): Promise<string[]> {
   const params = queryParams(sectionName, concept);
-  const result = await getImages({ params, featureFlags, pageSize: limit });
+  const result = await getImages({
+    params,
+    shouldUseStagingApi,
+    pageSize: limit,
+  });
   if (!('results' in result) || result.results.length === 0) return [];
   return result.results
     .slice(0, limit)
@@ -40,7 +43,7 @@ async function fetchImagesBySection(
 
 export function useConceptImageUrls(concept: Concept): ConceptImagesArray {
   const [images, setImages] = useState<string[]>([]);
-  const { toggles } = useContext(ServerDataContext);
+  const { stagingApi } = useFeatureFlags();
 
   const cacheKey = concept.id;
 
@@ -78,7 +81,7 @@ export function useConceptImageUrls(concept: Concept): ConceptImagesArray {
           'imagesAbout',
           concept,
           4 - images.length,
-          toggles.featureFlags
+          stagingApi
         );
         return [...images, ...aboutImages];
       };
@@ -91,29 +94,19 @@ export function useConceptImageUrls(concept: Concept): ConceptImagesArray {
         ) {
           // Prioritise images by this person/organisation/agent, then top up with imagesAbout
           fetchedImages = await topUpWithAbout(
-            await fetchImagesBySection(
-              'imagesBy',
-              concept,
-              4,
-              toggles.featureFlags
-            )
+            await fetchImagesBySection('imagesBy', concept, 4, stagingApi)
           );
         } else if (concept.type === 'Genre') {
           // Prioritise images of this type/technique (imagesIn), then top up with imagesAbout
           fetchedImages = await topUpWithAbout(
-            await fetchImagesBySection(
-              'imagesIn',
-              concept,
-              4,
-              toggles.featureFlags
-            )
+            await fetchImagesBySection('imagesIn', concept, 4, stagingApi)
           );
         } else {
           fetchedImages = await fetchImagesBySection(
             'imagesAbout',
             concept,
             4,
-            toggles.featureFlags
+            stagingApi
           );
         }
 
@@ -139,7 +132,7 @@ export function useConceptImageUrls(concept: Concept): ConceptImagesArray {
     return () => {
       isMounted = false;
     };
-  }, [cacheKey, concept.displayImages, concept.type, toggles]);
+  }, [cacheKey, concept.displayImages, concept.type, stagingApi]);
 
   return [images[0], images[1], images[2], images[3]] as ConceptImagesArray;
 }

--- a/content/webapp/hooks/useConceptImageUrls.ts
+++ b/content/webapp/hooks/useConceptImageUrls.ts
@@ -8,7 +8,7 @@ import {
 import { getImages } from '@weco/content/services/wellcome/catalogue/images';
 import type { Concept } from '@weco/content/services/wellcome/catalogue/types';
 import { queryParams } from '@weco/content/utils/concepts';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 /**
  * If displayImages is empty,
@@ -28,10 +28,10 @@ async function fetchImagesBySection(
   sectionName: string,
   concept: Concept,
   limit: number,
-  toggles: Toggles
+  featureFlags: FeatureFlags
 ): Promise<string[]> {
   const params = queryParams(sectionName, concept);
-  const result = await getImages({ params, toggles, pageSize: limit });
+  const result = await getImages({ params, featureFlags, pageSize: limit });
   if (!('results' in result) || result.results.length === 0) return [];
   return result.results
     .slice(0, limit)
@@ -78,7 +78,7 @@ export function useConceptImageUrls(concept: Concept): ConceptImagesArray {
           'imagesAbout',
           concept,
           4 - images.length,
-          toggles
+          toggles.featureFlags
         );
         return [...images, ...aboutImages];
       };
@@ -91,19 +91,29 @@ export function useConceptImageUrls(concept: Concept): ConceptImagesArray {
         ) {
           // Prioritise images by this person/organisation/agent, then top up with imagesAbout
           fetchedImages = await topUpWithAbout(
-            await fetchImagesBySection('imagesBy', concept, 4, toggles)
+            await fetchImagesBySection(
+              'imagesBy',
+              concept,
+              4,
+              toggles.featureFlags
+            )
           );
         } else if (concept.type === 'Genre') {
           // Prioritise images of this type/technique (imagesIn), then top up with imagesAbout
           fetchedImages = await topUpWithAbout(
-            await fetchImagesBySection('imagesIn', concept, 4, toggles)
+            await fetchImagesBySection(
+              'imagesIn',
+              concept,
+              4,
+              toggles.featureFlags
+            )
           );
         } else {
           fetchedImages = await fetchImagesBySection(
             'imagesAbout',
             concept,
             4,
-            toggles
+            toggles.featureFlags
           );
         }
 

--- a/content/webapp/pages/api/works/[workId].tsx
+++ b/content/webapp/pages/api/works/[workId].tsx
@@ -30,9 +30,9 @@ const WorksApi = async (
     ],
     tests: [],
   };
-  const toggles = getTogglesFromContext(togglesResp, { req });
+  const { featureFlags } = getTogglesFromContext(togglesResp, { req });
 
-  const response = await getWork({ id: workId, toggles });
+  const response = await getWork({ id: workId, featureFlags });
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/content/webapp/pages/api/works/[workId].tsx
+++ b/content/webapp/pages/api/works/[workId].tsx
@@ -32,7 +32,10 @@ const WorksApi = async (
   };
   const { featureFlags } = getTogglesFromContext(togglesResp, { req });
 
-  const response = await getWork({ id: workId, featureFlags });
+  const response = await getWork({
+    id: workId,
+    shouldUseStagingApi: featureFlags.stagingApi,
+  });
 
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/content/webapp/pages/api/works/items/[workId].tsx
+++ b/content/webapp/pages/api/works/items/[workId].tsx
@@ -11,7 +11,7 @@ import {
 } from '@weco/content/services/wellcome';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
 import { ItemsList } from '@weco/content/services/wellcome/catalogue/types';
-import { FeatureFlags, TogglesResp } from '@weco/toggles';
+import { TogglesResp } from '@weco/toggles';
 
 function getApiUrl(apiOptions: GlobalApiOptions, workId: string): string {
   return `${rootUris[apiOptions.env.catalogue]}/catalogue/v2/works/${workId}/items`;
@@ -32,12 +32,12 @@ function getApiKey(apiOptions: GlobalApiOptions): string {
 
 async function fetchWorkItems({
   workId,
-  featureFlags,
+  shouldUseStagingApi,
 }: {
   workId: string;
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
 }): Promise<ItemsList | WellcomeApiError> {
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
   const apiUrl = getApiUrl(apiOptions, workId);
   try {
     const items = await fetch(apiUrl, {
@@ -79,7 +79,7 @@ const ItemsApi = async (
     return;
   }
   const response = await fetchWorkItems({
-    featureFlags,
+    shouldUseStagingApi: featureFlags.stagingApi,
     workId,
   });
   res.setHeader('Content-Type', 'application/json');

--- a/content/webapp/pages/api/works/items/[workId].tsx
+++ b/content/webapp/pages/api/works/items/[workId].tsx
@@ -11,7 +11,7 @@ import {
 } from '@weco/content/services/wellcome';
 import { looksLikeCanonicalId } from '@weco/content/services/wellcome/catalogue';
 import { ItemsList } from '@weco/content/services/wellcome/catalogue/types';
-import { Toggles, TogglesResp } from '@weco/toggles';
+import { FeatureFlags, TogglesResp } from '@weco/toggles';
 
 function getApiUrl(apiOptions: GlobalApiOptions, workId: string): string {
   return `${rootUris[apiOptions.env.catalogue]}/catalogue/v2/works/${workId}/items`;
@@ -32,12 +32,12 @@ function getApiKey(apiOptions: GlobalApiOptions): string {
 
 async function fetchWorkItems({
   workId,
-  toggles,
+  featureFlags,
 }: {
   workId: string;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
 }): Promise<ItemsList | WellcomeApiError> {
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
   const apiUrl = getApiUrl(apiOptions, workId);
   try {
     const items = await fetch(apiUrl, {
@@ -71,7 +71,7 @@ const ItemsApi = async (
     ],
     tests: [],
   };
-  const toggles = getTogglesFromContext(togglesResp, { req });
+  const { featureFlags } = getTogglesFromContext(togglesResp, { req });
   const { workId } = req.query;
 
   if (!isString(workId) || !looksLikeCanonicalId(workId)) {
@@ -79,7 +79,7 @@ const ItemsApi = async (
     return;
   }
   const response = await fetchWorkItems({
-    toggles,
+    featureFlags,
     workId,
   });
   res.setHeader('Content-Type', 'application/json');

--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -106,7 +106,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
           params: {
             identifiers: newOnlineWorkIds,
           },
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
         });
 
         if (works.type !== 'Error') {

--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -106,7 +106,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
           params: {
             identifiers: newOnlineWorkIds,
           },
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
         });
 
         if (works.type !== 'Error') {

--- a/content/webapp/pages/collections/new-online.tsx
+++ b/content/webapp/pages/collections/new-online.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       page,
     },
     pageSize: 32,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (works.type === 'Error') {

--- a/content/webapp/pages/collections/new-online.tsx
+++ b/content/webapp/pages/collections/new-online.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       page,
     },
     pageSize: 32,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (works.type === 'Error') {

--- a/content/webapp/pages/collections/people-and-organisations.tsx
+++ b/content/webapp/pages/collections/people-and-organisations.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.thematicBrowsing.value) {
+  if (!serverData.toggles.featureFlags.thematicBrowsing) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/collections/places.tsx
+++ b/content/webapp/pages/collections/places.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.thematicBrowsing.value) {
+  if (!serverData.toggles.featureFlags.thematicBrowsing) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/collections/subjects/[uid].tsx
+++ b/content/webapp/pages/collections/subjects/[uid].tsx
@@ -118,7 +118,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       sortOrder: 'desc',
     },
     pageSize: 3,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (newOnlineWorksQuery.type !== 'Error') {
@@ -167,7 +167,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       params: {
         id: CONCEPT_GROUPS[pageUid].join(','),
       },
-      featureFlags: serverData.toggles.featureFlags,
+      shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
     });
 
     if (conceptResponse.type === 'Error') {
@@ -190,7 +190,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             params: {
               subjects: CONCEPT_GROUPS[pageUid],
             },
-            featureFlags: serverData.toggles.featureFlags,
+            shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
             pageSize: 5,
           }),
         byLabel: () =>
@@ -199,7 +199,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
               'subjects.label': displayLabels,
               aggregations: ['workType'],
             },
-            featureFlags: serverData.toggles.featureFlags,
+            shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
             pageSize: 5,
           }),
       },
@@ -209,7 +209,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             params: {
               'source.subjects': CONCEPT_GROUPS[pageUid],
             },
-            featureFlags: serverData.toggles.featureFlags,
+            shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
             pageSize: 12,
           }),
         byLabel: () =>
@@ -219,7 +219,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
                 c => c.label
               ),
             },
-            featureFlags: serverData.toggles.featureFlags,
+            shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
             pageSize: 12,
           }),
       },

--- a/content/webapp/pages/collections/subjects/[uid].tsx
+++ b/content/webapp/pages/collections/subjects/[uid].tsx
@@ -81,8 +81,8 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   if (
     !(
-      serverData.toggles.thematicBrowsing.value &&
-      serverData.toggles.thematicBrowsingSubCategory.value
+      serverData.toggles.featureFlags.thematicBrowsing &&
+      serverData.toggles.featureFlags.thematicBrowsingSubCategory
     ) ||
     !pageUid ||
     !subjectsEnum.includes(pageUid)
@@ -118,7 +118,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       sortOrder: 'desc',
     },
     pageSize: 3,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (newOnlineWorksQuery.type !== 'Error') {
@@ -167,7 +167,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       params: {
         id: CONCEPT_GROUPS[pageUid].join(','),
       },
-      toggles: serverData.toggles,
+      featureFlags: serverData.toggles.featureFlags,
     });
 
     if (conceptResponse.type === 'Error') {
@@ -190,7 +190,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             params: {
               subjects: CONCEPT_GROUPS[pageUid],
             },
-            toggles: serverData.toggles,
+            featureFlags: serverData.toggles.featureFlags,
             pageSize: 5,
           }),
         byLabel: () =>
@@ -199,7 +199,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
               'subjects.label': displayLabels,
               aggregations: ['workType'],
             },
-            toggles: serverData.toggles,
+            featureFlags: serverData.toggles.featureFlags,
             pageSize: 5,
           }),
       },
@@ -209,7 +209,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             params: {
               'source.subjects': CONCEPT_GROUPS[pageUid],
             },
-            toggles: serverData.toggles,
+            featureFlags: serverData.toggles.featureFlags,
             pageSize: 12,
           }),
         byLabel: () =>
@@ -219,7 +219,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
                 c => c.label
               ),
             },
-            toggles: serverData.toggles,
+            featureFlags: serverData.toggles.featureFlags,
             pageSize: 12,
           }),
       },

--- a/content/webapp/pages/collections/subjects/index.tsx
+++ b/content/webapp/pages/collections/subjects/index.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.thematicBrowsing.value) {
+  if (!serverData.toggles.featureFlags.thematicBrowsing) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/collections/types-and-techniques.tsx
+++ b/content/webapp/pages/collections/types-and-techniques.tsx
@@ -22,7 +22,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.thematicBrowsing.value) {
+  if (!serverData.toggles.featureFlags.thematicBrowsing) {
     return {
       notFound: true,
     };

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -85,7 +85,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const conceptResponse = await getConcept({
     id: conceptId,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (conceptResponse.type === 'Error') {
@@ -104,13 +104,13 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       byId: (sectionName: string) =>
         getWorks({
           params: queryParams(sectionName, conceptResponse),
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
           pageSize: 5,
         }),
       byLabel: (sectionName: string) =>
         getWorks({
           params: allRecordsLinkParams(sectionName, conceptResponse),
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
           pageSize: 5,
         }),
     },
@@ -118,13 +118,13 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       byId: (sectionName: string) =>
         getImages({
           params: queryParams(sectionName, conceptResponse),
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
           pageSize: 12,
         }),
       byLabel: (sectionName: string) =>
         getImages({
           params: allRecordsLinkParams(sectionName, conceptResponse),
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
           pageSize: 12,
         }),
     },

--- a/content/webapp/pages/concepts/[conceptId].tsx
+++ b/content/webapp/pages/concepts/[conceptId].tsx
@@ -85,7 +85,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const conceptResponse = await getConcept({
     id: conceptId,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (conceptResponse.type === 'Error') {
@@ -104,13 +104,13 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       byId: (sectionName: string) =>
         getWorks({
           params: queryParams(sectionName, conceptResponse),
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
           pageSize: 5,
         }),
       byLabel: (sectionName: string) =>
         getWorks({
           params: allRecordsLinkParams(sectionName, conceptResponse),
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
           pageSize: 5,
         }),
     },
@@ -118,13 +118,13 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       byId: (sectionName: string) =>
         getImages({
           params: queryParams(sectionName, conceptResponse),
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
           pageSize: 12,
         }),
       byLabel: (sectionName: string) =>
         getImages({
           params: allRecordsLinkParams(sectionName, conceptResponse),
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
           pageSize: 12,
         }),
     },

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -62,7 +62,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       ),
     },
     pageSize: 25,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (eventResponseList?.type === 'Error') {

--- a/content/webapp/pages/events/index.tsx
+++ b/content/webapp/pages/events/index.tsx
@@ -62,7 +62,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       ),
     },
     pageSize: 25,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (eventResponseList?.type === 'Error') {

--- a/content/webapp/pages/events/past.tsx
+++ b/content/webapp/pages/events/past.tsx
@@ -75,7 +75,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       ].filter(isNotUndefined),
     },
     pageSize: 25,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (eventResponseList?.type === 'Error') {

--- a/content/webapp/pages/events/past.tsx
+++ b/content/webapp/pages/events/past.tsx
@@ -75,7 +75,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       ].filter(isNotUndefined),
     },
     pageSize: 25,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (eventResponseList?.type === 'Error') {

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -74,7 +74,8 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     ) as RawThemeCardsListSlice | undefined;
 
     const themeCardsListSlice =
-      rawThemeCardsListSlice && serverData.toggles.exhibitionAndCollection.value
+      rawThemeCardsListSlice &&
+      serverData.toggles.featureFlags.exhibitionAndCollection
         ? transformThemeCardsList(rawThemeCardsListSlice)
         : undefined;
 

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const articlesResponsePromise = getArticles({
     params: {},
     pageSize: 4,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   const eventsQueryPromise = fetchEvents(client, {

--- a/content/webapp/pages/index.tsx
+++ b/content/webapp/pages/index.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const articlesResponsePromise = getArticles({
     params: {},
     pageSize: 4,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   const eventsQueryPromise = fetchEvents(client, {

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -46,7 +46,7 @@ export const getGenericPageProps = async ({
 }) => {
   const bodySliceContexts = await getBodySliceContexts(
     page.untransformedBody,
-    serverData.toggles.featureFlags
+    serverData.toggles.featureFlags.stagingApi
   );
 
   const jsonLd = genericPageLd({ page, canonicalUrl });

--- a/content/webapp/pages/pages/[pageId].tsx
+++ b/content/webapp/pages/pages/[pageId].tsx
@@ -46,7 +46,7 @@ export const getGenericPageProps = async ({
 }) => {
   const bodySliceContexts = await getBodySliceContexts(
     page.untransformedBody,
-    serverData.toggles
+    serverData.toggles.featureFlags
   );
 
   const jsonLd = genericPageLd({ page, canonicalUrl });

--- a/content/webapp/pages/search/concepts.tsx
+++ b/content/webapp/pages/search/concepts.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const concepts = await getConcepts({
     params,
     pageSize: 25,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (concepts.type === 'Error') {

--- a/content/webapp/pages/search/concepts.tsx
+++ b/content/webapp/pages/search/concepts.tsx
@@ -29,7 +29,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const serverData = await getServerData(context);
 
   // Redirect to main search page if concepts search toggle is disabled
-  if (!serverData.toggles.conceptsSearch?.value) {
+  if (!serverData.toggles.featureFlags.conceptsSearch) {
     return {
       redirect: {
         destination: '/search',
@@ -69,7 +69,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const concepts = await getConcepts({
     params,
     pageSize: 25,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (concepts.type === 'Error') {

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       ],
     },
     pageSize: 24,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (eventResponseList?.type === 'Error') {

--- a/content/webapp/pages/search/events.tsx
+++ b/content/webapp/pages/search/events.tsx
@@ -98,7 +98,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       ],
     },
     pageSize: 24,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (eventResponseList?.type === 'Error') {

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -76,7 +76,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   };
   const images = await getImages({
     params: apiProps,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
     pageSize: 30,
   });
 

--- a/content/webapp/pages/search/images.tsx
+++ b/content/webapp/pages/search/images.tsx
@@ -76,7 +76,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   };
   const images = await getImages({
     params: apiProps,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
     pageSize: 30,
   });
 

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     const contentResults = await getAddressables({
       params: query,
       pageSize: 20,
-      featureFlags: serverData.toggles.featureFlags,
+      shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
     });
 
     if (contentResults.type === 'Error') {

--- a/content/webapp/pages/search/index.tsx
+++ b/content/webapp/pages/search/index.tsx
@@ -55,7 +55,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     const contentResults = await getAddressables({
       params: query,
       pageSize: 20,
-      toggles: serverData.toggles,
+      featureFlags: serverData.toggles.featureFlags,
     });
 
     if (contentResults.type === 'Error') {

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       aggregations: ['format', 'contributors.contributor'],
     },
     pageSize: 25,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (storyResponseList?.type === 'Error') {

--- a/content/webapp/pages/search/stories.tsx
+++ b/content/webapp/pages/search/stories.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       aggregations: ['format', 'contributors.contributor'],
     },
     pageSize: 25,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (storyResponseList?.type === 'Error') {

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -39,9 +39,9 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const query = context.query;
   // TODO can remove searchIn when we remove the `semanticSearchPrototype` and `semanticSearchComparison` toggles,
   const semanticSearchPrototype =
-    serverData.toggles.semanticSearchPrototype.value;
+    serverData.toggles.featureFlags.semanticSearchPrototype;
   const semanticSearchComparison =
-    serverData.toggles.semanticSearchComparison.value;
+    serverData.toggles.featureFlags.semanticSearchComparison;
 
   // NOTE: The following logic exists to support two feature toggles used
   // for the semantic-search experiment (`semanticSearchPrototype` and
@@ -91,7 +91,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     };
   }
 
-  const aggregations = serverData.toggles.aggregationsInSearch?.value
+  const aggregations = serverData.toggles.featureFlags.aggregationsInSearch
     ? [
         'workType',
         'availabilities',
@@ -133,7 +133,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     const worksResult = await getWorks({
       params: worksApiProps,
       pageSize: 25,
-      toggles: serverData.toggles,
+      featureFlags: serverData.toggles.featureFlags,
     });
 
     if (worksResult.type === 'Error') {
@@ -170,7 +170,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             elasticCluster: getElasticCluster('alternative2'),
           },
           pageSize: 25,
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
         })
       : Promise.resolve(null);
 
@@ -181,7 +181,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             elasticCluster: getElasticCluster('alternative3'),
           },
           pageSize: 25,
-          toggles: serverData.toggles,
+          featureFlags: serverData.toggles.featureFlags,
         })
       : Promise.resolve(null);
 

--- a/content/webapp/pages/search/works.tsx
+++ b/content/webapp/pages/search/works.tsx
@@ -133,7 +133,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     const worksResult = await getWorks({
       params: worksApiProps,
       pageSize: 25,
-      featureFlags: serverData.toggles.featureFlags,
+      shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
     });
 
     if (worksResult.type === 'Error') {
@@ -170,7 +170,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             elasticCluster: getElasticCluster('alternative2'),
           },
           pageSize: 25,
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
         })
       : Promise.resolve(null);
 
@@ -181,7 +181,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
             elasticCluster: getElasticCluster('alternative3'),
           },
           pageSize: 25,
-          featureFlags: serverData.toggles.featureFlags,
+          shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
         })
       : Promise.resolve(null);
 

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const articlesResponsePromise = getArticles({
     params: {},
     pageSize: 11,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   const [articlesResponse, storiesLandingDoc, comicsQuery] = await Promise.all([

--- a/content/webapp/pages/stories/index.tsx
+++ b/content/webapp/pages/stories/index.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const articlesResponsePromise = getArticles({
     params: {},
     pageSize: 11,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   const [articlesResponse, storiesLandingDoc, comicsQuery] = await Promise.all([

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -32,7 +32,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.storiesKiosk?.value) {
+  if (!serverData.toggles.featureFlags.storiesKiosk) {
     return { notFound: true };
   }
 

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -39,7 +39,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const work = await getWork({
     id: workId,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (work.type === 'Error') {

--- a/content/webapp/pages/works/[workId]/download.tsx
+++ b/content/webapp/pages/works/[workId]/download.tsx
@@ -39,7 +39,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const work = await getWork({
     id: workId,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (work.type === 'Error') {

--- a/content/webapp/pages/works/[workId]/images.tsx
+++ b/content/webapp/pages/works/[workId]/images.tsx
@@ -57,7 +57,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const { url: catalogueApiUrl, image } = await getImage({
     id,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (image.type === 'Error') {
@@ -78,7 +78,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const work = await getWork({
     id: workId,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (work.type === 'Error') {

--- a/content/webapp/pages/works/[workId]/images.tsx
+++ b/content/webapp/pages/works/[workId]/images.tsx
@@ -57,7 +57,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const { url: catalogueApiUrl, image } = await getImage({
     id,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (image.type === 'Error') {
@@ -78,7 +78,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const work = await getWork({
     id: workId,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (work.type === 'Error') {

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -36,7 +36,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const workResponse = await getWork({
     id: workId,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
   });
 
   if (workResponse.type === 'Redirect') {

--- a/content/webapp/pages/works/[workId]/index.tsx
+++ b/content/webapp/pages/works/[workId]/index.tsx
@@ -36,7 +36,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const workResponse = await getWork({
     id: workId,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
   });
 
   if (workResponse.type === 'Redirect') {

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -76,7 +76,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const work = await getWork({
     id: context.query.workId,
-    toggles: serverData.toggles,
+    featureFlags: serverData.toggles.featureFlags,
     include: ['items', 'languages', 'contributors', 'production', 'notes'],
   });
 

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -76,7 +76,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const work = await getWork({
     id: context.query.workId,
-    featureFlags: serverData.toggles.featureFlags,
+    shouldUseStagingApi: serverData.toggles.featureFlags.stagingApi,
     include: ['items', 'languages', 'contributors', 'production', 'notes'],
   });
 

--- a/content/webapp/services/prismic/fetch/body-slice-contexts.ts
+++ b/content/webapp/services/prismic/fetch/body-slice-contexts.ts
@@ -4,11 +4,10 @@ import {
 } from '@weco/common/prismicio-types';
 import { getArchiveWorks } from '@weco/content/services/wellcome/catalogue/works';
 import { BodySliceContexts } from '@weco/content/views/components/Body';
-import { FeatureFlags } from '@weco/toggles';
 
 export async function getBodySliceContexts(
   bodySlices: PagesDocumentDataBodySlice[],
-  featureFlags: FeatureFlags
+  shouldUseStagingApi?: boolean
 ): Promise<BodySliceContexts> {
   const archiveCardIds = bodySlices
     .filter(
@@ -21,7 +20,7 @@ export async function getBodySliceContexts(
 
   const archiveWorks =
     archiveCardIds.length > 0
-      ? await getArchiveWorks(archiveCardIds, featureFlags)
+      ? await getArchiveWorks(archiveCardIds, shouldUseStagingApi)
       : {};
 
   return { archiveWorks };

--- a/content/webapp/services/prismic/fetch/body-slice-contexts.ts
+++ b/content/webapp/services/prismic/fetch/body-slice-contexts.ts
@@ -4,11 +4,11 @@ import {
 } from '@weco/common/prismicio-types';
 import { getArchiveWorks } from '@weco/content/services/wellcome/catalogue/works';
 import { BodySliceContexts } from '@weco/content/views/components/Body';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 export async function getBodySliceContexts(
   bodySlices: PagesDocumentDataBodySlice[],
-  toggles: Toggles
+  featureFlags: FeatureFlags
 ): Promise<BodySliceContexts> {
   const archiveCardIds = bodySlices
     .filter(
@@ -21,7 +21,7 @@ export async function getBodySliceContexts(
 
   const archiveWorks =
     archiveCardIds.length > 0
-      ? await getArchiveWorks(archiveCardIds, toggles)
+      ? await getArchiveWorks(archiveCardIds, featureFlags)
       : {};
 
   return { archiveWorks };

--- a/content/webapp/services/wellcome/catalogue/concepts.ts
+++ b/content/webapp/services/wellcome/catalogue/concepts.ts
@@ -6,7 +6,6 @@ import {
   WellcomeApiError,
   wellcomeApiFetch,
 } from '@weco/content/services/wellcome/';
-import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery, looksLikeCanonicalId, notFound } from '.';
 import {
@@ -17,20 +16,20 @@ import {
 
 type GetConceptProps = {
   id: string;
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
 };
 
 type ConceptResponse = Concept | WellcomeApiError;
 
 export async function getConcept({
   id,
-  featureFlags,
+  shouldUseStagingApi,
 }: GetConceptProps): Promise<ConceptResponse> {
   if (!looksLikeCanonicalId(id)) {
     return notFound();
   }
 
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
 
   const url = `${rootUris[apiOptions.env.concepts]}/catalogue/v2/concepts/${id}`;
 
@@ -59,7 +58,10 @@ export async function getConcepts(
  * Fetch concepts (topics) from the concepts API
  * Returns concepts that can be used for browse topics
  */
-export async function getConceptsByIds(ids: string[]): Promise<Concept[]> {
+export async function getConceptsByIds(
+  ids: string[],
+  shouldUseStagingApi?: boolean
+): Promise<Concept[]> {
   if (!ids || ids.length === 0) return [];
 
   // Filter to valid canonical IDs before querying
@@ -70,7 +72,7 @@ export async function getConceptsByIds(ids: string[]): Promise<Concept[]> {
 
   const result = await getConcepts({
     params: { id: validIds.join(',') },
-    featureFlags: {} as FeatureFlags,
+    shouldUseStagingApi,
   });
 
   if ('results' in result) return result.results;

--- a/content/webapp/services/wellcome/catalogue/concepts.ts
+++ b/content/webapp/services/wellcome/catalogue/concepts.ts
@@ -6,7 +6,7 @@ import {
   WellcomeApiError,
   wellcomeApiFetch,
 } from '@weco/content/services/wellcome/';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery, looksLikeCanonicalId, notFound } from '.';
 import {
@@ -17,20 +17,20 @@ import {
 
 type GetConceptProps = {
   id: string;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
 };
 
 type ConceptResponse = Concept | WellcomeApiError;
 
 export async function getConcept({
   id,
-  toggles,
+  featureFlags,
 }: GetConceptProps): Promise<ConceptResponse> {
   if (!looksLikeCanonicalId(id)) {
     return notFound();
   }
 
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
 
   const url = `${rootUris[apiOptions.env.concepts]}/catalogue/v2/concepts/${id}`;
 
@@ -70,7 +70,7 @@ export async function getConceptsByIds(ids: string[]): Promise<Concept[]> {
 
   const result = await getConcepts({
     params: { id: validIds.join(',') },
-    toggles: {},
+    featureFlags: {} as FeatureFlags,
   });
 
   if ('results' in result) return result.results;

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -13,7 +13,7 @@ import {
   ImagesProps,
   toQuery,
 } from '@weco/content/views/components/SearchPagesLink/Images';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery, looksLikeCanonicalId, notFound } from '.';
 import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
@@ -26,7 +26,7 @@ type ImageInclude =
 
 type GetImageProps = {
   id: string;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
   include?: ImageInclude[];
 };
 
@@ -71,14 +71,14 @@ type ImageResponse = {
 
 export async function getImage({
   id,
-  toggles,
+  featureFlags,
   include = [],
 }: GetImageProps): Promise<ImageResponse> {
   if (!looksLikeCanonicalId(id)) {
     return { image: notFound() };
   }
 
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
 
   const params = {
     include,

--- a/content/webapp/services/wellcome/catalogue/images.ts
+++ b/content/webapp/services/wellcome/catalogue/images.ts
@@ -13,7 +13,6 @@ import {
   ImagesProps,
   toQuery,
 } from '@weco/content/views/components/SearchPagesLink/Images';
-import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery, looksLikeCanonicalId, notFound } from '.';
 import { CatalogueImagesApiProps, CatalogueResultsList, Image } from './types';
@@ -26,7 +25,7 @@ type ImageInclude =
 
 type GetImageProps = {
   id: string;
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
   include?: ImageInclude[];
 };
 
@@ -71,14 +70,14 @@ type ImageResponse = {
 
 export async function getImage({
   id,
-  featureFlags,
+  shouldUseStagingApi,
   include = [],
 }: GetImageProps): Promise<ImageResponse> {
   if (!looksLikeCanonicalId(id)) {
     return { image: notFound() };
   }
 
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
 
   const params = {
     include,

--- a/content/webapp/services/wellcome/catalogue/index.ts
+++ b/content/webapp/services/wellcome/catalogue/index.ts
@@ -23,9 +23,9 @@ export const notFound = (): WellcomeApiError => ({
 
 export async function catalogueQuery<Params, Result extends ResultType>(
   endpoint: string,
-  { params, featureFlags, pageSize }: QueryProps<Params>
+  { params, shouldUseStagingApi, pageSize }: QueryProps<Params>
 ): Promise<CatalogueResultsList<Result> | WellcomeApiError> {
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
   const extendedParams = {
     ...params,
     pageSize,

--- a/content/webapp/services/wellcome/catalogue/index.ts
+++ b/content/webapp/services/wellcome/catalogue/index.ts
@@ -23,9 +23,9 @@ export const notFound = (): WellcomeApiError => ({
 
 export async function catalogueQuery<Params, Result extends ResultType>(
   endpoint: string,
-  { params, toggles, pageSize }: QueryProps<Params>
+  { params, featureFlags, pageSize }: QueryProps<Params>
 ): Promise<CatalogueResultsList<Result> | WellcomeApiError> {
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
   const extendedParams = {
     ...params,
     pageSize,

--- a/content/webapp/services/wellcome/catalogue/workTypeAggregations.test.ts
+++ b/content/webapp/services/wellcome/catalogue/workTypeAggregations.test.ts
@@ -161,7 +161,7 @@ describe('workTypeAggregations', () => {
       const result = await fetchImagesCount();
 
       expect(mockCatalogueQuery).toHaveBeenCalledWith('images', {
-        toggles: {},
+        shouldUseStagingApi: undefined,
         pageSize: 1,
         params: {},
       });

--- a/content/webapp/services/wellcome/catalogue/workTypeAggregations.ts
+++ b/content/webapp/services/wellcome/catalogue/workTypeAggregations.ts
@@ -1,5 +1,4 @@
 import { WellcomeAggregation } from '@weco/content/services/wellcome';
-import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery } from '.';
 import { WorkAggregations } from './types/aggregations';
@@ -93,11 +92,11 @@ export function transformWorkTypeAggregations(
 }
 
 export async function fetchWorksAggregations(
-  featureFlags: FeatureFlags = {} as FeatureFlags
+  shouldUseStagingApi?: boolean
 ): Promise<WellcomeAggregation | null> {
   try {
     const result = await catalogueQuery('works', {
-      featureFlags,
+      shouldUseStagingApi,
       pageSize: 1,
       params: {
         aggregations: 'workType',
@@ -124,11 +123,11 @@ export async function fetchWorksAggregations(
 }
 
 export async function fetchImagesCount(
-  featureFlags: FeatureFlags = {} as FeatureFlags
+  shouldUseStagingApi?: boolean
 ): Promise<number | null> {
   try {
     const result = await catalogueQuery('images', {
-      featureFlags,
+      shouldUseStagingApi,
       pageSize: 1,
       params: {},
     });
@@ -146,14 +145,14 @@ export async function fetchImagesCount(
 }
 
 export async function fetchCollectionStats(
-  featureFlags: FeatureFlags = {} as FeatureFlags
+  shouldUseStagingApi?: boolean
 ): Promise<CollectionStats> {
   const collectionStats = createDefaultCollectionStats();
 
   try {
     const [worksResult, imagesResult] = await Promise.allSettled([
-      fetchWorksAggregations(featureFlags),
-      fetchImagesCount(featureFlags),
+      fetchWorksAggregations(shouldUseStagingApi),
+      fetchImagesCount(shouldUseStagingApi),
     ]);
 
     if (worksResult.status === 'fulfilled' && worksResult.value !== null) {

--- a/content/webapp/services/wellcome/catalogue/workTypeAggregations.ts
+++ b/content/webapp/services/wellcome/catalogue/workTypeAggregations.ts
@@ -1,5 +1,5 @@
 import { WellcomeAggregation } from '@weco/content/services/wellcome';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery } from '.';
 import { WorkAggregations } from './types/aggregations';
@@ -93,11 +93,11 @@ export function transformWorkTypeAggregations(
 }
 
 export async function fetchWorksAggregations(
-  toggles: Toggles = {}
+  featureFlags: FeatureFlags = {} as FeatureFlags
 ): Promise<WellcomeAggregation | null> {
   try {
     const result = await catalogueQuery('works', {
-      toggles,
+      featureFlags,
       pageSize: 1,
       params: {
         aggregations: 'workType',
@@ -124,11 +124,11 @@ export async function fetchWorksAggregations(
 }
 
 export async function fetchImagesCount(
-  toggles: Toggles = {}
+  featureFlags: FeatureFlags = {} as FeatureFlags
 ): Promise<number | null> {
   try {
     const result = await catalogueQuery('images', {
-      toggles,
+      featureFlags,
       pageSize: 1,
       params: {},
     });
@@ -146,14 +146,14 @@ export async function fetchImagesCount(
 }
 
 export async function fetchCollectionStats(
-  toggles: Toggles = {}
+  featureFlags: FeatureFlags = {} as FeatureFlags
 ): Promise<CollectionStats> {
   const collectionStats = createDefaultCollectionStats();
 
   try {
     const [worksResult, imagesResult] = await Promise.allSettled([
-      fetchWorksAggregations(toggles),
-      fetchImagesCount(toggles),
+      fetchWorksAggregations(featureFlags),
+      fetchImagesCount(featureFlags),
     ]);
 
     if (worksResult.status === 'fulfilled' && worksResult.value !== null) {

--- a/content/webapp/services/wellcome/catalogue/works.ts
+++ b/content/webapp/services/wellcome/catalogue/works.ts
@@ -13,7 +13,6 @@ import {
   toQuery,
   WorksProps,
 } from '@weco/content/views/components/SearchPagesLink/Works';
-import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery, looksLikeCanonicalId, notFound } from '.';
 import {
@@ -33,7 +32,7 @@ export type ArchiveWorkData = {
 
 type GetWorkProps = {
   id: string;
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
   include?: string[];
 };
 
@@ -109,14 +108,14 @@ type WorkResponse =
 
 export async function getWork({
   id,
-  featureFlags,
+  shouldUseStagingApi,
   include = workIncludes,
 }: GetWorkProps): Promise<WorkResponse> {
   if (!looksLikeCanonicalId(id)) {
     return notFound();
   }
 
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
 
   const params = {
     include,
@@ -176,11 +175,15 @@ export async function getWorkClientSide(workId: string): Promise<WorkResponse> {
 
 export async function getArchiveWorks(
   ids: string[],
-  featureFlags: FeatureFlags
+  shouldUseStagingApi?: boolean
 ): Promise<Record<string, ArchiveWorkData>> {
   const settled = await Promise.allSettled(
     ids.map(id =>
-      getWork({ id, featureFlags, include: ['production', 'contributors'] })
+      getWork({
+        id,
+        shouldUseStagingApi,
+        include: ['production', 'contributors'],
+      })
     )
   );
 

--- a/content/webapp/services/wellcome/catalogue/works.ts
+++ b/content/webapp/services/wellcome/catalogue/works.ts
@@ -13,7 +13,7 @@ import {
   toQuery,
   WorksProps,
 } from '@weco/content/views/components/SearchPagesLink/Works';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { catalogueQuery, looksLikeCanonicalId, notFound } from '.';
 import {
@@ -33,7 +33,7 @@ export type ArchiveWorkData = {
 
 type GetWorkProps = {
   id: string;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
   include?: string[];
 };
 
@@ -109,14 +109,14 @@ type WorkResponse =
 
 export async function getWork({
   id,
-  toggles,
+  featureFlags,
   include = workIncludes,
 }: GetWorkProps): Promise<WorkResponse> {
   if (!looksLikeCanonicalId(id)) {
     return notFound();
   }
 
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
 
   const params = {
     include,
@@ -176,11 +176,11 @@ export async function getWorkClientSide(workId: string): Promise<WorkResponse> {
 
 export async function getArchiveWorks(
   ids: string[],
-  toggles: Toggles
+  featureFlags: FeatureFlags
 ): Promise<Record<string, ArchiveWorkData>> {
   const settled = await Promise.allSettled(
     ids.map(id =>
-      getWork({ id, toggles, include: ['production', 'contributors'] })
+      getWork({ id, featureFlags, include: ['production', 'contributors'] })
     )
   );
 

--- a/content/webapp/services/wellcome/content/all.ts
+++ b/content/webapp/services/wellcome/content/all.ts
@@ -4,6 +4,7 @@ import {
   ContentApiProps,
   ContentResultsList,
 } from '@weco/content/services/wellcome/content/types/api';
+import { FeatureFlags } from '@weco/toggles';
 
 import { contentDocumentQuery, contentListQuery } from '.';
 
@@ -26,13 +27,13 @@ export async function getAddressable({
   useStaging?: boolean;
 }): Promise<Addressable | WellcomeApiError> {
   // Create minimal toggles object just for this call
-  const toggles = useStaging
-    ? { stagingApi: { value: true, type: 'stage' as const } }
+  const featureFlags = useStaging
+    ? ({ stagingApi: true } as FeatureFlags)
     : undefined;
 
   const getAddressableResult = await contentDocumentQuery<Addressable>(
     `all/${id}`,
-    { toggles }
+    { featureFlags }
   );
 
   return getAddressableResult;

--- a/content/webapp/services/wellcome/content/all.ts
+++ b/content/webapp/services/wellcome/content/all.ts
@@ -4,7 +4,6 @@ import {
   ContentApiProps,
   ContentResultsList,
 } from '@weco/content/services/wellcome/content/types/api';
-import { FeatureFlags } from '@weco/toggles';
 
 import { contentDocumentQuery, contentListQuery } from '.';
 
@@ -21,19 +20,14 @@ export async function getAddressables(
 
 export async function getAddressable({
   id,
-  useStaging = false,
+  shouldUseStagingApi,
 }: {
   id: string;
-  useStaging?: boolean;
+  shouldUseStagingApi?: boolean;
 }): Promise<Addressable | WellcomeApiError> {
-  // Create minimal toggles object just for this call
-  const featureFlags = useStaging
-    ? ({ stagingApi: true } as FeatureFlags)
-    : undefined;
-
   const getAddressableResult = await contentDocumentQuery<Addressable>(
     `all/${id}`,
-    { featureFlags }
+    { shouldUseStagingApi }
   );
 
   return getAddressableResult;

--- a/content/webapp/services/wellcome/content/article.ts
+++ b/content/webapp/services/wellcome/content/article.ts
@@ -1,19 +1,18 @@
 import { WellcomeApiError } from '@weco/content/services/wellcome';
-import { FeatureFlags } from '@weco/toggles';
 
 import { contentDocumentQuery } from '.';
 import { Article } from './types/api';
 
 export async function getArticle({
   id,
-  featureFlags,
+  shouldUseStagingApi,
 }: {
   id: string;
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
 }): Promise<Article | WellcomeApiError> {
   const getArticleResult = await contentDocumentQuery<Article>(
     `articles/${id}`,
-    { featureFlags }
+    { shouldUseStagingApi }
   );
 
   return getArticleResult;

--- a/content/webapp/services/wellcome/content/article.ts
+++ b/content/webapp/services/wellcome/content/article.ts
@@ -1,19 +1,19 @@
 import { WellcomeApiError } from '@weco/content/services/wellcome';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { contentDocumentQuery } from '.';
 import { Article } from './types/api';
 
 export async function getArticle({
   id,
-  toggles,
+  featureFlags,
 }: {
   id: string;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
 }): Promise<Article | WellcomeApiError> {
   const getArticleResult = await contentDocumentQuery<Article>(
     `articles/${id}`,
-    { toggles }
+    { featureFlags }
   );
 
   return getArticleResult;

--- a/content/webapp/services/wellcome/content/index.ts
+++ b/content/webapp/services/wellcome/content/index.ts
@@ -6,15 +6,15 @@ import {
   WellcomeApiError,
   wellcomeApiQuery,
 } from '@weco/content/services/wellcome';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { ContentResultsList, ResultType } from './types/api';
 
 export async function contentListQuery<Params, Result extends ResultType>(
   endpoint: string,
-  { params, toggles, pageSize }: QueryProps<Params>
+  { params, featureFlags, pageSize }: QueryProps<Params>
 ): Promise<ContentResultsList<Result> | WellcomeApiError> {
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
   const extendedParams = {
     ...params,
     pageSize,
@@ -33,9 +33,9 @@ export async function contentListQuery<Params, Result extends ResultType>(
 
 export async function contentDocumentQuery<Result extends ResultType>(
   endpoint: string,
-  { toggles }: { toggles?: Toggles }
+  { featureFlags }: { featureFlags?: FeatureFlags }
 ): Promise<Result | WellcomeApiError> {
-  const apiOptions = globalApiOptions(toggles);
+  const apiOptions = globalApiOptions(featureFlags);
 
   const url = `${rootUris[apiOptions.env.content]}/content/v0/${endpoint}`;
 

--- a/content/webapp/services/wellcome/content/index.ts
+++ b/content/webapp/services/wellcome/content/index.ts
@@ -6,15 +6,14 @@ import {
   WellcomeApiError,
   wellcomeApiQuery,
 } from '@weco/content/services/wellcome';
-import { FeatureFlags } from '@weco/toggles';
 
 import { ContentResultsList, ResultType } from './types/api';
 
 export async function contentListQuery<Params, Result extends ResultType>(
   endpoint: string,
-  { params, featureFlags, pageSize }: QueryProps<Params>
+  { params, shouldUseStagingApi, pageSize }: QueryProps<Params>
 ): Promise<ContentResultsList<Result> | WellcomeApiError> {
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
   const extendedParams = {
     ...params,
     pageSize,
@@ -33,9 +32,9 @@ export async function contentListQuery<Params, Result extends ResultType>(
 
 export async function contentDocumentQuery<Result extends ResultType>(
   endpoint: string,
-  { featureFlags }: { featureFlags?: FeatureFlags }
+  { shouldUseStagingApi }: { shouldUseStagingApi?: boolean }
 ): Promise<Result | WellcomeApiError> {
-  const apiOptions = globalApiOptions(featureFlags);
+  const apiOptions = globalApiOptions(shouldUseStagingApi);
 
   const url = `${rootUris[apiOptions.env.content]}/content/v0/${endpoint}`;
 

--- a/content/webapp/services/wellcome/index.ts
+++ b/content/webapp/services/wellcome/index.ts
@@ -1,5 +1,5 @@
 import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 type envOptions = 'prod' | 'stage' | 'dev';
 
@@ -29,15 +29,17 @@ export type GlobalApiOptions = {
   index?: string;
 };
 
-export const globalApiOptions = (toggles?: Toggles): GlobalApiOptions => {
-  const toggleDefinedApiOption =
-    DEFAULT_API_ENV_OVERRIDE || (toggles?.stagingApi?.value ? 'stage' : 'prod');
+export const globalApiOptions = (
+  featureFlags?: FeatureFlags
+): GlobalApiOptions => {
+  const toggleDefinedApiEnv =
+    DEFAULT_API_ENV_OVERRIDE || (featureFlags?.stagingApi ? 'stage' : 'prod');
 
   const apiConfig = {
     env: {
-      catalogue: CATALOGUE_API_ENV_OVERRIDE ?? toggleDefinedApiOption,
-      concepts: CONCEPTS_API_ENV_OVERRIDE ?? toggleDefinedApiOption,
-      content: CONTENT_API_ENV_OVERRIDE ?? toggleDefinedApiOption,
+      catalogue: CATALOGUE_API_ENV_OVERRIDE ?? toggleDefinedApiEnv,
+      concepts: CONCEPTS_API_ENV_OVERRIDE ?? toggleDefinedApiEnv,
+      content: CONTENT_API_ENV_OVERRIDE ?? toggleDefinedApiEnv,
     },
   };
 
@@ -109,7 +111,7 @@ export type WellcomeAggregation<
 export type QueryProps<Params> = {
   params: Params;
   pageSize?: number;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
 };
 
 // Use shared undici agent configuration for keep-alive connections.

--- a/content/webapp/services/wellcome/index.ts
+++ b/content/webapp/services/wellcome/index.ts
@@ -1,5 +1,4 @@
 import { fetchWithUndiciAgent } from '@weco/common/utils/undici-agent';
-import { FeatureFlags } from '@weco/toggles';
 
 type envOptions = 'prod' | 'stage' | 'dev';
 
@@ -30,10 +29,10 @@ export type GlobalApiOptions = {
 };
 
 export const globalApiOptions = (
-  featureFlags?: FeatureFlags
+  shouldUseStagingApi?: boolean
 ): GlobalApiOptions => {
   const toggleDefinedApiEnv =
-    DEFAULT_API_ENV_OVERRIDE || (featureFlags?.stagingApi ? 'stage' : 'prod');
+    DEFAULT_API_ENV_OVERRIDE || (shouldUseStagingApi ? 'stage' : 'prod');
 
   const apiConfig = {
     env: {
@@ -111,7 +110,7 @@ export type WellcomeAggregation<
 export type QueryProps<Params> = {
   params: Params;
   pageSize?: number;
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
 };
 
 // Use shared undici agent configuration for keep-alive connections.

--- a/content/webapp/test/services/catalogue/concepts.test.ts
+++ b/content/webapp/test/services/catalogue/concepts.test.ts
@@ -4,7 +4,6 @@ import {
   getConcepts,
 } from '@weco/content/services/wellcome/catalogue/concepts';
 import { conceptsApiResponse } from '@weco/content/test/fixtures/catalogueApi/concept';
-import { FeatureFlags } from '@weco/toggles';
 
 // Mock the catalogueQuery function
 jest.mock('@weco/content/services/wellcome/catalogue', () => ({
@@ -20,7 +19,7 @@ describe('getConcept', () => {
   it('returns a 404 Not Found for a concept ID that is not alphanumeric', () => {
     const id = 'a\u200Bb';
 
-    getConcept({ id, featureFlags: {} as FeatureFlags }).then(result => {
+    getConcept({ id, shouldUseStagingApi: false }).then(result => {
       expect(result).toStrictEqual({
         errorType: 'http',
         httpStatus: 404,
@@ -42,7 +41,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { page: 1 },
-      featureFlags: {} as FeatureFlags,
+      shouldUseStagingApi: false,
       pageSize: 20,
     };
 
@@ -56,7 +55,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test search', page: 1 },
-      featureFlags: {} as FeatureFlags,
+      shouldUseStagingApi: false,
       pageSize: 20,
     };
 
@@ -70,7 +69,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test search' },
-      featureFlags: {} as FeatureFlags,
+      shouldUseStagingApi: false,
       pageSize: 20,
     };
 
@@ -84,7 +83,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: '' },
-      featureFlags: {} as FeatureFlags,
+      shouldUseStagingApi: false,
       pageSize: 20,
     };
 
@@ -98,7 +97,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test & search "with quotes"' },
-      featureFlags: {} as FeatureFlags,
+      shouldUseStagingApi: false,
       pageSize: 20,
     };
 
@@ -112,7 +111,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test', page: 3 },
-      featureFlags: {} as FeatureFlags,
+      shouldUseStagingApi: false,
       pageSize: 50,
     };
 

--- a/content/webapp/test/services/catalogue/concepts.test.ts
+++ b/content/webapp/test/services/catalogue/concepts.test.ts
@@ -4,6 +4,7 @@ import {
   getConcepts,
 } from '@weco/content/services/wellcome/catalogue/concepts';
 import { conceptsApiResponse } from '@weco/content/test/fixtures/catalogueApi/concept';
+import { FeatureFlags } from '@weco/toggles';
 
 // Mock the catalogueQuery function
 jest.mock('@weco/content/services/wellcome/catalogue', () => ({
@@ -19,7 +20,7 @@ describe('getConcept', () => {
   it('returns a 404 Not Found for a concept ID that is not alphanumeric', () => {
     const id = 'a\u200Bb';
 
-    getConcept({ id, toggles: {} }).then(result => {
+    getConcept({ id, featureFlags: {} as FeatureFlags }).then(result => {
       expect(result).toStrictEqual({
         errorType: 'http',
         httpStatus: 404,
@@ -41,7 +42,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { page: 1 },
-      toggles: {},
+      featureFlags: {} as FeatureFlags,
       pageSize: 20,
     };
 
@@ -55,7 +56,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test search', page: 1 },
-      toggles: {},
+      featureFlags: {} as FeatureFlags,
       pageSize: 20,
     };
 
@@ -69,7 +70,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test search' },
-      toggles: {},
+      featureFlags: {} as FeatureFlags,
       pageSize: 20,
     };
 
@@ -83,7 +84,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: '' },
-      toggles: {},
+      featureFlags: {} as FeatureFlags,
       pageSize: 20,
     };
 
@@ -97,7 +98,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test & search "with quotes"' },
-      toggles: {},
+      featureFlags: {} as FeatureFlags,
       pageSize: 20,
     };
 
@@ -111,7 +112,7 @@ describe('getConcepts', () => {
 
     const props = {
       params: { query: 'test', page: 3 },
-      toggles: {},
+      featureFlags: {} as FeatureFlags,
       pageSize: 50,
     };
 

--- a/content/webapp/test/services/catalogue/works.test.ts
+++ b/content/webapp/test/services/catalogue/works.test.ts
@@ -1,9 +1,10 @@
 import { getWork } from '@weco/content/services/wellcome/catalogue/works';
+import { FeatureFlags } from '@weco/toggles';
 
 it('returns a 404 Not Found for a work ID that’s not alphanumeric', () => {
   const id = 'a\u200Bb';
 
-  getWork({ id, toggles: {} }).then(result => {
+  getWork({ id, featureFlags: {} as FeatureFlags }).then(result => {
     expect(result).toStrictEqual({
       errorType: 'http',
       httpStatus: 404,

--- a/content/webapp/test/services/catalogue/works.test.ts
+++ b/content/webapp/test/services/catalogue/works.test.ts
@@ -1,10 +1,9 @@
 import { getWork } from '@weco/content/services/wellcome/catalogue/works';
-import { FeatureFlags } from '@weco/toggles';
 
 it('returns a 404 Not Found for a work ID that’s not alphanumeric', () => {
   const id = 'a\u200Bb';
 
-  getWork({ id, featureFlags: {} as FeatureFlags }).then(result => {
+  getWork({ id, shouldUseStagingApi: false }).then(result => {
     expect(result).toStrictEqual({
       errorType: 'http',
       httpStatus: 404,

--- a/content/webapp/views/components/ContentPage/index.tsx
+++ b/content/webapp/views/components/ContentPage/index.tsx
@@ -83,7 +83,7 @@ const ContentPage = ({
     try {
       const linkedWorksResults = await getLinkedWorks({
         id: `${id}.${contentApiType}`,
-        useStaging: stagingApi || false,
+        shouldUseStagingApi: stagingApi,
       });
 
       setLinkedWorks(() => {

--- a/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
+++ b/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
@@ -60,7 +60,7 @@ const VisuallySimilarImages: FunctionComponent<Props> = ({
     const fetchVisuallySimilarImages = async () => {
       const { image: fullImage } = await getImage({
         id: originalId,
-        toggles,
+        featureFlags: toggles.featureFlags,
         include: ['withSimilarFeatures'],
       });
       if (fullImage.type === 'Image') {

--- a/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
+++ b/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent, useContext, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { ServerDataContext } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import LL from '@weco/common/views/components/styled/LL';
 import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
@@ -53,14 +53,14 @@ const VisuallySimilarImages: FunctionComponent<Props> = ({
 }: Props) => {
   const [similarImages, setSimilarImages] = useState<ImageType[]>([]);
   const [requestState, setRequestState] = useState<State>('initial');
-  const { toggles } = useContext(ServerDataContext);
+  const { stagingApi } = useFeatureFlags();
 
   useEffect(() => {
     setRequestState('loading');
     const fetchVisuallySimilarImages = async () => {
       const { image: fullImage } = await getImage({
         id: originalId,
-        featureFlags: toggles.featureFlags,
+        shouldUseStagingApi: stagingApi,
         include: ['withSimilarFeatures'],
       });
       if (fullImage.type === 'Image') {

--- a/content/webapp/views/components/ImageModal/useExpandedImage.ts
+++ b/content/webapp/views/components/ImageModal/useExpandedImage.ts
@@ -1,14 +1,13 @@
 import {
   Dispatch,
   SetStateAction,
-  useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
 
-import { ServerDataContext } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { getImage } from '@weco/content/services/wellcome/catalogue/images';
 import { Image } from '@weco/content/services/wellcome/catalogue/types';
 
@@ -16,7 +15,7 @@ const useExpandedImage = (
   images: Image[]
 ): [Image | undefined, Dispatch<SetStateAction<Image | undefined>>] => {
   const [expandedImage, setExpandedImage] = useState<Image | undefined>();
-  const { toggles } = useContext(ServerDataContext);
+  const { stagingApi } = useFeatureFlags();
   const hasBeenExpanded = useRef(false);
 
   const imageMap = useMemo<Record<string, Image>>(
@@ -44,7 +43,7 @@ const useExpandedImage = (
         // if it's not, fetch the image and then update
         const { image } = await getImage({
           id: hash,
-          featureFlags: toggles.featureFlags,
+          shouldUseStagingApi: stagingApi,
         });
 
         if (image.type === 'Image') {

--- a/content/webapp/views/components/ImageModal/useExpandedImage.ts
+++ b/content/webapp/views/components/ImageModal/useExpandedImage.ts
@@ -42,7 +42,10 @@ const useExpandedImage = (
         setExpandedImage(imageMap[hash]);
       } else {
         // if it's not, fetch the image and then update
-        const { image } = await getImage({ id: hash, toggles });
+        const { image } = await getImage({
+          id: hash,
+          featureFlags: toggles.featureFlags,
+        });
 
         if (image.type === 'Image') {
           imageMap[image.id] = image;

--- a/content/webapp/views/components/ThemeCardsList/index.tsx
+++ b/content/webapp/views/components/ThemeCardsList/index.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { DataGtmProps } from '@weco/common/utils/gtm';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import { SizeMap } from '@weco/common/views/components/styled/Grid';
@@ -82,13 +83,14 @@ const ThemeCardsList: FunctionComponent<ThemeCardsListProps> = ({
   const scrollContainerRef = useRef<HTMLUListElement>(null);
   const [concepts, setConcepts] = useState<Concept[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const { stagingApi } = useFeatureFlags();
 
   useEffect(() => {
     const fetchData = async () => {
       if (conceptIds.length > 0) {
         setIsLoading(true);
         try {
-          const result = await getConceptsByIds(conceptIds);
+          const result = await getConceptsByIds(conceptIds, stagingApi);
           setConcepts(result);
           onConceptsFetched?.({ count: result.length });
         } catch (error) {

--- a/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.Works.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.Works.tsx
@@ -1,12 +1,6 @@
-import {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import { ServerDataContext } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { formatNumber } from '@weco/common/utils/grammar';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
@@ -35,7 +29,7 @@ const SubThemeWorks = ({
   works: WorksForTabs;
   conceptsDisplayLabels: string[];
 }) => {
-  const { toggles } = useContext(ServerDataContext);
+  const { stagingApi } = useFeatureFlags();
   const [selectedTab, setSelectedTab] = useState(ALL_WORKS_TAB_ID);
   const [displayedWorks, setDisplayedWorks] = useState<WorkBasic[]>(
     works.pageResults
@@ -92,7 +86,7 @@ const SubThemeWorks = ({
             workType: [selectedTab],
           },
           pageSize: works.pageResults.length,
-          featureFlags: toggles.featureFlags,
+          shouldUseStagingApi: stagingApi,
         });
 
         // Only update state if this is still the current tab (prevent race conditions)
@@ -129,7 +123,7 @@ const SubThemeWorks = ({
     };
 
     fetchFilteredWorks();
-  }, [selectedTab, conceptsDisplayLabels, toggles, works.pageResults]);
+  }, [selectedTab, conceptsDisplayLabels, stagingApi, works.pageResults]);
 
   // Use useLayoutEffect to measure the DOM synchronously after render but before paint
   // This ensures we capture the accurate height after results have rendered

--- a/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.Works.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.Works.tsx
@@ -92,7 +92,7 @@ const SubThemeWorks = ({
             workType: [selectedTab],
           },
           pageSize: works.pageResults.length,
-          toggles,
+          featureFlags: toggles.featureFlags,
         });
 
         // Only update state if this is still the current tab (prevent race conditions)

--- a/content/webapp/views/pages/search/index.tsx
+++ b/content/webapp/views/pages/search/index.tsx
@@ -1,12 +1,9 @@
 import { NextPage } from 'next';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useSearchContext } from '@weco/common/contexts/SearchContext';
 import { arrow } from '@weco/common/icons';
-import {
-  ServerDataContext,
-  useFeatureFlags,
-} from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { formatNumber } from '@weco/common/utils/grammar';
 import { getQueryResults } from '@weco/common/utils/search';
@@ -65,9 +62,8 @@ const SearchPage: NextPage<Props> = withSearchLayout(
     const { query: queryString } = query;
     const { extraApiToolbarLinks, setExtraApiToolbarLinks } =
       useSearchContext();
-    const { apiToolbar } = useFeatureFlags();
+    const { apiToolbar, stagingApi } = useFeatureFlags();
     const params = fromQuery(query);
-    const data = useContext(ServerDataContext);
     const { setLink } = useSearchContext();
     const [clientSideWorkTypes, setClientSideWorkTypes] = useState<
       WorkTypes | undefined
@@ -102,7 +98,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
             aggregations: ['workType'],
           },
           pageSize: 1,
-          featureFlags: data.toggles.featureFlags,
+          shouldUseStagingApi: stagingApi,
         });
 
         const workTypeBuckets = getQueryWorkTypeBuckets({
@@ -128,7 +124,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
         const imagesResults = await getImages({
           params,
           pageSize: 7,
-          featureFlags: data.toggles.featureFlags,
+          shouldUseStagingApi: stagingApi,
         });
 
         const images = getQueryResults({

--- a/content/webapp/views/pages/search/index.tsx
+++ b/content/webapp/views/pages/search/index.tsx
@@ -102,7 +102,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
             aggregations: ['workType'],
           },
           pageSize: 1,
-          toggles: data.toggles,
+          featureFlags: data.toggles.featureFlags,
         });
 
         const workTypeBuckets = getQueryWorkTypeBuckets({
@@ -128,7 +128,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
         const imagesResults = await getImages({
           params,
           pageSize: 7,
-          toggles: data.toggles,
+          featureFlags: data.toggles.featureFlags,
         });
 
         const images = getQueryResults({

--- a/content/webapp/views/pages/stories/story/index.tsx
+++ b/content/webapp/views/pages/stories/story/index.tsx
@@ -58,7 +58,11 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
     setSeries(article, setListOfSeries);
 
     if (article.exploreMoreDocument && !relatedDocument) {
-      getRelatedDoc(article, setRelatedDocument, serverData);
+      getRelatedDoc(
+        article,
+        setRelatedDocument,
+        serverData.toggles.featureFlags.stagingApi
+      );
     }
   }, []);
 

--- a/content/webapp/views/pages/stories/story/story.helpers.tsx
+++ b/content/webapp/views/pages/stories/story/story.helpers.tsx
@@ -2,7 +2,6 @@ import { ReactElement } from 'react';
 
 import { bodySquabblesSeries } from '@weco/common/data/hardcoded-ids';
 import { ExhibitionsDocument as RawExhibitionsDocument } from '@weco/common/prismicio-types';
-import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 import { isPast } from '@weco/common/utils/dates';
 import { fetchFromClientSide } from '@weco/content/services/prismic/fetch';
@@ -57,7 +56,7 @@ export const getRelatedDoc = async (
   setRelatedDocument: (
     doc: ExhibitionBasic | ContentAPIArticle | undefined
   ) => void,
-  serverData: SimplifiedServerData
+  shouldUseStagingApi?: boolean
 ) => {
   if (article.exploreMoreDocument?.type === 'exhibitions') {
     const relatedExhibition = await fetchFromClientSide<RawExhibitionsDocument>(
@@ -89,7 +88,7 @@ export const getRelatedDoc = async (
   if (article.exploreMoreDocument?.type === 'articles') {
     const relatedArticle = await getArticle({
       id: article.exploreMoreDocument.id,
-      featureFlags: serverData.toggles.featureFlags,
+      shouldUseStagingApi,
     });
 
     if (relatedArticle?.type === 'Article') {
@@ -100,14 +99,14 @@ export const getRelatedDoc = async (
 
 export const getLinkedWorks = async ({
   id,
-  useStaging = false,
+  shouldUseStagingApi,
 }: {
   id: string;
-  useStaging?: boolean;
+  shouldUseStagingApi?: boolean;
 }): Promise<ContentApiLinkedWork[]> => {
   const addressable = await getAddressable({
     id,
-    useStaging,
+    shouldUseStagingApi,
   });
 
   if (addressable.type !== 'Error') {

--- a/content/webapp/views/pages/stories/story/story.helpers.tsx
+++ b/content/webapp/views/pages/stories/story/story.helpers.tsx
@@ -89,7 +89,7 @@ export const getRelatedDoc = async (
   if (article.exploreMoreDocument?.type === 'articles') {
     const relatedArticle = await getArticle({
       id: article.exploreMoreDocument.id,
-      toggles: serverData.toggles,
+      featureFlags: serverData.toggles.featureFlags,
     });
 
     if (relatedArticle?.type === 'Article') {

--- a/content/webapp/views/pages/works/work/RelatedWorks/RelatedWorks.helpers.tsx
+++ b/content/webapp/views/pages/works/work/RelatedWorks/RelatedWorks.helpers.tsx
@@ -6,7 +6,7 @@ import {
   toWorkBasic,
   Work,
 } from '@weco/content/services/wellcome/catalogue/types';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 import { RelatedWork, WorkQueryProps } from '.';
 
@@ -35,10 +35,10 @@ export const fetchRelatedWorks = async ({
   subjects,
   typesTechniques,
   date,
-  toggles,
+  featureFlags,
   setIsLoading,
 }: WorkQueryProps & {
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
   setIsLoading: (isLoading: boolean) => void;
 }): Promise<RelatedWork | undefined> => {
   setIsLoading(true);
@@ -58,7 +58,7 @@ export const fetchRelatedWorks = async ({
     params
   ): Promise<WellcomeApiError | CatalogueResultsList<Work>> =>
     await catalogueQuery('works', {
-      toggles,
+      featureFlags,
       // Always fetch 4 works in case we get the current work back, then we will still have 3 to show.
       pageSize: 4,
       params: {

--- a/content/webapp/views/pages/works/work/RelatedWorks/RelatedWorks.helpers.tsx
+++ b/content/webapp/views/pages/works/work/RelatedWorks/RelatedWorks.helpers.tsx
@@ -6,7 +6,6 @@ import {
   toWorkBasic,
   Work,
 } from '@weco/content/services/wellcome/catalogue/types';
-import { FeatureFlags } from '@weco/toggles';
 
 import { RelatedWork, WorkQueryProps } from '.';
 
@@ -35,10 +34,10 @@ export const fetchRelatedWorks = async ({
   subjects,
   typesTechniques,
   date,
-  featureFlags,
+  shouldUseStagingApi,
   setIsLoading,
 }: WorkQueryProps & {
-  featureFlags: FeatureFlags;
+  shouldUseStagingApi?: boolean;
   setIsLoading: (isLoading: boolean) => void;
 }): Promise<RelatedWork | undefined> => {
   setIsLoading(true);
@@ -58,7 +57,7 @@ export const fetchRelatedWorks = async ({
     params
   ): Promise<WellcomeApiError | CatalogueResultsList<Work>> =>
     await catalogueQuery('works', {
-      featureFlags,
+      shouldUseStagingApi,
       // Always fetch 4 works in case we get the current work back, then we will still have 3 to show.
       pageSize: 4,
       params: {

--- a/content/webapp/views/pages/works/work/RelatedWorks/index.tsx
+++ b/content/webapp/views/pages/works/work/RelatedWorks/index.tsx
@@ -1,7 +1,7 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { ServerDataContext } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
@@ -51,7 +51,7 @@ const RelatedWorks = ({
   typesTechniques,
   date,
 }: WorkQueryProps) => {
-  const { toggles } = useContext(ServerDataContext);
+  const { stagingApi } = useFeatureFlags();
   const [isLoading, setIsLoading] = useState(true);
   const [relatedWorksTabs, setRelatedWorksTabs] = useState<RelatedWork>();
   const [selectedTab, setSelectedTab] = useState<string | undefined>();
@@ -67,7 +67,7 @@ const RelatedWorks = ({
         subjects,
         typesTechniques,
         date,
-        featureFlags: toggles.featureFlags,
+        shouldUseStagingApi: stagingApi,
         setIsLoading,
       }).then(data => {
         setRelatedWorksTabs(data);

--- a/content/webapp/views/pages/works/work/RelatedWorks/index.tsx
+++ b/content/webapp/views/pages/works/work/RelatedWorks/index.tsx
@@ -67,7 +67,7 @@ const RelatedWorks = ({
         subjects,
         typesTechniques,
         date,
-        toggles,
+        featureFlags: toggles.featureFlags,
         setIsLoading,
       }).then(data => {
         setRelatedWorksTabs(data);

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -202,7 +202,7 @@ export const WorkPage: NextPage<Props> = ({
         <StoriesOnWorks
           workId={work.id}
           showDivider={hasAtLeastOneSubject(work.subjects)}
-          toggles={serverData.toggles}
+          featureFlags={serverData.toggles.featureFlags}
         />
 
         {/* If the work has no subjects, it's not worth adding this component */}

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { SimplifiedServerData } from '@weco/common/server-data/types';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Divider from '@weco/common/views/components/Divider';
 import SearchForm from '@weco/common/views/components/SearchForm';
@@ -54,14 +53,12 @@ export type Props = {
   work: WorkType;
   apiUrl: string;
   transformedManifest?: TransformedManifest;
-  serverData: SimplifiedServerData;
 };
 
 export const WorkPage: NextPage<Props> = ({
   work,
   apiUrl,
   transformedManifest,
-  serverData,
 }) => {
   const { extendedViewer } = useFeatureFlags();
   const { userIsStaffWithRestricted } = useUserContext();
@@ -202,7 +199,6 @@ export const WorkPage: NextPage<Props> = ({
         <StoriesOnWorks
           workId={work.id}
           showDivider={hasAtLeastOneSubject(work.subjects)}
-          featureFlags={serverData.toggles.featureFlags}
         />
 
         {/* If the work has no subjects, it's not worth adding this component */}

--- a/content/webapp/views/pages/works/work/work.StoriesOnWorks.tsx
+++ b/content/webapp/views/pages/works/work/work.StoriesOnWorks.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -9,7 +10,6 @@ import Space from '@weco/common/views/components/styled/Space';
 import { getArticles } from '@weco/content/services/wellcome/content/articles';
 import { Article } from '@weco/content/services/wellcome/content/types/api';
 import StoriesGrid from '@weco/content/views/components/StoriesGrid';
-import { FeatureFlags } from '@weco/toggles';
 
 const LoadingWrapper = styled.div`
   position: relative;
@@ -25,14 +25,13 @@ const SectionWrapper = styled(Space).attrs({
 type Props = {
   workId: string;
   showDivider?: boolean;
-  featureFlags: FeatureFlags;
 };
 
 const WorkStoriesOnWorks: FunctionComponent<Props> = ({
   workId,
   showDivider,
-  featureFlags,
 }) => {
+  const { stagingApi } = useFeatureFlags();
   const [articles, setArticles] = useState<Article[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -44,7 +43,7 @@ const WorkStoriesOnWorks: FunctionComponent<Props> = ({
         const response = await getArticles({
           params: { linkedWork: workId },
           pageSize: 4,
-          featureFlags,
+          shouldUseStagingApi: stagingApi,
         });
 
         if (response?.type === 'Error') {
@@ -64,7 +63,7 @@ const WorkStoriesOnWorks: FunctionComponent<Props> = ({
     if (articles.length === 0) {
       fetchRelatedContent();
     }
-  }, [workId, featureFlags]);
+  }, [workId, stagingApi]);
 
   if (!isLoading && articles.length === 0) return null;
 

--- a/content/webapp/views/pages/works/work/work.StoriesOnWorks.tsx
+++ b/content/webapp/views/pages/works/work/work.StoriesOnWorks.tsx
@@ -9,7 +9,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { getArticles } from '@weco/content/services/wellcome/content/articles';
 import { Article } from '@weco/content/services/wellcome/content/types/api';
 import StoriesGrid from '@weco/content/views/components/StoriesGrid';
-import { Toggles } from '@weco/toggles';
+import { FeatureFlags } from '@weco/toggles';
 
 const LoadingWrapper = styled.div`
   position: relative;
@@ -25,13 +25,13 @@ const SectionWrapper = styled(Space).attrs({
 type Props = {
   workId: string;
   showDivider?: boolean;
-  toggles: Toggles;
+  featureFlags: FeatureFlags;
 };
 
 const WorkStoriesOnWorks: FunctionComponent<Props> = ({
   workId,
   showDivider,
-  toggles,
+  featureFlags,
 }) => {
   const [articles, setArticles] = useState<Article[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -44,7 +44,7 @@ const WorkStoriesOnWorks: FunctionComponent<Props> = ({
         const response = await getArticles({
           params: { linkedWork: workId },
           pageSize: 4,
-          toggles,
+          featureFlags,
         });
 
         if (response?.type === 'Error') {
@@ -64,7 +64,7 @@ const WorkStoriesOnWorks: FunctionComponent<Props> = ({
     if (articles.length === 0) {
       fetchRelatedContent();
     }
-  }, [workId, toggles]);
+  }, [workId, featureFlags]);
 
   if (!isLoading && articles.length === 0) return null;
 

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -84,6 +84,18 @@ const TogglesPage: FunctionComponent = () => {
       );
   }, []);
 
+  // Scroll to hash anchor after data loads (sections aren't in the DOM on first render)
+  useEffect(() => {
+    if (toggles.length === 0) return;
+    const hash = window.location.hash;
+    if (hash) {
+      const el = document.querySelector(hash);
+      if (el) {
+        el.scrollIntoView();
+      }
+    }
+  }, [toggles]);
+
   const handleToggle = useCallback(
     (toggleId: string, action: 'enable' | 'disable') => {
       const toggleExists = toggles.some(toggle => toggle.id === toggleId);

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -48,7 +48,7 @@ const TogglesPage: FunctionComponent = () => {
     fetch('https://toggles.wellcomecollection.org/toggles.json')
       .then(resp => resp.json())
       .then(json => {
-        setToggles(json.toggles);
+        setToggles(json.featureFlags ?? json.toggles);
         setAbTests(json.tests);
 
         const cookies = getCookies();

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -1,8 +1,4 @@
-import toggleConfig, {
-  ABTest,
-  PublishedFeatureFlag,
-  ToggleTypes,
-} from './toggles';
+import toggleConfig, { ABTest, PublishedFeatureFlag } from './toggles';
 
 export type FeatureFlagId = (typeof toggleConfig.featureFlags)[number]['id'];
 export type TestId = (typeof toggleConfig.tests)[number]['id'];
@@ -18,7 +14,10 @@ export type TogglesResp = {
 
 // Don't be tempted to make the keys on this optional - keeping them
 // as required means we catch dead code left over from removed toggles
-export type Toggles = Record<
-  ToggleId | TestId,
-  { value: boolean | undefined; type: ToggleTypes }
->;
+export type FeatureFlags = Record<FeatureFlagId, boolean | undefined>;
+export type Tests = Record<TestId, boolean | undefined>;
+
+export type Toggles = {
+  featureFlags: FeatureFlags;
+  tests: Tests;
+};

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -25,7 +25,7 @@ export async function setDefaultValueFor(client: S3Client): Promise<void> {
 
   const toggles = {
     featureFlags,
-    tests: remoteToggles.tests,
+    tests: remoteToggles.tests ?? [],
   };
 
   const { $metadata: putObjectResponseMetadata } = await putTogglesObject(

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -1,4 +1,4 @@
-export type ToggleTypes = 'permanent' | 'experimental' | 'test' | 'stage';
+type ToggleTypes = 'permanent' | 'experimental' | 'test' | 'stage';
 
 type ToggleBase = {
   id: string;


### PR DESCRIPTION
Part 2 of the toggles restructuring. Part 1 (#13087) renamed the JSON key from `toggles` to `featureFlags`, added `modes` as a new category, and separated tests into their own key.

This PR picks up where #13087 left off and focuses on how the rest of the codebase consumes toggles.

## What does this change?

1. **Removes the `{ value, type }` wrapper from toggle values** — the `type` field (`permanent`, `stage`, `experimental`) is only needed at resolution time (to filter stage-only flags) and in the dash (to display toggles by category). The main site never needed it at runtime — it only ever read `.value`. Now the resolved output is just the boolean.

   The dash is unaffected because it reads the toggle *config* (the `TogglesResp` array with `id`, `type`, `defaultValue`, etc.) to render its UI, not the resolved `FeatureFlags` record. It uses the config's `type` field to group toggles into sections, and reads/writes cookies directly. The flattened `FeatureFlags` type is only used by the main site's server-side rendering.

   Before:
   ```ts
   // Type
   type Toggles = Record<ToggleId, { value: boolean; type: string }>

   // Shape
   { stagingApi: { value: false, type: 'permanent' }, thematicBrowsing: { value: true, type: 'permanent' } }

   // Usage
   const useStagingApi = serverData.toggles.stagingApi.value;
   ```

   After:
   ```ts
   // Type
   type FeatureFlags = Record<FeatureFlagId, boolean | undefined>

   // Shape
   { stagingApi: false, thematicBrowsing: true }

   // Usage
   const useStagingApi = serverData.featureFlags.stagingApi;
   ```

2. **Simplifies the service layer** — the only flag services ever read is `stagingApi`, so instead of passing the entire `FeatureFlags` object through ~40 callsites, we now pass `shouldUseStagingApi?: boolean`. This removes coupling between the fetch layer and the toggle system.

   Before:
   ```ts
   const work = await getWork({ id, featureFlags: serverData.featureFlags });
   // inside getWork:
   globalApiOptions(featureFlags?.stagingApi)
   ```

   After:
   ```ts
   const work = await getWork({ id, shouldUseStagingApi: serverData.featureFlags.stagingApi });
   // inside getWork:
   globalApiOptions(shouldUseStagingApi)
   ```

3. **Client components use `useFeatureFlags()` hook** — instead of prop-drilling the flags object through component trees, nested components access feature flags directly via the hook.

4. **Adds tests for `getTogglesFromContext`** — covering cookie resolution, default values, stage-only filtering, test toggle behaviour, and backward compatibility with the old JSON shape.

## How to test

- Visit any page that uses the staging API toggle (e.g. search). Verify it works with and without the `toggle_stagingApi` cookie set to `"true"`.
- `yarn tsc` from root — no TypeScript errors.
- `cd common && npx jest --testPathPatterns="server-data/toggles.test" --no-coverage` — all 12 tests pass.
- Check the toggles dashboard still works (run the dash app and visit `/toggles`).

## Have we considered potential risks?

- **No behavioural regression** — the value computation (`cookie === 'true' ? true : defaultValue`) is identical to the old code. We verified this by comparing the old `getTogglesFromContext` on `main` with the new version — same logic, just without the wrapper object.
- **Backward compatibility** — `getTogglesFromContext` falls back to reading a `toggles` key if `featureFlags` is absent, so the transition between old and new JSON formats is seamless.
- **87 files touched** — mostly mechanical signature changes. The logic in each file is unchanged; we're just passing a boolean where we used to pass an object.
