### PR TITLE
Remove toggles being passed to GlobalStyles

### DIFF
--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -25,10 +25,7 @@ import CivicUK from '@weco/common/views/components/CivicUK';
 import GlobalSvgDefinitions from '@weco/common/views/components/GlobalSvgDefinitions';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator';
 import ErrorPage from '@weco/common/views/layouts/ErrorPage';
-import {
-  createThemeValues,
-  GlobalStyle,
-} from '@weco/common/views/themes/default';
+import themeValues, { GlobalStyle } from '@weco/common/views/themes/default';
 
 // Error pages can't send anything via the data fetching methods as
 // the page needs to be rendered as soon as the error happens.
@@ -159,13 +156,11 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
     <>
       <ApmContextProvider>
         <ServerDataContext.Provider value={serverData}>
-          <ThemeProvider
-            theme={createThemeValues(serverData.toggles.featureFlags)}
-          >
+          <ThemeProvider theme={themeValues}>
             <UserContextProvider>
               <AppContextProvider>
                 <SearchContextProvider>
-                  <GlobalStyle toggles={serverData.toggles.featureFlags} />
+                  <GlobalStyle />
 
                   <GlobalSvgDefinitions />
                   <LoadingIndicator />

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -1,7 +1,5 @@
 import { createGlobalStyle, css } from 'styled-components';
 
-import { FeatureFlags } from '@weco/toggles';
-
 import { fonts } from './base/fonts';
 import { layout } from './base/layout';
 import { normalize } from './base/normalize';
@@ -45,11 +43,7 @@ const cls = {
   ...sizesClasses,
 } as unknown as Classes & SizedClasses;
 
-export type GlobalStyleProps = {
-  toggles?: FeatureFlags;
-};
-
-const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
+const GlobalStyle = createGlobalStyle`
   ${css`
     .${cls.displayBlock} {
       display: block;
@@ -84,20 +78,8 @@ const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
   ${typography}
 `;
 
-// Theme factory that creates a theme with appropriate color function based on toggles
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const createThemeValues = (toggles: FeatureFlags) => {
-  // Manipulate themeValues with toggles here
-
-  return {
-    ...themeValues,
-    // Overrides here
-  };
-};
-
 // Static theme instance for backward compatibility
 // Used by: TypeScript type definitions (styled.d.ts), test utilities, and Storybook configuration
-// Production code should use ThemeProvider with createThemeValues(toggles) for toggle-aware themes
 export default themeValues;
 export { GlobalStyle, cls };
 

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -1,8 +1,6 @@
 import { theme as designSystemTheme } from '@wellcometrust/wellcome-design-system/theme';
 import { css } from 'styled-components';
 
-import { GlobalStyleProps } from './default';
-
 // Note: the design system font sizing uses vw units and clamp so that there is
 // a gradated change across viewport widths without a need for breakpoint changes.
 // We have considered the utility of a similar container query based approach using
@@ -17,9 +15,7 @@ const fontFamilies = {
   mono: designSystemTheme.font.family.mono,
 };
 
-const fontSizeMixin = (
-  size: -2 | -1 | 0 | 1 | 2 | 4 | 5
-) => css<GlobalStyleProps>`
+const fontSizeMixin = (size: -2 | -1 | 0 | 1 | 2 | 4 | 5) => css`
   font-size: ${designSystemTheme.font.size[`f${size}`]};
 `;
 type FontFamily = keyof typeof fontFamilies;
@@ -40,7 +36,7 @@ export const fontFamilyMixin = (
   `;
 };
 
-export const typography = css<GlobalStyleProps>`
+export const typography = css`
   .font-sans-bold {
     ${fontFamilyMixin('sans', true)};
   }
@@ -274,7 +270,7 @@ export const typography = css<GlobalStyleProps>`
   }
 `;
 
-export const makeFontSizeClasses = () => css<GlobalStyleProps>`
+export const makeFontSizeClasses = () => css`
   ${Object.entries(designSystemTheme.font.size)
     .map(([key, value]) => {
       return `.font-size-${key} {font-size: ${value}}`;

--- a/common/views/themes/utility-classes.ts
+++ b/common/views/themes/utility-classes.ts
@@ -1,7 +1,5 @@
 import { css } from 'styled-components';
 
-import { GlobalStyleProps } from './default';
-
 export const visuallyHiddenStyles = css`
   border: 0;
   clip: rect(0 0 0 0);
@@ -16,7 +14,7 @@ export const visuallyHiddenStyles = css`
 
 // Spring 2023: we went through utility classes and decided to only
 // keep the ones that had to do with display status/visibility.
-export const utilityClasses = css<GlobalStyleProps>`
+export const utilityClasses = css`
   .is-hidden {
     display: none !important;
   }


### PR DESCRIPTION
## What does this change?

As part of https://github.com/wellcomecollection/wellcomecollection.org/pull/13090 I noticed we were passing the toggles to GlobalStyles, I think this was done to change the colours based on a feature flag value, but we won't be doing that for a bit now, so I've chosen to tidy it up.


## How to test

Does the site render well?

## Have we considered potential risks?
N/A?