### PR TITLE
Stories kiosk mode: external link stripping and minimal layout

### DIFF
--- a/common/contexts/KioskContext.tsx
+++ b/common/contexts/KioskContext.tsx
@@ -1,0 +1,32 @@
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useContext,
+} from 'react';
+
+type KioskContextType = {
+  isKiosk: boolean;
+};
+
+const KioskContext = createContext<KioskContextType>({ isKiosk: false });
+
+type KioskProviderProps = PropsWithChildren<{
+  isActive: boolean;
+}>;
+
+export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
+  isActive,
+  children,
+}) => {
+  return (
+    <KioskContext.Provider value={{ isKiosk: isActive }}>
+      {children}
+    </KioskContext.Provider>
+  );
+};
+
+export const useKiosk = (): boolean => {
+  const { isKiosk } = useContext(KioskContext);
+  return isKiosk;
+};

--- a/common/views/components/Caption/index.tsx
+++ b/common/views/components/Caption/index.tsx
@@ -2,8 +2,9 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { font } from '@weco/common/utils/classnames';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -47,6 +48,8 @@ const Caption: FunctionComponent<Props> = ({
   preCaptionNode,
   width,
 }: Props) => {
+  const isKiosk = useKiosk();
+
   return (
     // In order to be valid html, a figcaption should appear as the first or
     // last element in a figure. We have previously made this happen
@@ -62,7 +65,7 @@ const Caption: FunctionComponent<Props> = ({
           <CaptionText>
             <PrismicHtmlBlock
               html={caption}
-              htmlSerializer={defaultSerializer}
+              htmlSerializer={createSerializer({ stripExternalLinks: isKiosk })}
             />
           </CaptionText>
         </CaptionWrapper>

--- a/common/views/components/HTMLSerializers/HTMLSerializers.test.tsx
+++ b/common/views/components/HTMLSerializers/HTMLSerializers.test.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { render } from '@testing-library/react';
 import { createElement, ReactNode } from 'react';
 
-import { dropCapSerializer } from './index';
+import { createSerializer, dropCapSerializer } from './index';
 
 describe('HTMLSerializers', () => {
   describe('dropCapSerializer', () => {
@@ -215,6 +215,90 @@ describe('HTMLSerializers', () => {
           container.querySelector<HTMLElement>('.drop-cap')
         ).toHaveTextContent('H');
       });
+    });
+  });
+
+  describe('createSerializer', () => {
+    const hyperlinkType = prismic.RichTextNodeType.hyperlink;
+    const mockKey = 'link-key';
+    const mockContent = '';
+    const children = ['Click here'] as unknown as ReactNode[];
+
+    it('strips external links when stripExternalLinks is true', () => {
+      const serializer = createSerializer({ stripExternalLinks: true });
+      const element = {
+        type: hyperlinkType,
+        data: { link_type: 'Web', url: 'https://www.bbc.co.uk/news' },
+        text: '',
+        start: 0,
+        end: 10,
+      } as unknown as prismic.RTAnyNode;
+
+      const result = serializer(
+        hyperlinkType,
+        element,
+        mockContent,
+        children,
+        mockKey
+      );
+
+      const { container } = render(<>{result}</>);
+      expect(container.querySelector('a')).not.toBeInTheDocument();
+      expect(container).toHaveTextContent('Click here');
+    });
+
+    it('keeps internal links when stripExternalLinks is true', () => {
+      const serializer = createSerializer({ stripExternalLinks: true });
+      const element = {
+        type: hyperlinkType,
+        data: {
+          link_type: 'Web',
+          url: 'https://wellcomecollection.org/stories',
+        },
+        text: '',
+        start: 0,
+        end: 10,
+      } as unknown as prismic.RTAnyNode;
+
+      const result = serializer(
+        hyperlinkType,
+        element,
+        mockContent,
+        children,
+        mockKey
+      );
+
+      const { container } = render(<>{result}</>);
+      const link = container.querySelector('a');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute(
+        'href',
+        'https://wellcomecollection.org/stories'
+      );
+    });
+
+    it('keeps all links when stripExternalLinks is false', () => {
+      const serializer = createSerializer({ stripExternalLinks: false });
+      const element = {
+        type: hyperlinkType,
+        data: { link_type: 'Web', url: 'https://www.bbc.co.uk/news' },
+        text: '',
+        start: 0,
+        end: 10,
+      } as unknown as prismic.RTAnyNode;
+
+      const result = serializer(
+        hyperlinkType,
+        element,
+        mockContent,
+        children,
+        mockKey
+      );
+
+      const { container } = render(<>{result}</>);
+      const link = container.querySelector('a');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', 'https://www.bbc.co.uk/news');
     });
   });
 });

--- a/common/views/components/HTMLSerializers/HTMLSerializers.test.tsx
+++ b/common/views/components/HTMLSerializers/HTMLSerializers.test.tsx
@@ -300,5 +300,28 @@ describe('HTMLSerializers', () => {
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', 'https://www.bbc.co.uk/news');
     });
+
+    it('strips protocol-relative URLs as external', () => {
+      const serializer = createSerializer({ stripExternalLinks: true });
+      const element = {
+        type: hyperlinkType,
+        data: { link_type: 'Web', url: '//example.com/page' },
+        text: '',
+        start: 0,
+        end: 10,
+      } as unknown as prismic.RTAnyNode;
+
+      const result = serializer(
+        hyperlinkType,
+        element,
+        mockContent,
+        children,
+        mockKey
+      );
+
+      const { container } = render(<>{result}</>);
+      expect(container.querySelector('a')).not.toBeInTheDocument();
+      expect(container).toHaveTextContent('Click here');
+    });
   });
 });

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -203,7 +203,8 @@ export const defaultSerializer: JSXFunctionSerializer = (
 };
 
 function isInternalLink(url: string): boolean {
-  if (url.startsWith('/') || url.startsWith('#')) return true;
+  if (url.startsWith('#')) return true;
+  if (url.startsWith('/') && !url.startsWith('//')) return true;
   try {
     const parsed = new URL(url);
     return (

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -206,7 +206,10 @@ function isInternalLink(url: string): boolean {
   if (url.startsWith('/') || url.startsWith('#')) return true;
   try {
     const parsed = new URL(url);
-    return parsed.hostname.endsWith('wellcomecollection.org');
+    return (
+      parsed.hostname === 'wellcomecollection.org' ||
+      parsed.hostname.endsWith('.wellcomecollection.org')
+    );
   } catch {
     return false;
   }

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -216,28 +216,6 @@ function isInternalLink(url: string): boolean {
 }
 
 /**
- * Creates a serializer that optionally strips external links,
- * rendering their text content without the anchor tag.
- */
-export const createSerializer = ({
-  stripExternalLinks = false,
-}: {
-  stripExternalLinks?: boolean;
-} = {}): JSXFunctionSerializer => {
-  if (!stripExternalLinks) return defaultSerializer;
-
-  return (type, element, content, children, key) => {
-    if (element.type === prismic.RichTextNodeType.hyperlink) {
-      const linkUrl = prismic.asLink(element.data, { linkResolver }) || '';
-      if (!isInternalLink(linkUrl)) {
-        return <span key={key}>{children}</span>;
-      }
-    }
-    return defaultSerializer(type, element, content, children, key);
-  };
-};
-
-/**
  * Safely extract the first string child from a React node.
  * Used by dropCapSerializer to get the first characters for drop cap styling.
  * Handles both direct strings and React elements with string children.
@@ -286,6 +264,36 @@ export const dropCapSerializer: JSXFunctionSerializer = (
     return <p key={key}>{childrenWithDropCap}</p>;
   }
   return defaultSerializer(type, element, content, children, key);
+};
+
+/**
+ * Creates a serializer that optionally strips external links and/or
+ * applies drop cap styling to the first paragraph.
+ */
+export const createSerializer = ({
+  stripExternalLinks = false,
+  dropCap = false,
+}: {
+  stripExternalLinks?: boolean;
+  dropCap?: boolean;
+} = {}): JSXFunctionSerializer => {
+  if (!stripExternalLinks && !dropCap) return defaultSerializer;
+  if (!stripExternalLinks && dropCap) return dropCapSerializer;
+
+  return (type, element, content, children, key) => {
+    if (element.type === prismic.RichTextNodeType.hyperlink) {
+      const linkUrl = prismic.asLink(element.data, { linkResolver }) || '';
+      if (!isInternalLink(linkUrl)) {
+        return <span key={key}>{children}</span>;
+      }
+    }
+
+    if (dropCap) {
+      return dropCapSerializer(type, element, content, children, key);
+    }
+
+    return defaultSerializer(type, element, content, children, key);
+  };
 };
 
 const ACCESSIBILITY_ICON_MAP: Record<string, IconSvg> = {

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -202,6 +202,38 @@ export const defaultSerializer: JSXFunctionSerializer = (
   }
 };
 
+function isInternalLink(url: string): boolean {
+  if (url.startsWith('/') || url.startsWith('#')) return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.endsWith('wellcomecollection.org');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates a serializer that optionally strips external links,
+ * rendering their text content without the anchor tag.
+ */
+export const createSerializer = ({
+  stripExternalLinks = false,
+}: {
+  stripExternalLinks?: boolean;
+} = {}): JSXFunctionSerializer => {
+  if (!stripExternalLinks) return defaultSerializer;
+
+  return (type, element, content, children, key) => {
+    if (element.type === prismic.RichTextNodeType.hyperlink) {
+      const linkUrl = prismic.asLink(element.data, { linkResolver }) || '';
+      if (!isInternalLink(linkUrl)) {
+        return <span key={key}>{children}</span>;
+      }
+    }
+    return defaultSerializer(type, element, content, children, key);
+  };
+};
+
 /**
  * Safely extract the first string child from a React node.
  * Used by dropCapSerializer to get the first characters for drop cap styling.

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -1,0 +1,223 @@
+import { useRouter } from 'next/router';
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+
+import { useKiosk } from '@weco/common/contexts/KioskContext';
+import Modal from '@weco/common/views/components/Modal';
+
+const INACTIVITY_TIMEOUT = 30 * 1000; // 30 seconds
+const WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
+
+const RedirectModalContent = styled.div`
+  padding: 24px;
+  text-align: center;
+
+  p {
+    margin: 16px 0;
+    font-size: 18px;
+    line-height: 1.5;
+  }
+`;
+
+const RedirectModalTitle = styled.h2`
+  font-size: 32px;
+  font-weight: bold;
+  margin: 0 0 24px;
+`;
+
+const CountdownText = styled.strong`
+  font-size: 24px;
+  font-weight: bold;
+`;
+
+type Props = {
+  redirectUrl: string;
+};
+
+const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
+  const isKiosk = useKiosk();
+  const router = useRouter();
+  const [isWarningActive, setIsWarningActive] = useState(false);
+  const [countdown, setCountdown] = useState(WARNING_COUNTDOWN);
+  const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const countdownTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const redirectTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const modalButtonRef = useRef<HTMLElement | null>(null);
+
+  // Don't run on the redirect destination itself
+  const isRedirectDestination = router.asPath === redirectUrl;
+
+  const performRedirect = useCallback(() => {
+    setIsWarningActive(false);
+    router.push(redirectUrl);
+  }, [router, redirectUrl]);
+
+  const resetInactivityTimer = useCallback(() => {
+    if (inactivityTimerRef.current) {
+      clearTimeout(inactivityTimerRef.current);
+    }
+
+    if (isWarningActive) return;
+
+    inactivityTimerRef.current = setTimeout(() => {
+      setIsWarningActive(true);
+      setCountdown(WARNING_COUNTDOWN);
+    }, INACTIVITY_TIMEOUT);
+  }, [isWarningActive]);
+
+  const handleCancelRedirect = useCallback(() => {
+    setIsWarningActive(false);
+    setCountdown(WARNING_COUNTDOWN);
+
+    if (countdownTimerRef.current) {
+      clearInterval(countdownTimerRef.current);
+      countdownTimerRef.current = null;
+    }
+    if (redirectTimerRef.current) {
+      clearTimeout(redirectTimerRef.current);
+      redirectTimerRef.current = null;
+    }
+
+    resetInactivityTimer();
+  }, [resetInactivityTimer]);
+
+  const handleUserActivity = useCallback(() => {
+    if (isWarningActive) {
+      handleCancelRedirect();
+    } else {
+      resetInactivityTimer();
+    }
+  }, [isWarningActive, handleCancelRedirect, resetInactivityTimer]);
+
+  // Clean up on route changes
+  useEffect(() => {
+    const handleRouteChange = () => {
+      setIsWarningActive(false);
+      setCountdown(WARNING_COUNTDOWN);
+
+      if (countdownTimerRef.current) {
+        clearInterval(countdownTimerRef.current);
+        countdownTimerRef.current = null;
+      }
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+        redirectTimerRef.current = null;
+      }
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+        inactivityTimerRef.current = null;
+      }
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router]);
+
+  // Countdown and redirect when warning is active
+  useEffect(() => {
+    if (isWarningActive) {
+      countdownTimerRef.current = setInterval(() => {
+        setCountdown(prev => {
+          if (prev <= 1) {
+            if (countdownTimerRef.current) {
+              clearInterval(countdownTimerRef.current);
+            }
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      redirectTimerRef.current = setTimeout(() => {
+        performRedirect();
+      }, WARNING_COUNTDOWN * 1000);
+
+      return () => {
+        if (countdownTimerRef.current) {
+          clearInterval(countdownTimerRef.current);
+        }
+        if (redirectTimerRef.current) {
+          clearTimeout(redirectTimerRef.current);
+        }
+      };
+    }
+  }, [isWarningActive, performRedirect]);
+
+  // Set up activity listeners
+  useEffect(() => {
+    if (!isKiosk || isRedirectDestination) return;
+
+    const events = [
+      'mousedown',
+      'mousemove',
+      'keydown',
+      'scroll',
+      'touchstart',
+      'click',
+    ];
+
+    events.forEach(event => {
+      window.addEventListener(event, handleUserActivity, { passive: true });
+    });
+
+    resetInactivityTimer();
+
+    return () => {
+      events.forEach(event => {
+        window.removeEventListener(event, handleUserActivity);
+      });
+
+      if (inactivityTimerRef.current) {
+        clearTimeout(inactivityTimerRef.current);
+      }
+      if (countdownTimerRef.current) {
+        clearInterval(countdownTimerRef.current);
+      }
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+    };
+  }, [
+    isKiosk,
+    isRedirectDestination,
+    isWarningActive,
+    handleUserActivity,
+    resetInactivityTimer,
+  ]);
+
+  if (!isKiosk || isRedirectDestination) {
+    return null;
+  }
+
+  return (
+    <Modal
+      data-component="inactivity-redirect"
+      isActive={isWarningActive}
+      setIsActive={handleCancelRedirect}
+      id="kiosk-inactivity-warning"
+      dataTestId="kiosk-inactivity-warning"
+      openButtonRef={modalButtonRef}
+      showOverlay={true}
+    >
+      <RedirectModalContent>
+        <RedirectModalTitle>Are you still there?</RedirectModalTitle>
+        <p>
+          Due to inactivity, you will be redirected in{' '}
+          <CountdownText>{countdown}</CountdownText> second
+          {countdown !== 1 ? 's' : ''}.
+        </p>
+        <p>Tap the screen to stay on this page.</p>
+      </RedirectModalContent>
+    </Modal>
+  );
+};
+
+export default InactivityRedirect;

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -203,7 +203,6 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
       isActive={isWarningActive}
       setIsActive={handleCancelRedirect}
       id="kiosk-inactivity-warning"
-      dataTestId="kiosk-inactivity-warning"
       openButtonRef={modalButtonRef}
       showOverlay={true}
     >

--- a/common/views/components/PageHeaderStandfirst/index.tsx
+++ b/common/views/components/PageHeaderStandfirst/index.tsx
@@ -1,6 +1,8 @@
 import { ComponentPropsWithoutRef, FunctionComponent } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
+import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -15,10 +17,20 @@ const Wrapper = styled(Space).attrs({
 
 export type Props = ComponentPropsWithoutRef<typeof PrismicHtmlBlock>;
 
-const PageHeaderStandfirst: FunctionComponent<Props> = props => (
-  <Wrapper data-component="page-header-standfirst">
-    <PrismicHtmlBlock {...props} />
-  </Wrapper>
-);
+const PageHeaderStandfirst: FunctionComponent<Props> = props => {
+  const isKiosk = useKiosk();
+
+  return (
+    <Wrapper data-component="page-header-standfirst">
+      <PrismicHtmlBlock
+        {...props}
+        htmlSerializer={
+          props.htmlSerializer ||
+          createSerializer({ stripExternalLinks: isKiosk })
+        }
+      />
+    </Wrapper>
+  );
+};
 
 export default PageHeaderStandfirst;

--- a/common/views/slices/Text/index.tsx
+++ b/common/views/slices/Text/index.tsx
@@ -9,7 +9,6 @@ import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper
 import {
   accessibilitySerializer,
   createSerializer,
-  dropCapSerializer,
 } from '@weco/common/views/components/HTMLSerializers';
 import { ContaineredLayout } from '@weco/common/views/components/Layout';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
@@ -56,7 +55,10 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
             <>
               <PrismicHtmlBlock
                 html={[slice.primary.text[0]] as prismic.RichTextField}
-                htmlSerializer={dropCapSerializer}
+                htmlSerializer={createSerializer({
+                  stripExternalLinks: isKiosk,
+                  dropCap: true,
+                })}
               />
               <PrismicHtmlBlock
                 html={slice.primary.text.slice(1) as prismic.RichTextField}

--- a/common/views/slices/Text/index.tsx
+++ b/common/views/slices/Text/index.tsx
@@ -2,12 +2,13 @@ import * as prismic from '@prismicio/client';
 import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { TextSlice as RawTextSlice } from '@weco/common/prismicio-types';
 import { classNames } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import {
   accessibilitySerializer,
-  defaultSerializer,
+  createSerializer,
   dropCapSerializer,
 } from '@weco/common/views/components/HTMLSerializers';
 import { ContaineredLayout } from '@weco/common/views/components/Layout';
@@ -21,6 +22,7 @@ import {
 export type TextProps = SliceComponentProps<RawTextSlice, SliceZoneContext>;
 
 const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
+  const isKiosk = useKiosk();
   const options = { ...defaultContext, ...context };
   const shouldBeDroppedCap =
     options.firstTextSliceIndex === slice.id && options.isDropCapped;
@@ -29,6 +31,10 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
   const isAccessibilityPage =
     options.pageUid === 'accessibility' ||
     options.pageUid === 'prototype-a11y-november-2025';
+
+  const serializer = isAccessibilityPage
+    ? accessibilitySerializer
+    : createSerializer({ stripExternalLinks: isKiosk });
 
   return (
     <SpacingComponent $sliceType={slice.slice_type}>
@@ -54,21 +60,13 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
               />
               <PrismicHtmlBlock
                 html={slice.primary.text.slice(1) as prismic.RichTextField}
-                htmlSerializer={
-                  isAccessibilityPage
-                    ? accessibilitySerializer
-                    : defaultSerializer
-                }
+                htmlSerializer={serializer}
               />
             </>
           ) : (
             <PrismicHtmlBlock
               html={slice.primary.text}
-              htmlSerializer={
-                isAccessibilityPage
-                  ? accessibilitySerializer
-                  : defaultSerializer
-              }
+              htmlSerializer={serializer}
             />
           )}
         </div>

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -8,7 +8,7 @@ import {
   WebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { appError } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -41,7 +41,7 @@ import ArticleSeriesPage, {
 } from '@weco/content/views/pages/series/series';
 
 const Page: NextPage<ArticleSeriesPageProps> = props => {
-  const { storiesKiosk } = useToggles();
+  const { storiesKiosk } = useFeatureFlags();
 
   return (
     <KioskProvider isActive={!!storiesKiosk}>

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -1,15 +1,18 @@
 import * as prismic from '@prismicio/client';
 import { NextPage } from 'next';
 
+import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { bodySquabblesSeries as bodySquabblesSeriesId } from '@weco/common/data/hardcoded-ids';
 import {
   SeriesDocument,
   WebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
+import { useToggles } from '@weco/common/server-data/Context';
 import { appError } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
+import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -38,7 +41,14 @@ import ArticleSeriesPage, {
 } from '@weco/content/views/pages/series/series';
 
 const Page: NextPage<ArticleSeriesPageProps> = props => {
-  return <ArticleSeriesPage {...props} />;
+  const { storiesKiosk } = useToggles();
+
+  return (
+    <KioskProvider isActive={!!storiesKiosk}>
+      {storiesKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
+      <ArticleSeriesPage {...props} />
+    </KioskProvider>
+  );
 };
 
 type Props = ServerSideProps<ArticleSeriesPageProps>;

--- a/content/webapp/pages/stories/[articleId].tsx
+++ b/content/webapp/pages/stories/[articleId].tsx
@@ -1,9 +1,12 @@
 import { NextPage } from 'next';
 
+import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
+import { useToggles } from '@weco/common/server-data/Context';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
+import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -18,7 +21,14 @@ import ArticlePage, {
 } from '@weco/content/views/pages/stories/story';
 
 const Page: NextPage<ArticlePageProps> = props => {
-  return <ArticlePage {...props} />;
+  const { storiesKiosk } = useToggles();
+
+  return (
+    <KioskProvider isActive={!!storiesKiosk}>
+      {storiesKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
+      <ArticlePage {...props} />
+    </KioskProvider>
+  );
 };
 
 type Props = ServerSideProps<ArticlePageProps>;

--- a/content/webapp/pages/stories/[articleId].tsx
+++ b/content/webapp/pages/stories/[articleId].tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 
 import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
-import { useToggles } from '@weco/common/server-data/Context';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -21,7 +21,7 @@ import ArticlePage, {
 } from '@weco/content/views/pages/stories/story';
 
 const Page: NextPage<ArticlePageProps> = props => {
-  const { storiesKiosk } = useToggles();
+  const { storiesKiosk } = useFeatureFlags();
 
   return (
     <KioskProvider isActive={!!storiesKiosk}>

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -1,10 +1,8 @@
 import { NextPage } from 'next';
 
-import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
-import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -23,12 +21,7 @@ import KioskStoriesListingPage, {
 } from '@weco/content/views/pages/stories/kiosk';
 
 const Page: NextPage<KioskStoriesListingPageProps> = props => {
-  return (
-    <KioskProvider isActive>
-      <InactivityRedirect redirectUrl="/stories/kiosk" />
-      <KioskStoriesListingPage {...props} />
-    </KioskProvider>
-  );
+  return <KioskStoriesListingPage {...props} />;
 };
 
 type Props = ServerSideProps<KioskStoriesListingPageProps>;

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -1,8 +1,10 @@
 import { NextPage } from 'next';
 
+import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
+import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -21,7 +23,12 @@ import KioskStoriesListingPage, {
 } from '@weco/content/views/pages/stories/kiosk';
 
 const Page: NextPage<KioskStoriesListingPageProps> = props => {
-  return <KioskStoriesListingPage {...props} />;
+  return (
+    <KioskProvider isActive>
+      <InactivityRedirect redirectUrl="/stories/kiosk" />
+      <KioskStoriesListingPage {...props} />
+    </KioskProvider>
+  );
 };
 
 type Props = ServerSideProps<KioskStoriesListingPageProps>;

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -3,13 +3,14 @@ import { SliceZone } from '@prismicio/react';
 import { Fragment, FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { officialLandingPagesUid } from '@weco/common/data/hardcoded-ids';
 import { ContentListSlice as RawContentListSlice } from '@weco/common/prismicio-types';
 import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { classNames, font } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import {
   ContaineredLayout,
   gridSize12,
@@ -142,6 +143,7 @@ const Body: FunctionComponent<Props> = ({
   contentType,
   bodySliceContexts,
 }: Props) => {
+  const isKiosk = useKiosk();
   const filteredUntransformedBody = untransformedBody.filter(
     (slice: prismic.Slice) => slice.slice_type !== 'standfirst'
   );
@@ -335,7 +337,9 @@ const Body: FunctionComponent<Props> = ({
                 >
                   <FeaturedText
                     html={introText}
-                    htmlSerializer={defaultSerializer}
+                    htmlSerializer={createSerializer({
+                      stripExternalLinks: isKiosk,
+                    })}
                   />
                 </Space>
               </div>

--- a/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
+++ b/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
@@ -131,10 +131,10 @@ const Contributor: FunctionComponent<ContributorType> = ({
 
           {role && role.title && <Role>{role.title}</Role>}
 
-          {!isKiosk && contributor.sameAs.length > 0 && (
+          {contributor.sameAs.length > 0 && (
             <LinkLabels
               items={contributor.sameAs.map(({ link, title }) => ({
-                url: link,
+                url: isKiosk ? undefined : link,
                 text: title,
               }))}
             />

--- a/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
+++ b/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
@@ -1,8 +1,10 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { getCrop } from '@weco/common/model/image';
 import { font } from '@weco/common/utils/classnames';
+import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
@@ -66,6 +68,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
   role,
   description,
 }) => {
+  const isKiosk = useKiosk();
   const descriptionToRender = description || contributor.description;
 
   // Contributor images should always be square.
@@ -128,7 +131,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
 
           {role && role.title && <Role>{role.title}</Role>}
 
-          {contributor.sameAs.length > 0 && (
+          {!isKiosk && contributor.sameAs.length > 0 && (
             <LinkLabels
               items={contributor.sameAs.map(({ link, title }) => ({
                 url: link,
@@ -139,7 +142,12 @@ const Contributor: FunctionComponent<ContributorType> = ({
 
           {descriptionToRender && (
             <Description>
-              <PrismicHtmlBlock html={descriptionToRender} />
+              <PrismicHtmlBlock
+                html={descriptionToRender}
+                htmlSerializer={createSerializer({
+                  stripExternalLinks: isKiosk,
+                })}
+              />
             </Description>
           )}
         </div>

--- a/content/webapp/views/components/TextAndImageOrIcons/index.tsx
+++ b/content/webapp/views/components/TextAndImageOrIcons/index.tsx
@@ -2,8 +2,9 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { ImageType } from '@weco/common/model/image';
-import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
+import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -90,6 +91,7 @@ export type Props = {
 };
 
 const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
+  const isKiosk = useKiosk();
   // Icons can be added indefinitely without necessarily having an image, so we are filtering it here
   const icons: ImageType[] = [];
   if (item.type === 'icons') {
@@ -124,7 +126,7 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
         <Text>
           <PrismicHtmlBlock
             html={item.text}
-            htmlSerializer={defaultSerializer}
+            htmlSerializer={createSerializer({ stripExternalLinks: isKiosk })}
           />
         </Text>
       </MediaAndTextWrap>

--- a/content/webapp/views/pages/series/series/index.tsx
+++ b/content/webapp/views/pages/series/series/index.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
@@ -37,10 +38,11 @@ export type Props = {
 
 const ArticleSeriesPage: NextPage<Props> = props => {
   const { series, articles, scheduledItems } = props;
+  const isKiosk = useKiosk();
   const breadcrumbs = {
     items: [
       {
-        url: '/stories',
+        url: isKiosk ? '/stories/kiosk' : '/stories',
         text: 'Stories',
       },
       {
@@ -49,6 +51,7 @@ const ArticleSeriesPage: NextPage<Props> = props => {
         isHidden: true,
       },
     ],
+    noHomeLink: isKiosk,
   };
 
   const ContentTypeInfo = series.untransformedStandfirst ? (
@@ -89,6 +92,9 @@ const ArticleSeriesPage: NextPage<Props> = props => {
       openGraphType="website"
       image={series.image}
       apiToolbarLinks={[createPrismicLink(series.id)]}
+      hideHeader={isKiosk}
+      hideFooter={isKiosk}
+      hideNewsletterPromo={isKiosk}
     >
       <ContentPage
         id={series.id}

--- a/content/webapp/views/pages/stories/story/index.tsx
+++ b/content/webapp/views/pages/stories/story/index.tsx
@@ -2,6 +2,7 @@ import { NextPage } from 'next';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { getCrop } from '@weco/common/model/image';
 import { SimplifiedServerData } from '@weco/common/server-data/types';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
@@ -49,6 +50,7 @@ export type ArticleSeriesList = {
 }[];
 
 const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
+  const isKiosk = useKiosk();
   const [listOfSeries, setListOfSeries] = useState<ArticleSeriesList>();
   const [relatedDocument, setRelatedDocument] = useState<
     ExhibitionBasic | ContentAPIArticle | undefined
@@ -80,6 +82,16 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
     },
   ];
 
+  const breadcrumbs = isKiosk
+    ? {
+        items: [
+          { text: 'Stories', url: '/stories/kiosk' },
+          ...extraBreadcrumbs,
+        ],
+        noHomeLink: true,
+      }
+    : getBreadcrumbItems('stories', extraBreadcrumbs);
+
   const isPodcast = article.format?.id === ArticleFormatIds.Podcast;
 
   // Check if the article is in a serial, and where
@@ -110,7 +122,7 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
   const Header = (
     <PageHeader
       variant="basic"
-      breadcrumbs={getBreadcrumbItems('stories', extraBreadcrumbs)}
+      breadcrumbs={breadcrumbs}
       labels={{ labels: article.labels }}
       title={article.title}
       ContentTypeInfo={ContentTypeInfo(article)}
@@ -158,6 +170,9 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
       siteSection="stories"
       image={article.image}
       apiToolbarLinks={[createPrismicLink(article.id)]}
+      hideHeader={isKiosk}
+      hideFooter={isKiosk}
+      hideNewsletterPromo={isKiosk}
     >
       <ContentPage
         id={article.id}


### PR DESCRIPTION
- For #13076

## What does this change?

Used ideas/implementations from https://github.com/wellcomecollection/wellcomecollection.org/pull/13070

This implements kiosk mode for stories pages, designed for in-gallery touchscreen displays. When the `storiesKiosk` toggle is enabled:

1. **Minimal layout to other page**: header, footer, and newsletter promo are hidden on individual story pages and series pages
2. **External link stripping**: all external links in rich text content are rendered as plain text (internal wellcomecollection.org links are preserved)
3. **Kiosk breadcrumbs**: the "Stories" breadcrumb links to `/stories/kiosk` instead of `/stories`, and the Home breadcrumb is hidden
4. **Inactivity redirect**: after 30 seconds of inactivity a warning modal appears; if dismissed by countdown (30s) it redirects back to `/stories/kiosk`

### Architecture

- `KioskContext` provides a boolean `isKiosk` value down the tree where relevant. We could possibly use this to pass more information in if we need it, keeping it separate from our higher level contexts.
- `KioskProvider` wraps at the page level (`[articleId].tsx`, `[seriesId].tsx`)
- Components use `useKiosk()` to read the state and adjust rendering
- `createSerializer({ stripExternalLinks })` is a factory that wraps the default Prismic HTML serializer, intercepting hyperlink nodes and rendering external ones as `<span>` instead of `<a>`

### Files changed

- **New:** `common/contexts/KioskContext.tsx`, `common/views/components/InactivityRedirect/index.tsx`
- **Modified serializers:** `HTMLSerializers/index.tsx` (added `createSerializer` factory and `isInternalLink` helper)
- **Modified components:** `Text` slice, `Body`, `Caption`, `TextAndImageOrIcons`, `PageHeaderStandfirst`, `Contributors.Contributor`. More might be needed but those were the ones we identified at this stage
- **Modified pages:** `stories/[articleId].tsx`, `stories/kiosk.tsx`, `series/[seriesId].tsx`, `stories/story/index.tsx`, `series/series/index.tsx`

[We might eventually want to make these changes across the codebase](https://wellcome.slack.com/archives/CUA669WHH/p1779194248501949) but not at this stage (feels like a lot?)

## How to test

[Enable the `storiesKiosk` toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=storiesKiosk) locally, then:

1. Visit `/stories/kiosk` — should show a minimal stories listing with no header/footer
2. Click into a story — should show the article with no header/footer, breadcrumb linking back to `/stories/kiosk`
3. Wait 60 seconds without interaction — warning modal should appear, then redirect after 30s countdown

### Test external link stripping

These stories have external links in their **body text** — verify the links appear as plain text in kiosk mode but remain clickable on the normal site:

- https://www-dev.wellcomecollection.org/stories/mis-representations-of-gout (links to jstor.org, springer.com, arthritis-uk.org)
- https://www-dev.wellcomecollection.org/stories/the-weird-folklore-of-british-cakes (links to englishchristmascake.com, twitter.com, wikipedia.org)

These stories have external links in their **standfirst**:

- https://www-dev.wellcomecollection.org/stories/there-s-more-to-gingerbread-than-ginger (links to thegreatbritishbakeoff.co.uk)
- https://www-dev.wellcomecollection.org//stories/gender-gap (links to nhs.uk)

### Test contributor section

Any story with contributors who have social media links (sameAs) and description text with external links should also be rendered as plain text. https://www-dev.wellcomecollection.org/stories/generation-portraits

### Test series pages

Navigate to a series page from a kiosk story — should have the same minimal layout with breadcrumbs pointing to `/stories/kiosk`. https://www-dev.wellcomecollection.org/series/WsSUrR8AAL3KGFPF

## Have we considered potential risks?

- **Non-kiosk pages unaffected** — `useKiosk()` defaults to `false` when no provider is present, so all existing behaviour is preserved
- **Toggle-gated** — everything is behind the `storiesKiosk` experimental toggle
- **Internal links preserved** — the `isInternalLink` check allows relative paths, hash links, and any wellcomecollection.org URLs through