### PR TITLE
Remove backwards compatibility for toggles

### DIFF
--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -214,32 +214,4 @@ describe('getTogglesFromContext', () => {
       ).toBeUndefined();
     });
   });
-
-  describe('backward compatibility', () => {
-    it('supports the old JSON format with toggles field', () => {
-      const togglesResp = {
-        toggles: [stagingApiFlag],
-        tests: [],
-      } as unknown as TogglesResp;
-
-      const result = getTogglesFromContext(togglesResp, createContext());
-
-      expect(result.featureFlags.stagingApi).toBe(false);
-    });
-
-    it('prefers featureFlags over toggles if both are present', () => {
-      const togglesResp = {
-        featureFlags: [stagingApiFlag],
-        toggles: [{ ...stagingApiFlag, id: 'oldField' }],
-        tests: [],
-      } as unknown as TogglesResp;
-
-      const result = getTogglesFromContext(togglesResp, createContext());
-
-      expect(result.featureFlags.stagingApi).toBe(false);
-      expect(
-        (result.featureFlags as Record<string, unknown>).oldField
-      ).toBeUndefined();
-    });
-  });
 });

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -39,12 +39,7 @@ export function getTogglesFromContext(
 ): Toggles {
   const isStage = context.req.headers.host?.startsWith('www-stage');
   const allCookies = getCookies(context);
-  // Support both old ({ toggles: [...] }) and new ({ featureFlags: [...] }) JSON formats
-  const featureFlagsList =
-    togglesResp.featureFlags ??
-    (togglesResp as unknown as { toggles: TogglesResp['featureFlags'] })
-      .toggles ??
-    [];
+  const featureFlagsList = togglesResp.featureFlags ?? [];
   const featureFlags = featureFlagsList
     .filter(toggle => {
       return !(!isStage && toggle.type === 'stage');

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -48,7 +48,7 @@ const TogglesPage: FunctionComponent = () => {
     fetch('https://toggles.wellcomecollection.org/toggles.json')
       .then(resp => resp.json())
       .then(json => {
-        const featureFlags: Toggle[] = json.featureFlags ?? json.toggles ?? [];
+        const featureFlags: Toggle[] = json.featureFlags ?? [];
         const tests: AbTest[] = json.tests ?? [];
 
         setToggles(featureFlags);

--- a/toggles/webapp/deploy.test.ts
+++ b/toggles/webapp/deploy.test.ts
@@ -1,7 +1,7 @@
 import { withDefaultValuesUnmodified } from './deploy';
-import { PublishedToggle, ToggleDefinition } from './toggles';
+import { FeatureFlagDefinition, PublishedFeatureFlag } from './toggles';
 
-function getPublishedToggle(id: number): PublishedToggle {
+function getPublishedToggle(id: number): PublishedFeatureFlag {
   return {
     id: `toggle-${id}`,
     title: `title-${id}`,
@@ -11,7 +11,7 @@ function getPublishedToggle(id: number): PublishedToggle {
   };
 }
 
-function getToggleDefinition(id: number): ToggleDefinition {
+function getToggleDefinition(id: number): FeatureFlagDefinition {
   return {
     id: `toggle-${id}`,
     title: `title-${id}`,
@@ -51,7 +51,7 @@ it('removes tests', () => {
 });
 
 it('updates existing toggles leaving defaultValue unmodified', () => {
-  const remote: PublishedToggle[] = [
+  const remote: PublishedFeatureFlag[] = [
     {
       id: 'id-1',
       title: 'title1',
@@ -75,7 +75,7 @@ it('updates existing toggles leaving defaultValue unmodified', () => {
     },
   ];
 
-  const definitions: ToggleDefinition[] = [
+  const definitions: FeatureFlagDefinition[] = [
     {
       id: 'id-1',
       title: 'updated title1',
@@ -101,7 +101,7 @@ it('updates existing toggles leaving defaultValue unmodified', () => {
 
   const newRemote = withDefaultValuesUnmodified(remote, definitions);
 
-  const expected: PublishedToggle[] = [
+  const expected: PublishedFeatureFlag[] = [
     {
       id: 'id-1',
       title: 'updated title1',

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -3,12 +3,15 @@ import { info } from 'console';
 
 import { TogglesResp } from '.';
 import { getTogglesObject, putTogglesObject } from './s3-utils';
-import localToggles, { PublishedToggle, ToggleDefinition } from './toggles';
+import localToggles, {
+  FeatureFlagDefinition,
+  PublishedFeatureFlag,
+} from './toggles';
 
 export const withDefaultValuesUnmodified = (
-  publishedToggles: PublishedToggle[],
-  definitions: ToggleDefinition[]
-): PublishedToggle[] => {
+  publishedToggles: PublishedFeatureFlag[],
+  definitions: FeatureFlagDefinition[]
+): PublishedFeatureFlag[] => {
   /**
    * We don't deploy over the defaultValue as this can be set manually by
    * updating the toggle via setDefaultValueFor.  We want to make updating
@@ -49,14 +52,7 @@ export const withDefaultValuesUnmodified = (
 
 export async function deploy(client: S3Client): Promise<void> {
   const remoteToggles = await getTogglesObject(client);
-
-  // Backward compat: S3 may still have the old shape ({ toggles: [...] })
-  // until this deploy writes the new format.
-  const remoteFeatureFlags =
-    remoteToggles.featureFlags ??
-    (remoteToggles as unknown as { toggles: TogglesResp['featureFlags'] })
-      .toggles ??
-    [];
+  const remoteFeatureFlags = remoteToggles.featureFlags ?? [];
 
   const featureFlagsToDeploy = withDefaultValuesUnmodified(remoteFeatureFlags, [
     ...localToggles.featureFlags,

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -2,8 +2,6 @@ import toggleConfig, { ABTest, PublishedFeatureFlag } from './toggles';
 
 export type FeatureFlagId = (typeof toggleConfig.featureFlags)[number]['id'];
 export type TestId = (typeof toggleConfig.tests)[number]['id'];
-// Backward compatibility alias
-export type ToggleId = FeatureFlagId;
 
 // As togglesConfig is what is served at https://toggles.wellcomecollection.org/toggles.json
 // This allows methods fetching that URL to type the data fetched

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -16,10 +16,6 @@ export type PublishedFeatureFlag = ToggleBase & {
   defaultValue: boolean;
 };
 
-// Backward compatibility aliases
-export type ToggleDefinition = FeatureFlagDefinition;
-export type PublishedToggle = PublishedFeatureFlag;
-
 export type ABTest = {
   id: string;
   title: string;


### PR DESCRIPTION
## What does this change?

When we did
https://github.com/wellcomecollection/wellcomecollection.org/pull/13090
https://github.com/wellcomecollection/wellcomecollection.org/pull/13091
https://github.com/wellcomecollection/wellcomecollection.org/pull/13092

We needed to still support the old naming structure because we had to deploy the changes separately. That's done now ([see here](https://toggles.wellcomecollection.org/toggles.json)) so we don't need to support the old form. 


## How to test

Play around with toggles locally?


## Have we considered potential risks?
N/A