### PR TITLE
Add Modes as a type of toggle

### DIFF
--- a/common/server-data/Context.tsx
+++ b/common/server-data/Context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 
-import { FeatureFlags, Tests } from '@weco/toggles';
+import { FeatureFlags, Modes, Tests } from '@weco/toggles';
 
 import { SimplifiedPrismicData } from './prismic';
 import { defaultServerData, SimplifiedServerData } from './types';
@@ -29,6 +29,11 @@ export const useFeatureFlags = (): FeatureFlags => {
 export const useABTest = (): Tests => {
   const data = useContext(ServerDataContext);
   return data.toggles.tests;
+};
+
+export const useModes = (): Modes => {
+  const data = useContext(ServerDataContext);
+  return data.toggles.modes;
 };
 
 export const usePrismicData = (): SimplifiedPrismicData => {

--- a/common/server-data/__mocks__/index.ts
+++ b/common/server-data/__mocks__/index.ts
@@ -5,7 +5,7 @@ import {
   emptyPopupDialog,
   emptyPrismicQuery,
 } from '@weco/common/services/prismic/documents';
-import { FeatureFlags, Tests } from '@weco/toggles';
+import { FeatureFlags, Modes, Tests } from '@weco/toggles';
 
 export async function init(): Promise<void> {
   // we avoid writing to the filesystem so we can run this in CI
@@ -20,6 +20,7 @@ export async function getServerData(): Promise<ServerData> {
     toggles: {
       featureFlags: {} as FeatureFlags,
       tests: {} as Tests,
+      modes: {} as Modes,
     },
     prismic: {
       globalAlert: emptyGlobalAlert(),

--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -128,7 +128,10 @@ export const getServerData = async (
     typeof toggle === 'string' ? toggle : undefined;
 
   // Resolve toggle values from the cached config + user's cookies
-  const { featureFlags, tests } = getTogglesFromContext(togglesResp, context);
+  const { featureFlags, tests, modes } = getTogglesFromContext(
+    togglesResp,
+    context
+  );
 
   // If a valid toggle was requested via query param, set a cookie and enable it
   const allToggleIds = [...Object.keys(featureFlags), ...Object.keys(tests)];
@@ -146,7 +149,7 @@ export const getServerData = async (
   // Read cookie consent status (analytics, marketing)
   const consentStatus = getAllConsentStates(context);
 
-  const toggles: Toggles = { featureFlags, tests };
+  const toggles: Toggles = { featureFlags, tests, modes };
 
   const serverData = {
     toggles,

--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -242,4 +242,81 @@ describe('getTogglesFromContext', () => {
       ).toBeUndefined();
     });
   });
+
+  describe('modes', () => {
+    const modeDefinition = {
+      id: 'kioskMode',
+      title: 'Kiosk Mode',
+      description: 'Select which iPad this kiosk is running on',
+      options: [
+        { id: 'ipad-1', label: 'iPad 1' },
+        { id: 'ipad-2', label: 'iPad 2' },
+      ],
+    };
+
+    it('returns undefined when no cookie is set', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [],
+        modes: [modeDefinition],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(togglesResp, createContext());
+
+      expect(
+        (result.modes as Record<string, unknown>).kioskMode
+      ).toBeUndefined();
+    });
+
+    it('returns the value when cookie matches a valid option', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [],
+        modes: [modeDefinition],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_kioskMode: 'ipad-1' })
+      );
+
+      expect((result.modes as Record<string, unknown>).kioskMode).toBe(
+        'ipad-1'
+      );
+    });
+
+    it('returns undefined when cookie is an empty string', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [],
+        modes: [modeDefinition],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_kioskMode: '' })
+      );
+
+      expect(
+        (result.modes as Record<string, unknown>).kioskMode
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when cookie value is not a valid option', () => {
+      const togglesResp = {
+        featureFlags: [],
+        tests: [],
+        modes: [modeDefinition],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_kioskMode: 'invalid-ipad' })
+      );
+
+      expect(
+        (result.modes as Record<string, unknown>).kioskMode
+      ).toBeUndefined();
+    });
+  });
 });

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -1,11 +1,17 @@
 import { getCookies } from 'cookies-next';
 import { IncomingMessage } from 'http';
 
-import { FeatureFlags, Tests, Toggles, TogglesResp } from '@weco/toggles';
+import {
+  FeatureFlags,
+  Modes,
+  Tests,
+  Toggles,
+  TogglesResp,
+} from '@weco/toggles';
 
 import { Handler } from './';
 
-const defaultValue = { featureFlags: [], tests: [] };
+const defaultValue = { featureFlags: [], tests: [], modes: [] };
 
 async function fetchToggles(): Promise<TogglesResp> {
   const resp = await fetch(
@@ -76,7 +82,18 @@ export function getTogglesFromContext(
       [test.id]: testToggleValue(test.id),
     };
   }, {} as Tests);
-  return { featureFlags, tests };
+
+  const modesList = togglesResp.modes ?? [];
+  const modes = modesList.reduce((acc, mode) => {
+    const cookieValue = allCookies[`toggle_${mode.id}`];
+    return {
+      ...acc,
+      [mode.id]:
+        cookieValue && cookieValue.length > 0 ? cookieValue : undefined,
+    };
+  }, {} as Modes);
+
+  return { featureFlags, tests, modes };
 }
 
 export default togglesHandler;

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -86,10 +86,11 @@ export function getTogglesFromContext(
   const modesList = togglesResp.modes ?? [];
   const modes = modesList.reduce((acc, mode) => {
     const cookieValue = allCookies[`toggle_${mode.id}`];
+    const isValid =
+      cookieValue && mode.options.some(opt => opt.id === cookieValue);
     return {
       ...acc,
-      [mode.id]:
-        cookieValue && cookieValue.length > 0 ? cookieValue : undefined,
+      [mode.id]: isValid ? cookieValue : undefined,
     };
   }, {} as Modes);
 

--- a/common/server-data/types.ts
+++ b/common/server-data/types.ts
@@ -3,7 +3,7 @@ import {
   defaultValue as prismicDefaultValue,
   SimplifiedPrismicData,
 } from '@weco/common/server-data/prismic';
-import { FeatureFlags, Tests, Toggles } from '@weco/toggles';
+import { FeatureFlags, Modes, Tests, Toggles } from '@weco/toggles';
 
 /**
  * The type is stored here rather than with the service because
@@ -32,6 +32,7 @@ export const defaultServerData: SimplifiedServerData = {
   toggles: {
     featureFlags: {} as FeatureFlags,
     tests: {} as Tests,
+    modes: {} as Modes,
   },
   prismic: prismicDefaultValue,
   consentStatus: {

--- a/dash/webapp/views/pages/index.tsx
+++ b/dash/webapp/views/pages/index.tsx
@@ -75,7 +75,7 @@ const Dashboard: FunctionComponent = () => {
             <Card href="/toggles" role="listitem">
               <CardTitle>Toggles</CardTitle>
               <CardDescription>
-                Manage and test feature flags and A/B tests.
+                Manage and test feature flags, A/B tests, and modes.
               </CardDescription>
               <CardStatus $type="neutral">View all toggles →</CardStatus>
             </Card>

--- a/dash/webapp/views/pages/toggles/ListOfToggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/index.tsx
@@ -2,10 +2,7 @@ import { Dispatch, FunctionComponent, SetStateAction } from 'react';
 
 import { tokens } from '@weco/dash/views/themes/tokens';
 
-import { setCookieCustom, Toggle, ToggleStates } from '../toggles.helpers';
-import CopyLinkIcon from './ListOfToggles.CopyLinkIcon';
-import StatusBadge from './ListOfToggles.StatusBadge';
-import ToggleSwitch from './ListOfToggles.ToggleSwitch';
+import { FeatureFlag, setCookieCustom, ToggleStates } from '../toggles.helpers';
 import {
   ToggleControls,
   ToggleHeadingRow,
@@ -14,22 +11,42 @@ import {
   ToggleListItem,
   ToggleRow,
 } from '../toggles.styles';
+import CopyLinkIcon from './ListOfToggles.CopyLinkIcon';
+import StatusBadge from './ListOfToggles.StatusBadge';
+import ToggleSwitch from './ListOfToggles.ToggleSwitch';
 
 type ListOfTogglesProps = {
-  toggles: Toggle[];
+  title: string;
+  anchorId: string;
+  description?: string;
+  featureFlags: FeatureFlag[];
   toggleStates: ToggleStates;
   setToggleStates: Dispatch<SetStateAction<ToggleStates>>;
 };
 
 const ListOfToggles: FunctionComponent<ListOfTogglesProps> = ({
-  toggles,
+  title,
+  anchorId,
+  description,
+  featureFlags,
   toggleStates,
   setToggleStates,
 }) => (
   <>
-    {toggles.length > 0 ? (
+    <h2 id={anchorId}>
+      {title}
+      <a href={`#${anchorId}`} aria-label="Link to this section">
+        <span aria-hidden="true">#</span>
+      </a>
+    </h2>
+    {description && (
+      <p style={{ marginTop: 0, color: tokens.colors.text.secondary }}>
+        {description}
+      </p>
+    )}
+    {featureFlags.length > 0 ? (
       <ToggleList>
-        {toggles.map(toggle => {
+        {featureFlags.map(toggle => {
           const isPublicOn = toggle.defaultValue === true;
           const currentState = toggleStates[toggle.id];
           const isOn = (currentState ?? toggle.defaultValue) === true;

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -55,26 +55,7 @@ const TogglesPage: FunctionComponent = () => {
       .then(json => {
         const flags: FeatureFlag[] = json.featureFlags ?? [];
         const tests: AbTest[] = json.tests ?? [];
-        // TODO: remove hardcoded fallback once modes are deployed to S3.
-        // Until then, uncomment the fallback below to test the Modes UI locally.
         const modeDefinitions: ModeDefinition[] = json.modes ?? [];
-        // const modeDefinitions: ModeDefinition[] = json.modes?.length
-        //   ? json.modes
-        //   : [
-        //       {
-        //         id: 'kioskMode',
-        //         title: 'Kiosk mode',
-        //         description:
-        //           'Activate kiosk mode to display content optimised for in-gallery screens.',
-        //         options: [
-        //           { id: 'RR-iPad1', label: 'Reading Room: iPad 1' },
-        //           { id: 'RR-iPad2', label: 'Reading Room: iPad 2' },
-        //           { id: 'RR-iPad3', label: 'Reading Room: iPad 3' },
-        //           { id: 'TR-iPad1', label: 'Tenderness & Rage: iPad 1' },
-        //           { id: 'TR-iPad2', label: 'Tenderness & Rage: iPad 2' },
-        //         ],
-        //       },
-        //     ];
 
         setFeatureFlags(flags);
         setAbTests(tests);

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -12,7 +12,7 @@ import {
   PageTitle,
 } from '@weco/dash/views/components/PageLayout';
 import { tokens } from '@weco/dash/views/themes/tokens';
-import { ModeDefinition } from '@weco/toggles/toggles';
+import { ModeDefinition } from '@weco/toggles';
 
 import ListOfToggles from './ListOfToggles';
 import ABTests, { AbTest } from './toggles.ABTests';

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -12,24 +12,27 @@ import {
   PageTitle,
 } from '@weco/dash/views/components/PageLayout';
 import { tokens } from '@weco/dash/views/themes/tokens';
+import { ModeDefinition } from '@weco/toggles/toggles';
 
 import ListOfToggles from './ListOfToggles';
 import ABTests, { AbTest } from './toggles.ABTests';
 import {
   deleteCookieCustom,
+  FeatureFlag,
   setCookieCustom,
-  Toggle,
   ToggleStates,
 } from './toggles.helpers';
+import Modes from './toggles.Modes';
 import {
   MessageBox,
   ResetButton,
   SearchInput,
   Section,
   SectionInner,
+  TableOfContentsList,
 } from './toggles.styles';
 
-const GENERAL_TOGGLE_IDS = ['apiToolbar', 'conceptsSearch'];
+const GENERAL_FEATURE_FLAG_IDS = ['apiToolbar', 'conceptsSearch'];
 
 const TogglesPage: FunctionComponent = () => {
   const router = useRouter();
@@ -40,25 +43,48 @@ const TogglesPage: FunctionComponent = () => {
     isEnabled?: boolean;
   } | null>(null);
   const [toggleStates, setToggleStates] = useState<ToggleStates>({});
-  const [toggles, setToggles] = useState<Toggle[]>([]);
+  const [featureFlags, setFeatureFlags] = useState<FeatureFlag[]>([]);
   const [abTests, setAbTests] = useState<AbTest[]>([]);
+  const [modes, setModes] = useState<ModeDefinition[]>([]);
+  const [modeStates, setModeStates] = useState<Record<string, string>>({});
   const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
     fetch('https://toggles.wellcomecollection.org/toggles.json')
       .then(resp => resp.json())
       .then(json => {
-        const featureFlags: Toggle[] = json.featureFlags ?? json.toggles ?? [];
+        const flags: FeatureFlag[] = json.featureFlags ?? json.toggles ?? [];
         const tests: AbTest[] = json.tests ?? [];
+        // TODO: remove hardcoded fallback once modes are deployed to S3.
+        // Until then, uncomment the fallback below to test the Modes UI locally.
+        const modeDefinitions: ModeDefinition[] = json.modes ?? [];
+        // const modeDefinitions: ModeDefinition[] = json.modes?.length
+        //   ? json.modes
+        //   : [
+        //       {
+        //         id: 'kioskMode',
+        //         title: 'Kiosk mode',
+        //         description:
+        //           'Activate kiosk mode to display content optimised for in-gallery screens.',
+        //         options: [
+        //           { id: 'RR-iPad1', label: 'Reading Room: iPad 1' },
+        //           { id: 'RR-iPad2', label: 'Reading Room: iPad 2' },
+        //           { id: 'RR-iPad3', label: 'Reading Room: iPad 3' },
+        //           { id: 'TR-iPad1', label: 'Tenderness & Rage: iPad 1' },
+        //           { id: 'TR-iPad2', label: 'Tenderness & Rage: iPad 2' },
+        //         ],
+        //       },
+        //     ];
 
-        setToggles(featureFlags);
+        setFeatureFlags(flags);
         setAbTests(tests);
+        setModes(modeDefinitions);
 
         const cookies = getCookies();
         const initialStates: ToggleStates = {};
 
-        // Toggles: cookie value or default
-        for (const toggle of featureFlags) {
+        // Feature flags: cookie value or default
+        for (const toggle of flags) {
           const cookieKey = `toggle_${toggle.id}`;
           initialStates[toggle.id] =
             cookieKey in cookies
@@ -74,6 +100,17 @@ const TogglesPage: FunctionComponent = () => {
           }
         }
 
+        // Modes: read plain string cookie values
+        const initialModeStates: Record<string, string> = {};
+        for (const mode of modeDefinitions) {
+          const cookieKey = `toggle_${mode.id}`;
+          const cookieValue = cookies[cookieKey];
+          if (cookieValue && cookieValue.length > 0) {
+            initialModeStates[mode.id] = cookieValue;
+          }
+        }
+        setModeStates(initialModeStates);
+
         setToggleStates(initialStates);
       })
       .catch(() =>
@@ -86,7 +123,7 @@ const TogglesPage: FunctionComponent = () => {
 
   // Scroll to hash anchor after data loads (sections aren't in the DOM on first render)
   useEffect(() => {
-    if (toggles.length === 0) return;
+    if (featureFlags.length === 0) return;
     const hash = window.location.hash;
     if (hash) {
       const el = document.querySelector(hash);
@@ -94,11 +131,11 @@ const TogglesPage: FunctionComponent = () => {
         el.scrollIntoView();
       }
     }
-  }, [toggles]);
+  }, [featureFlags]);
 
-  const handleToggle = useCallback(
+  const handleFeatureFlag = useCallback(
     (toggleId: string, action: 'enable' | 'disable') => {
-      const toggleExists = toggles.some(toggle => toggle.id === toggleId);
+      const toggleExists = featureFlags.some(toggle => toggle.id === toggleId);
       if (toggleExists) {
         if (action === 'enable') {
           setCookieCustom(toggleId, 'true');
@@ -112,7 +149,7 @@ const TogglesPage: FunctionComponent = () => {
             isEnabled: true,
           });
         } else {
-          const toggle = toggles.find(t => t.id === toggleId);
+          const toggle = featureFlags.find(t => t.id === toggleId);
           deleteCookieCustom(toggleId);
           setToggleStates(prev => ({
             ...prev,
@@ -131,20 +168,20 @@ const TogglesPage: FunctionComponent = () => {
         });
       }
     },
-    [toggles]
+    [featureFlags]
   );
 
   const reset = useCallback(
     () =>
       setToggleStates(prev => {
         const next = { ...prev };
-        for (const { id, defaultValue } of toggles) {
+        for (const { id, defaultValue } of featureFlags) {
           deleteCookieCustom(id);
           next[id] = defaultValue;
         }
         return next;
       }),
-    [toggles]
+    [featureFlags]
   );
 
   const resetAbTests = useCallback(() => {
@@ -163,7 +200,7 @@ const TogglesPage: FunctionComponent = () => {
   }, [abTests]);
 
   useEffect(() => {
-    if (toggles.length === 0) return;
+    if (featureFlags.length === 0) return;
 
     if (resetToggles !== undefined) {
       reset();
@@ -172,16 +209,23 @@ const TogglesPage: FunctionComponent = () => {
         isError: false,
       });
     } else if (enableToggle) {
-      handleToggle(enableToggle as string, 'enable');
+      handleFeatureFlag(enableToggle as string, 'enable');
     } else if (disableToggle) {
-      handleToggle(disableToggle as string, 'disable');
+      handleFeatureFlag(disableToggle as string, 'disable');
     }
-  }, [enableToggle, disableToggle, resetToggles, handleToggle, reset, toggles]);
+  }, [
+    enableToggle,
+    disableToggle,
+    resetToggles,
+    handleFeatureFlag,
+    reset,
+    featureFlags,
+  ]);
 
-  const filterToggles = (toggleList: Toggle[]) => {
-    if (!searchQuery) return toggleList;
+  const filterFeatureFlags = (flagList: FeatureFlag[]) => {
+    if (!searchQuery) return flagList;
     const query = searchQuery.toLowerCase();
-    return toggleList.filter(
+    return flagList.filter(
       t =>
         t.title.toLowerCase().includes(query) ||
         t.description.toLowerCase().includes(query) ||
@@ -189,18 +233,20 @@ const TogglesPage: FunctionComponent = () => {
     );
   };
 
-  const generalToggles = filterToggles(
-    toggles.filter(t => GENERAL_TOGGLE_IDS.includes(t.id))
+  const generalFeatureFlags = filterFeatureFlags(
+    featureFlags.filter(t => GENERAL_FEATURE_FLAG_IDS.includes(t.id))
   );
-  const restOfPermanentToggles = filterToggles(
-    toggles
+  const permanentFeatureFlags = filterFeatureFlags(
+    featureFlags
       .filter(t => t.type === 'permanent')
-      .filter(t => !GENERAL_TOGGLE_IDS.includes(t.id))
+      .filter(t => !GENERAL_FEATURE_FLAG_IDS.includes(t.id))
   );
-  const experimentalToggles = filterToggles(
-    toggles.filter(t => t.type === 'experimental')
+  const experimentalFeatureFlags = filterFeatureFlags(
+    featureFlags.filter(t => t.type === 'experimental')
   );
-  const stageToggles = filterToggles(toggles.filter(t => t.type === 'stage'));
+  const stageFeatureFlags = filterFeatureFlags(
+    featureFlags.filter(t => t.type === 'stage')
+  );
   const filteredAbTests: AbTest[] = searchQuery
     ? abTests.filter(
         t =>
@@ -211,10 +257,10 @@ const TogglesPage: FunctionComponent = () => {
     : abTests;
 
   const totalResults =
-    generalToggles.length +
-    restOfPermanentToggles.length +
-    experimentalToggles.length +
-    stageToggles.length +
+    generalFeatureFlags.length +
+    permanentFeatureFlags.length +
+    experimentalFeatureFlags.length +
+    stageFeatureFlags.length +
     filteredAbTests.length;
 
   return (
@@ -227,9 +273,10 @@ const TogglesPage: FunctionComponent = () => {
         <PageHeader>
           <PageTitle>Toggles</PageTitle>
           <PageDescription>
-            Manage and test feature flags and A/B tests; changes only affect
-            your own browser. Feature flags also have a public status which is
-            set for 100% of users, which is done through devs running a script.
+            Manage and test feature flags, A/B tests, and modes; changes only
+            affect your own browser. Feature flags also have a public status
+            which is set for 100% of users, which is done through devs running a
+            script.
           </PageDescription>
         </PageHeader>
 
@@ -244,6 +291,29 @@ const TogglesPage: FunctionComponent = () => {
               {message.text}
             </MessageBox>
           )}
+
+          <nav aria-label="Table of contents">
+            <TableOfContentsList>
+              <li>
+                <a href="#general">General</a>
+              </li>
+              <li>
+                <a href="#permanent">Permanent</a>
+              </li>
+              <li>
+                <a href="#wip">Work in progress</a>
+              </li>
+              <li>
+                <a href="#staging">Staging</a>
+              </li>
+              <li>
+                <a href="#ab-tests">A/B tests</a>
+              </li>
+              <li>
+                <a href="#modes">Modes</a>
+              </li>
+            </TableOfContentsList>
+          </nav>
 
           <SearchInput
             type="search"
@@ -264,33 +334,34 @@ const TogglesPage: FunctionComponent = () => {
           )}
 
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <ResetButton
-              onClick={() => {
-                reset();
-                setMessage({
-                  text: '🔄 All feature flags have been reset to their default values.',
-                  isError: false,
-                });
-              }}
-              aria-label="Reset all feature flags to default values"
-            >
-              Reset feature flags to defaults
-            </ResetButton>
+            {featureFlags.some(
+              flag => toggleStates[flag.id] !== flag.defaultValue
+            ) && (
+              <ResetButton
+                onClick={() => {
+                  reset();
+                  setMessage({
+                    text: '🔄 All feature flags have been reset to their default values.',
+                    isError: false,
+                  });
+                }}
+                aria-label="Reset all feature flags to default values"
+              >
+                Reset feature flags to defaults
+              </ResetButton>
+            )}
           </div>
         </main>
       </PageContainer>
 
-      {(generalToggles.length > 0 || !searchQuery) && (
+      {(generalFeatureFlags.length > 0 || !searchQuery) && (
         <Section $background="default" $hasNoTopPadding>
           <SectionInner>
-            <h2 id="general">
-              Feature flags for general use
-              <a href="#general" aria-label="Link to this section">
-                <span aria-hidden="true">#</span>
-              </a>
-            </h2>
             <ListOfToggles
-              toggles={generalToggles}
+              title="Feature flags for general use"
+              anchorId="general"
+              description="Permanent flags useful to all users."
+              featureFlags={generalFeatureFlags}
               toggleStates={toggleStates}
               setToggleStates={setToggleStates}
             />
@@ -298,17 +369,14 @@ const TogglesPage: FunctionComponent = () => {
         </Section>
       )}
 
-      {(restOfPermanentToggles.length > 0 || !searchQuery) && (
+      {(permanentFeatureFlags.length > 0 || !searchQuery) && (
         <Section $background="light">
           <SectionInner>
-            <h2 id="permanent">
-              Feature flags for Digital team - Permanent
-              <a href="#permanent" aria-label="Link to this section">
-                <span aria-hidden="true">#</span>
-              </a>
-            </h2>
             <ListOfToggles
-              toggles={restOfPermanentToggles}
+              title="Feature flags for Digital team - Permanent"
+              anchorId="permanent"
+              description="Long-lived flags that control established features."
+              featureFlags={permanentFeatureFlags}
               toggleStates={toggleStates}
               setToggleStates={setToggleStates}
             />
@@ -316,17 +384,14 @@ const TogglesPage: FunctionComponent = () => {
         </Section>
       )}
 
-      {(experimentalToggles.length > 0 || !searchQuery) && (
+      {(experimentalFeatureFlags.length > 0 || !searchQuery) && (
         <Section $background="alt">
           <SectionInner>
-            <h2 id="wip">
-              Feature flags for Digital team - Work in progress
-              <a href="#wip" aria-label="Link to this section">
-                <span aria-hidden="true">#</span>
-              </a>
-            </h2>
             <ListOfToggles
-              toggles={experimentalToggles}
+              title="Feature flags for Digital team - Work in progress"
+              anchorId="wip"
+              description="Experimental flags for features currently in development."
+              featureFlags={experimentalFeatureFlags}
               toggleStates={toggleStates}
               setToggleStates={setToggleStates}
             />
@@ -334,17 +399,14 @@ const TogglesPage: FunctionComponent = () => {
         </Section>
       )}
 
-      {(stageToggles.length > 0 || !searchQuery) && (
+      {(stageFeatureFlags.length > 0 || !searchQuery) && (
         <Section $background="light">
           <SectionInner>
-            <h2 id="staging">
-              Feature flags for Digital team - Staging
-              <a href="#staging" aria-label="Link to this section">
-                <span aria-hidden="true">#</span>
-              </a>
-            </h2>
             <ListOfToggles
-              toggles={stageToggles}
+              title="Feature flags for Digital team - Staging"
+              anchorId="staging"
+              description="These flags are only active on the staging environment (www-stage)."
+              featureFlags={stageFeatureFlags}
               toggleStates={toggleStates}
               setToggleStates={setToggleStates}
             />
@@ -360,6 +422,22 @@ const TogglesPage: FunctionComponent = () => {
               toggleStates={toggleStates}
               setToggleStates={setToggleStates}
               onReset={resetAbTests}
+            />
+          </SectionInner>
+        </Section>
+      )}
+
+      {(modes?.length > 0 || !searchQuery) && (
+        <Section $background="light">
+          <SectionInner>
+            <Modes
+              modes={modes}
+              modeStates={modeStates}
+              setModeStates={setModeStates}
+              onReset={() => {
+                modes.forEach(mode => deleteCookieCustom(mode.id));
+                setModeStates({});
+              }}
             />
           </SectionInner>
         </Section>

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -256,12 +256,25 @@ const TogglesPage: FunctionComponent = () => {
       )
     : abTests;
 
+  const filteredModes: ModeDefinition[] = searchQuery
+    ? modes.filter(m => {
+        const query = searchQuery.toLowerCase();
+        return (
+          m.title.toLowerCase().includes(query) ||
+          m.description.toLowerCase().includes(query) ||
+          m.id.toLowerCase().includes(query) ||
+          m.options.some(opt => opt.label.toLowerCase().includes(query))
+        );
+      })
+    : modes;
+
   const totalResults =
     generalFeatureFlags.length +
     permanentFeatureFlags.length +
     experimentalFeatureFlags.length +
     stageFeatureFlags.length +
-    filteredAbTests.length;
+    filteredAbTests.length +
+    filteredModes.length;
 
   return (
     <>
@@ -427,11 +440,11 @@ const TogglesPage: FunctionComponent = () => {
         </Section>
       )}
 
-      {(modes?.length > 0 || !searchQuery) && (
+      {(filteredModes.length > 0 || !searchQuery) && (
         <Section $background="light">
           <SectionInner>
             <Modes
-              modes={modes}
+              modes={filteredModes}
               modeStates={modeStates}
               setModeStates={setModeStates}
               onReset={() => {

--- a/dash/webapp/views/pages/toggles/toggles.ABTests.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.ABTests.tsx
@@ -66,14 +66,16 @@ const ABTests = ({
             #
           </a>
         </h2>
-        <ResetButton
-          onClick={onReset}
-          aria-label="Reset all A/B tests to random allocation"
-        >
-          Reset to random allocation
-        </ResetButton>
+        {filteredAbTests.some(test => toggleStates[test.id] !== undefined) && (
+          <ResetButton
+            onClick={onReset}
+            aria-label="Reset all A/B tests to random allocation"
+          >
+            Reset to random allocation
+          </ResetButton>
+        )}
       </div>
-      <p>
+      <p style={{ marginTop: 0, color: tokens.colors.text.secondary }}>
         You can opt in to a test, explicitly opt out, or be randomly allocated
         according to our A/B decision rules.
       </p>

--- a/dash/webapp/views/pages/toggles/toggles.Modes.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.Modes.tsx
@@ -1,0 +1,119 @@
+import { Dispatch, FunctionComponent, SetStateAction } from 'react';
+import styled from 'styled-components';
+
+import { tokens } from '@weco/dash/views/themes/tokens';
+import { ModeDefinition } from '@weco/toggles/toggles';
+
+import { deleteCookieCustom, setCookieCustom } from './toggles.helpers';
+import {
+  ResetButton,
+  ToggleControls,
+  ToggleInfo,
+  ToggleList,
+  ToggleListItem,
+  ToggleRow,
+} from './toggles.styles';
+
+const ModeSelect = styled.select`
+  padding: 6px;
+  max-width: 300px;
+`;
+
+type ModesProps = {
+  modes: ModeDefinition[];
+  modeStates: Record<string, string>;
+  setModeStates: Dispatch<SetStateAction<Record<string, string>>>;
+  onReset: () => void;
+};
+
+const Modes: FunctionComponent<ModesProps> = ({
+  modes,
+  modeStates,
+  setModeStates,
+  onReset,
+}) => (
+  <>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <h2 id="modes">
+        Modes
+        <a href="#modes" aria-label="Link to this section">
+          <span aria-hidden="true">#</span>
+        </a>
+      </h2>
+      {Object.keys(modeStates).length > 0 && (
+        <ResetButton onClick={onReset} aria-label="Reset all modes to off">
+          Reset all modes
+        </ResetButton>
+      )}
+    </div>
+    <p style={{ marginTop: 0, color: tokens.colors.text.secondary }}>
+      Modes carry structured data beyond a simple on/off, they might represent
+      different levels of a feature, or a choice between multiple options.
+    </p>
+    {modes.length > 0 ? (
+      <ToggleList>
+        {modes.map(mode => {
+          const currentValue = modeStates[mode.id];
+
+          return (
+            <ToggleListItem key={mode.id}>
+              <ToggleRow>
+                <ToggleInfo>
+                  <h3 style={{ margin: 0 }}>{mode.title}</h3>
+                  <p
+                    style={{
+                      margin: `${tokens.spacing.xs} 0`,
+                      color: tokens.colors.text.secondary,
+                    }}
+                  >
+                    {mode.description}
+                  </p>
+                </ToggleInfo>
+
+                <ToggleControls>
+                  <ModeSelect
+                    value={currentValue || ''}
+                    onChange={e => {
+                      const value = e.target.value;
+                      if (value) {
+                        setModeStates(prev => ({
+                          ...prev,
+                          [mode.id]: value,
+                        }));
+                        setCookieCustom(mode.id, value);
+                      } else {
+                        setModeStates(prev => {
+                          const next = { ...prev };
+                          delete next[mode.id];
+                          return next;
+                        });
+                        deleteCookieCustom(mode.id);
+                      }
+                    }}
+                  >
+                    <option value="">— Off —</option>
+                    {mode.options.map(opt => (
+                      <option key={opt.id} value={opt.id}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </ModeSelect>
+                </ToggleControls>
+              </ToggleRow>
+            </ToggleListItem>
+          );
+        })}
+      </ToggleList>
+    ) : (
+      <p>None for now, check back later…</p>
+    )}
+  </>
+);
+
+export default Modes;

--- a/dash/webapp/views/pages/toggles/toggles.Modes.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.Modes.tsx
@@ -59,13 +59,18 @@ const Modes: FunctionComponent<ModesProps> = ({
     {modes.length > 0 ? (
       <ToggleList>
         {modes.map(mode => {
-          const currentValue = modeStates[mode.id];
+          const rawValue = modeStates[mode.id];
+          const currentValue = mode.options.some(opt => opt.id === rawValue)
+            ? rawValue
+            : '';
 
           return (
             <ToggleListItem key={mode.id}>
               <ToggleRow>
                 <ToggleInfo>
-                  <h3 style={{ margin: 0 }}>{mode.title}</h3>
+                  <h3 id={`mode-${mode.id}`} style={{ margin: 0 }}>
+                    {mode.title}
+                  </h3>
                   <p
                     style={{
                       margin: `${tokens.spacing.xs} 0`,
@@ -78,7 +83,8 @@ const Modes: FunctionComponent<ModesProps> = ({
 
                 <ToggleControls>
                   <ModeSelect
-                    value={currentValue || ''}
+                    aria-labelledby={`mode-${mode.id}`}
+                    value={currentValue}
                     onChange={e => {
                       const value = e.target.value;
                       if (value) {

--- a/dash/webapp/views/pages/toggles/toggles.Modes.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.Modes.tsx
@@ -2,7 +2,7 @@ import { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import styled from 'styled-components';
 
 import { tokens } from '@weco/dash/views/themes/tokens';
-import { ModeDefinition } from '@weco/toggles/toggles';
+import { ModeDefinition } from '@weco/toggles';
 
 import { deleteCookieCustom, setCookieCustom } from './toggles.helpers';
 import {

--- a/dash/webapp/views/pages/toggles/toggles.helpers.ts
+++ b/dash/webapp/views/pages/toggles/toggles.helpers.ts
@@ -1,6 +1,6 @@
 import { deleteCookie, setCookie } from 'cookies-next';
 
-export type Toggle = {
+export type FeatureFlag = {
   id: string;
   title: string;
   defaultValue: boolean;
@@ -11,7 +11,7 @@ export type Toggle = {
 
 export type ToggleStates = { [id: string]: boolean | undefined };
 
-export const setCookieCustom = (key: string, value: 'true' | 'false') => {
+export const setCookieCustom = (key: string, value: string) => {
   const nowPlusOneYear = new Date();
   nowPlusOneYear.setFullYear(nowPlusOneYear.getFullYear() + 1);
 

--- a/dash/webapp/views/pages/toggles/toggles.styles.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.styles.tsx
@@ -2,6 +2,15 @@ import styled from 'styled-components';
 
 import { tokens } from '@weco/dash/views/themes/tokens';
 
+export const TableOfContentsList = styled.ul`
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+
 export const ResetButton = styled.button`
   border: 2px solid ${tokens.colors.error.main};
   background-color: ${tokens.colors.error.light};

--- a/dash/webapp/views/pages/toggles/toggles.styles.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.styles.tsx
@@ -4,9 +4,10 @@ import { tokens } from '@weco/dash/views/themes/tokens';
 
 export const TableOfContentsList = styled.ul`
   list-style: none;
+  margin: 0 0 ${tokens.spacing.lg} 0;
   padding: 0;
   display: flex;
-  gap: 16px;
+  gap: ${tokens.spacing.md};
   flex-wrap: wrap;
   justify-content: center;
 `;

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -48,6 +48,20 @@ export const withDefaultValuesUnmodified = (
 };
 
 export async function deploy(client: S3Client): Promise<void> {
+  // Check for duplicate IDs across feature flags, tests, and modes
+  const allIds = [
+    ...localToggles.featureFlags.map(f => f.id),
+    ...localToggles.tests.map(t => t.id),
+    ...localToggles.modes.map(m => m.id),
+  ];
+  const duplicates = allIds.filter((id, index) => allIds.indexOf(id) !== index);
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Duplicate toggle IDs found across feature flags, tests, and modes: ${duplicates.join(', ')}. ` +
+        `All IDs must be unique because they share the toggle_ cookie prefix.`
+    );
+  }
+
   const remoteToggles = await getTogglesObject(client);
 
   // Backward compat: S3 may still have the old shape ({ toggles: [...] })
@@ -68,6 +82,9 @@ export async function deploy(client: S3Client): Promise<void> {
   const toggles: TogglesResp = {
     featureFlags: featureFlagsToDeploy,
     tests: localToggles.tests,
+    // Spread to convert from readonly (due to `as const` in the config, which
+    // gives us literal ModeId types) to a mutable array for the response type.
+    modes: [...localToggles.modes],
   };
 
   // GA4 now limits event parameter values to 100 characters: https://support.google.com/analytics/answer/9267744?hl=en

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -1,7 +1,15 @@
-import toggleConfig, { ABTest, PublishedFeatureFlag } from './toggles';
+import toggleConfig, {
+  ABTest,
+  ModeDefinition,
+  ModeOption,
+  PublishedFeatureFlag,
+} from './toggles';
+
+export type { ABTest, ModeDefinition, ModeOption, PublishedFeatureFlag };
 
 export type FeatureFlagId = (typeof toggleConfig.featureFlags)[number]['id'];
 export type TestId = (typeof toggleConfig.tests)[number]['id'];
+export type ModeId = (typeof toggleConfig.modes)[number]['id'];
 // Backward compatibility alias
 export type ToggleId = FeatureFlagId;
 
@@ -10,6 +18,9 @@ export type ToggleId = FeatureFlagId;
 export type TogglesResp = {
   featureFlags: PublishedFeatureFlag[];
   tests: ABTest[];
+  // Optional because the S3 JSON won't include modes until the first deploy
+  // that includes them. Can be made required once modes are live.
+  modes?: ModeDefinition[];
 };
 
 // Don't be tempted to make the keys on this optional - keeping them
@@ -17,7 +28,12 @@ export type TogglesResp = {
 export type FeatureFlags = Record<FeatureFlagId, boolean | undefined>;
 export type Tests = Record<TestId, boolean | undefined>;
 
+/** A mode value is the selected option string, or undefined if inactive */
+export type ModeValue = string | undefined;
+export type Modes = Record<ModeId, ModeValue>;
+
 export type Toggles = {
   featureFlags: FeatureFlags;
   tests: Tests;
+  modes: Modes;
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -27,6 +27,18 @@ export type ABTest = {
   range: [number, number];
 };
 
+export type ModeOption = {
+  id: string;
+  label: string;
+};
+
+export type ModeDefinition = {
+  id: string;
+  title: string;
+  description: string;
+  options: readonly ModeOption[];
+};
+
 const toggleConfig = {
   // Feature flags (permanent toggles, experiments, stage toggles)
   // Toggles of type 'stage' will only be applied on stage
@@ -168,6 +180,23 @@ const toggleConfig = {
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth
   tests: [] as ABTest[],
+  // Modes are toggles whose value is a selected option string rather than a boolean.
+  // They are activated via a cookie containing the option value.
+  modes: [
+    {
+      id: 'kioskMode',
+      title: 'Kiosk mode',
+      description:
+        'Select which kiosk device this browser represents and it will activate kiosk-specific behaviour and layout.',
+      options: [
+        { id: 'RR-iPad1', label: 'Reading Room: iPad 1' },
+        { id: 'RR-iPad2', label: 'Reading Room: iPad 2' },
+        { id: 'RR-iPad3', label: 'Reading Room: iPad 3' },
+        { id: 'TR-iPad1', label: 'Tenderness & Rage: iPad 1' },
+        { id: 'TR-iPad2', label: 'Tenderness & Rage: iPad 2' },
+      ],
+    },
+  ] as const,
 };
 
 export default toggleConfig;


### PR DESCRIPTION
- For #13088 

## What does this change?

Adds a new toggle type called "modes" — these are toggles whose value is a selected option (string) rather than a simple boolean. The first mode is `kioskMode`, which identifies which iPad device a browser represents (e.g. "Reading Room iPad 1").

This implements [RFC 087](https://github.com/wellcomecollection/docs/blob/main/rfcs/087-kiosk-mode/README.md) option 3 ("cookie that's not a classic toggle"), but keeps the cookie value as a plain string rather than a JSON object. I felt that for now, we didn't really need anything more complex; a plain string is simpler to debug, works cleanly with the existing `setCookieCustom` infrastructure, and carries the same information since the only data needed right now is the device ID. If we later need multiple fields in a single mode, migrating to a JSON value would be straightforward. It means we're not overcomplicating things if we don't need to whilst still marking modes as having a different purpose to feature flags; other opinions/points v welcome!

Changes:
- New `ModeDefinition` and `ModeOption` types in `@weco/toggles`
- Mode definitions in `toggles/webapp/toggles.ts` with `kioskMode` as the first entry
- Server-side parsing of mode cookies in `common/server-data/toggles.ts`
- `useModes()` hook via context for consuming mode values in app code
- New "Modes" section in the dash with select dropdowns and a reset button
- Runtime duplicate ID check in `deploy.ts` (feature flags, tests, and modes share the `toggle_` cookie prefix, so IDs must be unique across all three)
- Dash UI improvements: table of contents, section descriptions, consistent styling

## How to test

1. In `dash/webapp/views/pages/toggles/index.tsx`, uncomment the hardcoded mode fallback (around line 60 — swap the active `const modeDefinitions` line for the commented-out block below it)
2. Build the dash: `cd dash/webapp && yarn build && yarn dev`
3. Open the toggles page — you should see a "Modes" section with "Kiosk mode"
4. Select an option from the dropdown — check `document.cookie` includes `toggle_kioskMode=RR-iPad1` (or whichever option)
5. Click "Reset all modes" — cookie should be removed
6. Run `yarn tsc --noEmit` from root — no errors

## Have we considered potential risks?

- Cookie name collision between modes and feature flags: mitigated by a runtime check in `deploy.ts` that throws if any ID is duplicated across categories.
- The `modes` field in the S3 JSON is optional, so existing deployments won't break. Once it's been added, we can default it to an empty array instead and make it required.
- The hardcoded fallback in dash is temporary and clearly marked with a TODO.
