### PR TITLE
Move positionInList onto data-component

### DIFF
--- a/common/views/components/PortraitVideoEmbed/index.tsx
+++ b/common/views/components/PortraitVideoEmbed/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   duration?: string;
   title?: string;
   onOpen: () => void;
+  positionInList?: number;
 };
 
 const CardButton = styled.button`
@@ -94,8 +95,12 @@ const PortraitVideoEmbed: FunctionComponent<Props> = ({
   duration,
   title,
   onOpen,
+  positionInList,
 }) => (
-  <div data-component="portrait-video-embed">
+  <div
+    data-component="portrait-video-embed"
+    data-gtm-position-in-list={positionInList}
+  >
     <CardButton type="button" onClick={onOpen}>
       <span style={{ display: 'block' }}>
         <PosterContainer>

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -126,17 +126,13 @@ const PortraitVideoList: FunctionComponent<Props> = ({
         }
       >
         {items.map((item, i) => (
-          <ListItem
-            key={item.title}
-            $usesShim={useShim}
-            $cols={3}
-            data-gtm-position-in-list={i + 1}
-          >
+          <ListItem key={item.title} $usesShim={useShim} $cols={3}>
             <PortraitVideoEmbed
               posterImage={item.posterImage}
               duration={item.duration}
               title={item.title}
               onOpen={() => openAt(i)}
+              positionInList={i + 1}
             />
           </ListItem>
         ))}


### PR DESCRIPTION
- For #13084 

## What does this change?

The `data-gtm-position-in-list` attribute was on the parent of the element that will be used as the GTM trigger for tracking (`data-component="portrait-video-embed"`) which would have made it hard to extract its value. Moving it to the `data-component` element makes it straightforward.

<img width="522" height="68" alt="image" src="https://github.com/user-attachments/assets/361ca069-3940-4950-9950-637a53d95539" />


## How to test

- Visit Tenderness and Rage with the [vertical videos](https://dash.wellcomecollection.org/toggles/?enableToggle=verticalVideos) and [exhibition pages and collections content](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection) toggles on
- Check the `data-gtm-position-in-list` attributes are on the `data-component="portrait-video-embed"` elements

## Have we considered potential risks?

n/a
