### PR TITLE
Render stories kiosk if Feature flag OR Mode is active

### DIFF
--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -56,12 +56,18 @@ const stageOnlyFlag = {
   type: 'stage' as const,
 };
 
+const defaultTogglesResp: TogglesResp = {
+  featureFlags: [],
+  tests: [],
+  modes: [],
+};
+
 describe('getTogglesFromContext', () => {
   describe('featureFlags', () => {
     it('returns defaultValue when no cookie is set', () => {
       const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
         featureFlags: [stagingApiFlag, thematicBrowsingFlag],
-        tests: [],
       };
 
       const result = getTogglesFromContext(togglesResp, createContext());
@@ -72,8 +78,8 @@ describe('getTogglesFromContext', () => {
 
     it('returns true when cookie is "true"', () => {
       const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
         featureFlags: [stagingApiFlag],
-        tests: [],
       };
 
       const result = getTogglesFromContext(
@@ -86,8 +92,8 @@ describe('getTogglesFromContext', () => {
 
     it('returns defaultValue when cookie is "false" (not false)', () => {
       const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
         featureFlags: [stagingApiFlag],
-        tests: [],
       };
 
       const result = getTogglesFromContext(
@@ -101,8 +107,8 @@ describe('getTogglesFromContext', () => {
 
     it('returns defaultValue when cookie is any non-"true" string', () => {
       const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
         featureFlags: [thematicBrowsingFlag],
-        tests: [],
       };
 
       const result = getTogglesFromContext(
@@ -115,8 +121,8 @@ describe('getTogglesFromContext', () => {
 
     it('excludes stage-only flags on non-stage hosts', () => {
       const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
         featureFlags: [stageOnlyFlag],
-        tests: [],
       };
 
       const result = getTogglesFromContext(
@@ -130,8 +136,8 @@ describe('getTogglesFromContext', () => {
 
     it('includes stage-only flags on stage hosts', () => {
       const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
         featureFlags: [stageOnlyFlag],
-        tests: [],
       };
 
       const result = getTogglesFromContext(
@@ -151,7 +157,7 @@ describe('getTogglesFromContext', () => {
     // the result to access arbitrary keys
     it('returns true when cookie is "true"', () => {
       const togglesResp = {
-        featureFlags: [],
+        ...defaultTogglesResp,
         tests: [
           { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
         ],
@@ -167,7 +173,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns false when cookie is "false"', () => {
       const togglesResp = {
-        featureFlags: [],
+        ...defaultTogglesResp,
         tests: [
           { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
         ],
@@ -183,7 +189,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns undefined when no cookie is set', () => {
       const togglesResp = {
-        featureFlags: [],
+        ...defaultTogglesResp,
         tests: [
           { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
         ],
@@ -198,7 +204,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns undefined when cookie is any non-boolean string', () => {
       const togglesResp = {
-        featureFlags: [],
+        ...defaultTogglesResp,
         tests: [
           { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
         ],
@@ -228,8 +234,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns undefined when no cookie is set', () => {
       const togglesResp = {
-        featureFlags: [],
-        tests: [],
+        ...defaultTogglesResp,
         modes: [modeDefinition],
       } as unknown as TogglesResp;
 
@@ -242,8 +247,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns the value when cookie matches a valid option', () => {
       const togglesResp = {
-        featureFlags: [],
-        tests: [],
+        ...defaultTogglesResp,
         modes: [modeDefinition],
       } as unknown as TogglesResp;
 
@@ -259,8 +263,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns undefined when cookie is an empty string', () => {
       const togglesResp = {
-        featureFlags: [],
-        tests: [],
+        ...defaultTogglesResp,
         modes: [modeDefinition],
       } as unknown as TogglesResp;
 
@@ -276,8 +279,7 @@ describe('getTogglesFromContext', () => {
 
     it('returns undefined when cookie value is not a valid option', () => {
       const togglesResp = {
-        featureFlags: [],
-        tests: [],
+        ...defaultTogglesResp,
         modes: [modeDefinition],
       } as unknown as TogglesResp;
 

--- a/common/services/app/analytics-scripts/google-analytics.tsx
+++ b/common/services/app/analytics-scripts/google-analytics.tsx
@@ -43,7 +43,7 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
   consentStatus,
 }) => {
   const abTestsToggleString = createABToggleString(data.toggles?.tests);
-  const device = getKioskDevice(data.toggles?.modes);
+  const kioskDevice = getKioskDevice(data.toggles?.modes);
 
   return (
     <script
@@ -77,9 +77,9 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
             }
 
             ${
-              device &&
+              kioskDevice &&
               `window.dataLayer.push({
-                device: '${device}'
+                device: '${kioskDevice}'
               });`
             }
           `,

--- a/common/services/app/analytics-scripts/google-analytics.tsx
+++ b/common/services/app/analytics-scripts/google-analytics.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { ConsentStatusProps } from '@weco/common/server-data/types';
-import { Tests, Toggles } from '@weco/toggles';
+import { Modes, Tests, Toggles } from '@weco/toggles';
 
 // Don't use the next/script `Script` component for these as in
 // Next.js v11 it does not work when inside a `Head` component
@@ -33,11 +33,17 @@ function createABToggleString(tests?: Tests): string | null {
   return entries.length > 0 ? entries.join(',') : null;
 }
 
+function getDevice(modes?: Modes): string | null {
+  if (!modes) return null;
+  return modes.kioskMode ?? null;
+}
+
 export const Ga4DataLayer: FunctionComponent<Props> = ({
   data,
   consentStatus,
 }) => {
   const abTestsToggleString = createABToggleString(data.toggles?.tests);
+  const device = getDevice(data.toggles?.modes);
 
   return (
     <script
@@ -67,6 +73,13 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
               abTestsToggleString &&
               `window.dataLayer.push({
                 toggles: '${abTestsToggleString}'
+              });`
+            }
+
+            ${
+              device &&
+              `window.dataLayer.push({
+                device: '${device}'
               });`
             }
           `,

--- a/common/services/app/analytics-scripts/google-analytics.tsx
+++ b/common/services/app/analytics-scripts/google-analytics.tsx
@@ -72,14 +72,14 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
             ${
               abTestsToggleString &&
               `window.dataLayer.push({
-                toggles: '${abTestsToggleString}'
+                toggles: ${JSON.stringify(abTestsToggleString)}
               });`
             }
 
             ${
               kioskDevice &&
               `window.dataLayer.push({
-                device: '${kioskDevice}'
+                device: ${JSON.stringify(kioskDevice)}
               });`
             }
           `,

--- a/common/services/app/analytics-scripts/google-analytics.tsx
+++ b/common/services/app/analytics-scripts/google-analytics.tsx
@@ -33,7 +33,7 @@ function createABToggleString(tests?: Tests): string | null {
   return entries.length > 0 ? entries.join(',') : null;
 }
 
-function getDevice(modes?: Modes): string | null {
+function getKioskDevice(modes?: Modes): string | null {
   if (!modes) return null;
   return modes.kioskMode ?? null;
 }
@@ -43,7 +43,7 @@ export const Ga4DataLayer: FunctionComponent<Props> = ({
   consentStatus,
 }) => {
   const abTestsToggleString = createABToggleString(data.toggles?.tests);
-  const device = getDevice(data.toggles?.modes);
+  const device = getKioskDevice(data.toggles?.modes);
 
   return (
     <script

--- a/content/webapp/pages/api/works/[workId].tsx
+++ b/content/webapp/pages/api/works/[workId].tsx
@@ -29,6 +29,7 @@ const WorksApi = async (
       },
     ],
     tests: [],
+    modes: [],
   };
   const { featureFlags } = getTogglesFromContext(togglesResp, { req });
 

--- a/content/webapp/pages/api/works/items/[workId].tsx
+++ b/content/webapp/pages/api/works/items/[workId].tsx
@@ -70,6 +70,7 @@ const ItemsApi = async (
       },
     ],
     tests: [],
+    modes: [],
   };
   const { featureFlags } = getTogglesFromContext(togglesResp, { req });
   const { workId } = req.query;

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -8,7 +8,7 @@ import {
   WebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
-import { useFeatureFlags } from '@weco/common/server-data/Context';
+import { useFeatureFlags, useModes } from '@weco/common/server-data/Context';
 import { appError } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -42,10 +42,12 @@ import ArticleSeriesPage, {
 
 const Page: NextPage<ArticleSeriesPageProps> = props => {
   const { storiesKiosk } = useFeatureFlags();
+  const { kioskMode } = useModes();
+  const isKiosk = !!storiesKiosk || !!kioskMode;
 
   return (
-    <KioskProvider isActive={!!storiesKiosk}>
-      {storiesKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
+    <KioskProvider isActive={isKiosk}>
+      {isKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
       <ArticleSeriesPage {...props} />
     </KioskProvider>
   );

--- a/content/webapp/pages/stories/[articleId].tsx
+++ b/content/webapp/pages/stories/[articleId].tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 
 import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
-import { useFeatureFlags } from '@weco/common/server-data/Context';
+import { useFeatureFlags, useModes } from '@weco/common/server-data/Context';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -22,10 +22,12 @@ import ArticlePage, {
 
 const Page: NextPage<ArticlePageProps> = props => {
   const { storiesKiosk } = useFeatureFlags();
+  const { kioskMode } = useModes();
+  const isKiosk = !!storiesKiosk || !!kioskMode;
 
   return (
-    <KioskProvider isActive={!!storiesKiosk}>
-      {storiesKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
+    <KioskProvider isActive={isKiosk}>
+      {isKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
       <ArticlePage {...props} />
     </KioskProvider>
   );

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -32,7 +32,10 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.featureFlags.storiesKiosk) {
+  if (
+    !serverData.toggles.featureFlags.storiesKiosk &&
+    !serverData.toggles.modes.kioskMode
+  ) {
     return { notFound: true };
   }
 

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -16,9 +16,7 @@ export type ModeId = (typeof toggleConfig.modes)[number]['id'];
 export type TogglesResp = {
   featureFlags: PublishedFeatureFlag[];
   tests: ABTest[];
-  // Optional because the S3 JSON won't include modes until the first deploy
-  // that includes them. Can be made required once modes are live.
-  modes?: ModeDefinition[];
+  modes: ModeDefinition[];
 };
 
 // Don't be tempted to make the keys on this optional - keeping them

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -26,6 +26,7 @@ export async function setDefaultValueFor(client: S3Client): Promise<void> {
   const toggles = {
     featureFlags,
     tests: remoteToggles.tests ?? [],
+    modes: remoteToggles.modes ?? [],
   };
 
   const { $metadata: putObjectResponseMetadata } = await putTogglesObject(


### PR DESCRIPTION
- For #13088 and #13078

Child PR of https://github.com/wellcomecollection/wellcomecollection.org/pull/13094

## What does this change?

- Checks either the feature flag (`storiesKiosk`) or the mode (`kioskMode`) to determine whether or not to show the page. The goal being to then remove `storiesKiosk` and just use the mode.
- I also added a dataLayer variable with said mode value, which has to be valid = part of the list we've established.
- Removed the optional property for Modes, it was there because it had never been deployed to S3 before but now it should [always be there](https://toggles.wellcomecollection.org/toggles.json), even if empty. Looks like it was missing from a few other places so added it.

## How to test

https://www-dev.wellcomecollection.org/stories/kiosk should be available if either the [Stories kiosk toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=storiesKiosk) is activated, or we have [selected a Mode](https://dash.wellcomecollection.org/toggles/#modes) for it. Without either, it shouldn't be available.

Then check in Google Tag Manager if the new prop is available in the data layer should a Mode have been selected.
<img width="896" height="371" alt="Screenshot 2026-05-26 at 12 12 16" src="https://github.com/user-attachments/assets/e7c9d632-e30a-4844-9ddf-3965f1caa399" />


## Have we considered potential risks?
N/A