### PR TITLE
Add positionInList regardless of card type

### DIFF
--- a/content/webapp/views/components/Card/index.tsx
+++ b/content/webapp/views/components/Card/index.tsx
@@ -16,6 +16,7 @@ export const CardImageWrapper = styled.div`
 
 type Props = {
   item: CardType;
+  positionInList?: number;
 };
 
 const sharedCardOuter = css`
@@ -171,11 +172,15 @@ export const CardTitle = styled(Space).attrs({
   transition: color 400ms ease;
 `;
 
-const Card: FunctionComponent<Props> = ({ item }: Props) => {
+const Card: FunctionComponent<Props> = ({ item, positionInList }: Props) => {
   const image = getCrop(item.image, '16:9');
 
   return (
-    <CardOuter data-component="card" href={item.link}>
+    <CardOuter
+      data-component="card"
+      data-gtm-position-in-list={positionInList}
+      href={item.link}
+    >
       <CardImageWrapper>
         {image && (
           <PrismicImage

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -83,7 +83,10 @@ const ExhibitionCollectionsContent = ({
                       />
                     )}
                     {item.type === 'series' && (
-                      <Card item={convertItemToCardProps(item)} />
+                      <Card
+                        item={convertItemToCardProps(item)}
+                        positionInList={index + 1}
+                      />
                     )}
                   </Space>
                 </GridCell>


### PR DESCRIPTION
- For #13084 

## What does this change?

Adds `data-gtm-position-in-list` to `Card`s (it is only currently being added to `StoryCard`s)

## How to test

- Turn on [Prismic stage](https://dash.wellcomecollection.org/toggles/?enableToggle=prismicStage) and [Exhibition pages and collections content](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection)
- Visit [Tenderness and Rage](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage) 
- Check all three of the anchor elements that render these 'related stories' cards have `data-gtm-trigger="card_link"` and the correct `data-gtm-position-in-list` (1, 2, 3)

<img width="1040" height="547" alt="image" src="https://github.com/user-attachments/assets/2828df00-2096-4c7e-a34e-58739432f444" />


## Have we considered potential risks?

n/a