### PR TITLE
Add data-gtm-label=title to potrait videos

### DIFF
--- a/common/views/components/PortraitVideoEmbed/index.tsx
+++ b/common/views/components/PortraitVideoEmbed/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { play } from '@weco/common/icons';
 import { ImageType } from '@weco/common/model/image';
 import { font } from '@weco/common/utils/classnames';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -100,6 +101,10 @@ const PortraitVideoEmbed: FunctionComponent<Props> = ({
   <div
     data-component="portrait-video-embed"
     data-gtm-position-in-list={positionInList}
+    {...dataGtmPropsToAttributes({
+      'position-in-list': `${positionInList}`,
+      label: title,
+    })}
   >
     <CardButton type="button" onClick={onOpen}>
       <span style={{ display: 'block' }}>

--- a/common/views/components/PortraitVideoEmbed/index.tsx
+++ b/common/views/components/PortraitVideoEmbed/index.tsx
@@ -100,7 +100,6 @@ const PortraitVideoEmbed: FunctionComponent<Props> = ({
 }) => (
   <div
     data-component="portrait-video-embed"
-    data-gtm-position-in-list={positionInList}
     {...dataGtmPropsToAttributes({
       'position-in-list': `${positionInList}`,
       label: title,

--- a/common/views/components/PortraitVideoEmbed/index.tsx
+++ b/common/views/components/PortraitVideoEmbed/index.tsx
@@ -101,8 +101,10 @@ const PortraitVideoEmbed: FunctionComponent<Props> = ({
   <div
     data-component="portrait-video-embed"
     {...dataGtmPropsToAttributes({
-      'position-in-list': `${positionInList}`,
-      label: title,
+      ...(positionInList !== undefined && {
+        'position-in-list': `${positionInList}`,
+      }),
+      ...(title !== undefined && { label: title }),
     })}
   >
     <CardButton type="button" onClick={onOpen}>


### PR DESCRIPTION
- For #13084 

## What does this change?

Adds the potrait video's title as a `data-gtm-label` on the `data-component="potrait-video-embed"` element to simplify tracking that piece of information.


## How to test

- Visit Tenderness and Rage with [Exhibition pages and collection content](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection) toggle, and [vertical video](https://dash.wellcomecollection.org/toggles/?enableToggle=verticalVideos) toggle
- Check the portrait video embeds have a `data-gtm-label` attribute containing the title of the video

<img width="306" height="71" alt="image" src="https://github.com/user-attachments/assets/51153189-988e-41f3-8cd2-d58b7af9e086" />


## Have we considered potential risks?

n/a
