### PR TITLE
Spacing amendments in Tenderness and Rage

### DIFF
--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
@@ -184,3 +184,9 @@ export const ScrollShim = styled.li.attrs({
       );
   `)}
 `;
+
+export const CopyContainer = styled.div`
+  > *:last-child {
+    margin-bottom: 0;
+  }
+`;

--- a/content/webapp/views/components/ScrollContainer/index.tsx
+++ b/content/webapp/views/components/ScrollContainer/index.tsx
@@ -14,6 +14,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import ScrollableNavigation from './ScrollContainer.Navigation';
 import {
   ContentContainer,
+  CopyContainer,
   ScrollButtonsContainer,
   ScrollShim,
 } from './ScrollContainer.styles';
@@ -55,7 +56,7 @@ const ScrollContainer: FunctionComponent<Props> = ({
           </ContaineredLayout>
         )}
       >
-        <div>{CopyContent}</div>
+        <CopyContainer>{CopyContent}</CopyContainer>
       </ConditionalWrapper>
     );
   };

--- a/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
+++ b/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
@@ -12,12 +12,10 @@ export const Title = styled.h2.attrs<{
   as: props.$headingLevel === 2 ? 'h2' : 'h3',
 }))<{ $hasDescriptionSibling: boolean }>`
   ${props =>
-    props.$hasDescriptionSibling
-      ? props.theme.makeSpacePropertyValues('xs', ['margin-bottom'])
-      : 'margin-bottom: 0'};
+    props.$hasDescriptionSibling &&
+    props.theme.makeSpacePropertyValues('xs', ['margin-bottom'])};
 `;
 
 export const Description = styled.p`
   color: ${props => props.theme.color('black')};
-  margin-bottom: 0;
 `;

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -25,6 +25,10 @@ export const Wrapper = styled(Space).attrs({
   background: ${props => props.theme.color('warmNeutral.300')};
 `;
 
+const SectionHeaderWrapper = styled.div`
+  margin-bottom: ${props => props.theme.spacingUnits['100']};
+`;
+
 const ExhibitionCollectionsContent = ({
   isTendernessAndRageExhibition,
   themeCardsListSlice,
@@ -56,7 +60,9 @@ const ExhibitionCollectionsContent = ({
   return (
     <Wrapper>
       <Container>
-        <SectionHeader title="Further reading" />
+        <SectionHeaderWrapper>
+          <SectionHeader title="Further reading" />
+        </SectionHeaderWrapper>
         <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
           <p>
             Explore the subjects and stories inspired by the topics in the
@@ -109,6 +115,7 @@ const ExhibitionCollectionsContent = ({
           />
         </Space>
       )}
+
       {verticalVideos && videos?.length > 0 && (
         <SliceZone
           slices={videos}


### PR DESCRIPTION
- For #13079 

## What does this change?

Based on QA comments for the Stories and Themes part of the T&R QA, it's just a couple spacing tweaks. 

I thought the last element of the "Copy" element of ScrollableContainer should always have a `margin-bottom: 0` to ensure bottom alignment, so did the change at that level.

## How to test

[Toggle Prismic stage](https://dash.wellcomecollection.org/toggles/?enableToggle=prismicStage)
[Toggle Exhibition content](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection)

Look at QA comments and compare https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage
Browse around and look at other carousel's bottom alignment of Copy and Arrows

Also here's a change in Cardigan: https://www.chromatic.com/test?appId=62f13cdbd0ff140768a8d87b&id=6a1576a77cf460564b2f711e
This is an expected change as it should've been bottom aligned to start.


## Have we considered potential risks?
N/A