### PR TITLE
Add icons to WorkCards if they don't have an image

### DIFF
--- a/cardigan/.storybook/main.js
+++ b/cardigan/.storybook/main.js
@@ -12,7 +12,7 @@ function getAbsolutePath(value) {
 const monorepoRoot = resolve(__dirname, '../..');
 
 const config = {
-  staticDirs: ['../public'],
+  staticDirs: ['../public', '../../content/webapp/public'],
   stories: [
     '../stories/global/**/*.mdx',
     '../stories/global/**/*.stories.tsx',

--- a/cardigan/stories/components/Cards/WorkCards/WorksCards.stories.tsx
+++ b/cardigan/stories/components/Cards/WorkCards/WorksCards.stories.tsx
@@ -8,25 +8,25 @@ import WorkCards from '@weco/content/views/components/WorkCards';
 faker.seed(123);
 
 const formatOptions = [
-  'Books',
-  'E-books',
-  'Journals',
-  'E-journals',
-  'Student dissertations',
-  'Archives and manuscripts',
-  'Manuscripts',
-  'Born digital archives',
-  'Pictures',
-  'Digital images',
-  'Maps',
-  'Audio',
-  'Video',
-  'Music',
-  'Film',
-  'CD-Roms',
-  'Ephemera',
-  '3-D objects',
-  'Mixed materials',
+  { label: 'Books', id: 'a' },
+  { label: 'E-books', id: 'a' },
+  { label: 'Journals', id: 'd' },
+  { label: 'E-journals', id: 'd' },
+  { label: 'Student dissertations', id: 'w' },
+  { label: 'Archives and manuscripts', id: 'h' },
+  { label: 'Manuscripts', id: 'b' },
+  { label: 'Born digital archives', id: 'hdig' },
+  { label: 'Pictures', id: 'k' },
+  { label: 'Digital images', id: 'q' },
+  { label: 'Maps', id: 'q' },
+  { label: 'Audio', id: 'i' },
+  { label: 'Video', id: 'g' },
+  { label: 'Music', id: 'c' },
+  { label: 'Film', id: 'n' },
+  { label: 'CD-Roms', id: 'm' },
+  { label: 'Ephemera', id: 'l' },
+  { label: '3-D objects', id: 'r' },
+  { label: 'Mixed materials', id: 'p' },
 ];
 
 // Extend the story type
@@ -60,7 +60,7 @@ const meta: Meta<StoryProps> = {
     format: {
       name: 'Work format',
       control: 'select',
-      options: formatOptions,
+      options: formatOptions.map(option => option.label),
       description: 'Work format (visible when hasImage is false)',
     },
     columns: {
@@ -69,10 +69,15 @@ const meta: Meta<StoryProps> = {
   },
   render: args => {
     const { numberOfCards, hasImage, format } = args;
+    const selectedFormat = formatOptions.find(
+      option => option.label === format
+    );
+
     args.works = Array.from({ length: numberOfCards }).map(() => ({
       ...workBasic,
       title: faker.lorem.lines(),
       thumbnail: hasImage ? workBasic.thumbnail : undefined,
+      workTypeId: selectedFormat?.id,
       cardLabels: format
         ? [{ text: format }, { text: 'Online', labelColor: 'white' }]
         : workBasic.cardLabels,

--- a/cardigan/stories/components/Cards/WorkCards/WorksCards.stories.tsx
+++ b/cardigan/stories/components/Cards/WorkCards/WorksCards.stories.tsx
@@ -7,10 +7,33 @@ import WorkCards from '@weco/content/views/components/WorkCards';
 
 faker.seed(123);
 
+const formatOptions = [
+  'Books',
+  'E-books',
+  'Journals',
+  'E-journals',
+  'Student dissertations',
+  'Archives and manuscripts',
+  'Manuscripts',
+  'Born digital archives',
+  'Pictures',
+  'Digital images',
+  'Maps',
+  'Audio',
+  'Video',
+  'Music',
+  'Film',
+  'CD-Roms',
+  'Ephemera',
+  '3-D objects',
+  'Mixed materials',
+];
+
 // Extend the story type
 type StoryProps = ComponentProps<typeof WorkCards> & {
   numberOfCards: number;
   hasImage?: boolean;
+  format?: string;
 };
 
 const meta: Meta<StoryProps> = {
@@ -20,23 +43,39 @@ const meta: Meta<StoryProps> = {
     works: [workBasic],
     numberOfCards: 1,
     hasImage: true,
+    format: 'Books',
+    columns: 4,
   },
   argTypes: {
     works: { table: { disable: true } },
     numberOfCards: {
+      name: 'Number of cards',
       control: {
         type: 'range',
         min: 1,
         max: 10,
       },
     },
+    hasImage: { name: 'Has image', control: 'boolean' },
+    format: {
+      name: 'Work format',
+      control: 'select',
+      options: formatOptions,
+      description: 'Work format (visible when hasImage is false)',
+    },
+    columns: {
+      name: 'Columns',
+    },
   },
   render: args => {
-    const { numberOfCards, hasImage } = args;
+    const { numberOfCards, hasImage, format } = args;
     args.works = Array.from({ length: numberOfCards }).map(() => ({
       ...workBasic,
       title: faker.lorem.lines(),
       thumbnail: hasImage ? workBasic.thumbnail : undefined,
+      cardLabels: format
+        ? [{ text: format }, { text: 'Online', labelColor: 'white' }]
+        : workBasic.cardLabels,
     }));
 
     if (args.works.length === 1) {

--- a/cardigan/stories/data/work.ts
+++ b/cardigan/stories/data/work.ts
@@ -21,6 +21,7 @@ export const workBasic: WorkBasic = {
     },
     type: 'DigitalLocation',
   },
+  workTypeId: 'a',
   productionDates: ['1906'],
   cardLabels: [{ text: 'Books' }, { text: 'Online', labelColor: 'white' }],
   primaryContributorLabel: 'Mannel, Wilhelm, 1870-1935.',

--- a/content/webapp/contexts/ItemViewerContext/index.tsx
+++ b/content/webapp/contexts/ItemViewerContext/index.tsx
@@ -82,6 +82,7 @@ const query = {
 const work: WorkBasic & Pick<Work, 'description'> = {
   id: '',
   title: '',
+  workTypeId: undefined,
   description: undefined,
   languageId: undefined,
   thumbnail: undefined,

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -14,6 +14,7 @@ import { Work } from '.';
 export type WorkBasic = OptionalToUndefined<{
   id: string;
   title: string;
+  workTypeId?: string;
   languageId?: string;
   thumbnail?: DigitalLocation;
   referenceNumber?: string;
@@ -25,7 +26,7 @@ export type WorkBasic = OptionalToUndefined<{
 }>;
 
 export function toWorkBasic(work: Work): WorkBasic {
-  const { id, title, thumbnail, referenceNumber, notes } = work;
+  const { id, title, thumbnail, referenceNumber, notes, workType } = work;
 
   // We only send a lang if it's unambiguous -- better to send
   // no language than the wrong one.
@@ -37,6 +38,7 @@ export function toWorkBasic(work: Work): WorkBasic {
   return {
     id,
     title,
+    workTypeId: workType?.id,
     thumbnail,
     referenceNumber,
     languageId,

--- a/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
+++ b/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
@@ -107,7 +107,7 @@ const FormatIconContainer = styled.div`
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%) rotate(-2deg);
+  transform: translate(-50%, -50%);
   width: 100px;
   height: 100px;
 
@@ -122,11 +122,6 @@ type Props = {
 };
 
 const WorkCard: FunctionComponent<Props> = ({ item }) => {
-  const formatLabel =
-    item.cardLabels?.length > 0 && !item.cardLabels[0].labelColor
-      ? item.cardLabels[0].text
-      : undefined;
-
   const formatIconPath = getFormatIconPath(item.workTypeId);
 
   const transformedWork = {
@@ -135,7 +130,10 @@ const WorkCard: FunctionComponent<Props> = ({ item }) => {
     // `cardLabels` contains `workType` and `availabilities`, adding a labelColor to the latter.
     // As we only want the workType here, we filter out any with a labelColor.
     // It's not ideal but I prefer that to modifying a transformer that's heavily used elsewhere.
-    labels: formatLabel ? [{ text: formatLabel }] : [],
+    labels:
+      item.cardLabels?.length > 0 && !item.cardLabels[0].labelColor
+        ? [{ text: item.cardLabels[0].text }]
+        : [],
     imageUrl: item.thumbnail
       ? convertIiifImageUri(item.thumbnail.url, 400)
       : undefined,

--- a/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
+++ b/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
@@ -127,9 +127,7 @@ const WorkCard: FunctionComponent<Props> = ({ item }) => {
       ? item.cardLabels[0].text
       : undefined;
 
-  const formatIconPath = formatLabel
-    ? getFormatIconPath(formatLabel)
-    : undefined;
+  const formatIconPath = getFormatIconPath(item.workTypeId);
 
   const transformedWork = {
     title: item.title,

--- a/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
+++ b/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
@@ -7,6 +7,8 @@ import LabelsList from '@weco/common/views/components/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
 
+import { getFormatIconPath } from './WorkCards.FormatIcons';
+
 export const POPOUT_IMAGE_OFFSET = 'md' as const;
 
 // Ensures the image container takes up the same amount of vertical space
@@ -101,21 +103,41 @@ const NotAvailable = styled.span.attrs({
   text-align: center;
 `;
 
+const FormatIconContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-2deg);
+  width: 100px;
+  height: 100px;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
 type Props = {
   item: WorkBasic;
 };
 
 const WorkCard: FunctionComponent<Props> = ({ item }) => {
+  const formatLabel =
+    item.cardLabels?.length > 0 && !item.cardLabels[0].labelColor
+      ? item.cardLabels[0].text
+      : undefined;
+
+  const formatIconPath = formatLabel
+    ? getFormatIconPath(formatLabel)
+    : undefined;
+
   const transformedWork = {
     title: item.title,
     url: '/works/' + item.id,
     // `cardLabels` contains `workType` and `availabilities`, adding a labelColor to the latter.
     // As we only want the workType here, we filter out any with a labelColor.
     // It's not ideal but I prefer that to modifying a transformer that's heavily used elsewhere.
-    labels:
-      item.cardLabels?.length > 0 && !item.cardLabels[0].labelColor
-        ? [{ text: item.cardLabels[0].text }]
-        : [],
+    labels: formatLabel ? [{ text: formatLabel }] : [],
     imageUrl: item.thumbnail
       ? convertIiifImageUri(item.thumbnail.url, 400)
       : undefined,
@@ -134,6 +156,10 @@ const WorkCard: FunctionComponent<Props> = ({ item }) => {
               <PopoutCardImage>
                 <img alt="" src={transformedWork.imageUrl} />
               </PopoutCardImage>
+            ) : formatIconPath ? (
+              <FormatIconContainer>
+                <img alt="" src={formatIconPath} />
+              </FormatIconContainer>
             ) : (
               <NotAvailable>Preview not available</NotAvailable>
             )}

--- a/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
+++ b/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
@@ -19,6 +19,8 @@ const Shim = styled.div<{ $hasImage: boolean }>`
 `;
 
 const PopoutCardImageContainer = styled.div<{ $hasImage: boolean }>`
+  display: grid;
+  place-items: center;
   position: ${props => (props.$hasImage ? 'relative' : 'absolute')};
   height: ${props => (props.$hasImage ? 'auto' : '100%')};
   bottom: 0;
@@ -32,11 +34,7 @@ const PopoutCardImage = styled(Space).attrs({
 })`
   position: relative;
   width: 66%;
-  left: 50%;
-  transform: translateX(-50%) rotate(2deg);
-
-  /** This fixes an alignment issue with cards without images **/
-  display: flex;
+  transform: rotate(2deg);
 
   img {
     width: auto;
@@ -96,18 +94,10 @@ const Meta = styled.p.attrs({
 const NotAvailable = styled.span.attrs({
   className: font('sans', -2),
 })`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%) rotate(2deg);
-  text-align: center;
+  transform: rotate(2deg);
 `;
 
 const FormatIconContainer = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   width: 100px;
   height: 100px;
 

--- a/content/webapp/views/components/WorkCards/WorkCards.FormatIcons.ts
+++ b/content/webapp/views/components/WorkCards/WorkCards.FormatIcons.ts
@@ -1,0 +1,45 @@
+/**
+ * Maps work format labels (from the catalogue API's workType.label)
+ * to thumbnail icon image paths (served from /icons/).
+ *
+ * Based on the groupings defined in:
+ * https://github.com/wellcomecollection/wellcomecollection.org/issues/12802
+ */
+export function getFormatIconPath(formatLabel: string): string | undefined {
+  switch (formatLabel) {
+    // Archives and manuscripts
+    case 'Archives and manuscripts':
+    case 'Manuscripts':
+    case 'Born digital archives':
+      return '/icons/archives.svg';
+
+    // Books and journals
+    case 'Books':
+    case 'E-books':
+    case 'Journals':
+    case 'E-journals':
+    case 'Student dissertations':
+      return '/icons/book.svg';
+
+    // Images
+    case 'Pictures':
+    case 'Digital images':
+    case 'Maps':
+      return '/icons/image.svg';
+
+    // Audio and video
+    case 'Audio':
+    case 'Video':
+    case 'Music':
+    case 'Film':
+    case 'CD-Roms':
+      return '/icons/video-audio.svg';
+
+    // Ephemera
+    case 'Ephemera':
+      return '/icons/ephemera.svg';
+
+    default:
+      return undefined;
+  }
+}

--- a/content/webapp/views/components/WorkCards/WorkCards.FormatIcons.ts
+++ b/content/webapp/views/components/WorkCards/WorkCards.FormatIcons.ts
@@ -1,42 +1,39 @@
 /**
- * Maps work format labels (from the catalogue API's workType.label)
+ * Maps catalogue workType IDs to thumbnail icon image paths (served from /icons/).
  * to thumbnail icon image paths (served from /icons/).
  *
  * Based on the groupings defined in:
  * https://github.com/wellcomecollection/wellcomecollection.org/issues/12802
  */
-export function getFormatIconPath(formatLabel: string): string | undefined {
-  switch (formatLabel) {
+export function getFormatIconPath(formatId?: string): string | undefined {
+  switch (formatId) {
     // Archives and manuscripts
-    case 'Archives and manuscripts':
-    case 'Manuscripts':
-    case 'Born digital archives':
+    case 'h': // Archives and manuscripts
+    case 'b': // Manuscripts
+    case 'hdig': // Born-digital archives
       return '/icons/archives.svg';
 
     // Books and journals
-    case 'Books':
-    case 'E-books':
-    case 'Journals':
-    case 'E-journals':
-    case 'Student dissertations':
+    case 'a': // Books
+    case 'd': // Journals
+    case 'w': // Student dissertations
       return '/icons/book.svg';
 
     // Images
-    case 'Pictures':
-    case 'Digital images':
-    case 'Maps':
+    case 'k': // Pictures
+    case 'q': // Digital Images
       return '/icons/image.svg';
 
     // Audio and video
-    case 'Audio':
-    case 'Video':
-    case 'Music':
-    case 'Film':
-    case 'CD-Roms':
+    case 'i': // Audio
+    case 'g': // Videos
+    case 'n': // Film
+    case 'c': // Music
+    case 'm': // CD-Roms
       return '/icons/video-audio.svg';
 
     // Ephemera
-    case 'Ephemera':
+    case 'l': // Ephemera
       return '/icons/ephemera.svg';
 
     default:


### PR DESCRIPTION
- For #12802 

## What does this change?

Work cards that don't have a thumbnail image now display a format-specific icon (e.g. a book for Books, a film reel for Audio/Video) instead of the generic "Preview not available" text, if they are part of the list we provided (see ticket for the list).

Format labels from the catalogue API's `workType.label` are mapped to SVG icons served from `/icons/`. 

Also adds the content app's `public/` directory to Storybook's `staticDirs` so the icons resolve correctly in Cardigan without needing a symlink.

### Changes

- **`WorkCards.FormatIcons.ts`** — new module that maps format labels to icon paths
- **`WorkCards.Card.tsx`** — shows a format icon when there's no thumbnail but a recognised format exists
- **`WorksCards.stories.tsx`** — adds format and image controls to the story for easier testing
- **`cardigan/.storybook/main.js`** — serves content app's public assets in Storybook

## How to test

1. Run Cardigan (`yarn dev` in `cardigan/`) and open the WorkCards story
2. Uncheck "Has image" and pick different formats from the dropdown — the corresponding icon should appear
3. I'm not sure where to test it in real case scenarios as most of our works do have icons, suggestions welcome?

## Have we considered potential risks?

Low risk. The change is purely additive — works with thumbnails are unaffected. If a format isn't mapped, the existing "Preview not available" fallback still shows. The `staticDirs` addition in Storybook is additive and won't affect production.
