### PR TITLE
Inactivity modal changes and tracking

### DIFF
--- a/cardigan/stories/components/InactivityRedirect/InactivityRedirect.stories.tsx
+++ b/cardigan/stories/components/InactivityRedirect/InactivityRedirect.stories.tsx
@@ -1,0 +1,60 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ComponentProps, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import InactivityRedirectModal from '@weco/common/views/components/InactivityRedirect/InactivityRedirect.Modal';
+
+const ModalFrame = styled.div`
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  max-width: 500px;
+  margin: 40px auto;
+`;
+
+type StoryProps = ComponentProps<typeof InactivityRedirectModal>;
+
+const CountdownPreview = (args: StoryProps) => {
+  const [countdown, setCountdown] = useState(args.warningCountdown);
+
+  useEffect(() => {
+    setCountdown(args.warningCountdown);
+  }, [args.warningCountdown]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown(prev => (prev <= 0 ? args.warningCountdown : prev - 1));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [args.warningCountdown]);
+
+  return (
+    <ModalFrame>
+      <InactivityRedirectModal {...args} countdown={countdown} />
+    </ModalFrame>
+  );
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Components/InactivityRedirect',
+  component: InactivityRedirectModal,
+  args: {
+    warningCountdown: 30,
+  },
+  argTypes: {
+    warningCountdown: {
+      name: 'Warning countdown (seconds)',
+      control: { type: 'number' },
+    },
+    countdown: { table: { disable: true } },
+    onKeepBrowsing: { table: { disable: true } },
+    onReset: { table: { disable: true } },
+  },
+  render: args => <CountdownPreview {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<StoryProps>;
+
+export const Default: Story = { name: 'InactivityRedirect' };

--- a/common/views/components/InactivityRedirect/InactivityRedirect.Modal.tsx
+++ b/common/views/components/InactivityRedirect/InactivityRedirect.Modal.tsx
@@ -55,7 +55,7 @@ const InactivityRedirectModal: FunctionComponent<Props> = ({
         This screen will reset in {warningCountdown} seconds for the next
         visitor.
       </p>
-      <CountdownText>{countdown}</CountdownText>
+      <CountdownText data-chromatic="ignore">{countdown}</CountdownText>
       <ButtonRow>
         <Button
           variant="ButtonSolid"

--- a/common/views/components/InactivityRedirect/InactivityRedirect.Modal.tsx
+++ b/common/views/components/InactivityRedirect/InactivityRedirect.Modal.tsx
@@ -1,0 +1,79 @@
+import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+
+import Button from '@weco/common/views/components/Buttons';
+import { themeValues } from '@weco/common/views/themes/config';
+
+const RedirectModalContent = styled.div`
+  padding: 24px;
+  text-align: center;
+
+  p {
+    margin: 16px 0;
+    font-size: 18px;
+    line-height: 1.5;
+  }
+`;
+
+const RedirectModalTitle = styled.h2`
+  font-size: 32px;
+  font-weight: bold;
+  margin: 0 0 24px;
+`;
+
+const CountdownText = styled.strong`
+  display: block;
+  font-size: 32px;
+  font-weight: bold;
+  margin-top: 16px;
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin-top: 24px;
+`;
+
+type Props = {
+  countdown: number;
+  warningCountdown: number;
+  onKeepBrowsing: () => void;
+  onReset: () => void;
+};
+
+const InactivityRedirectModal: FunctionComponent<Props> = ({
+  countdown,
+  warningCountdown,
+  onKeepBrowsing,
+  onReset,
+}) => {
+  return (
+    <RedirectModalContent>
+      <RedirectModalTitle>Need more time?</RedirectModalTitle>
+      <p>
+        This screen will reset in {warningCountdown} seconds for the next
+        visitor.
+      </p>
+      <CountdownText>{countdown}</CountdownText>
+      <ButtonRow>
+        <Button
+          variant="ButtonSolid"
+          text="Keep browsing"
+          clickHandler={onKeepBrowsing}
+          colors={themeValues.buttonColors.greenGreenWhite}
+          dataGtmProps={{ trigger: 'reset-modal-keep-browsing-button' }}
+        />
+        <Button
+          variant="ButtonSolid"
+          text="Reset now"
+          clickHandler={onReset}
+          colors={themeValues.buttonColors.yellowYellowBlack}
+          dataGtmProps={{ trigger: 'reset-modal-reset-now-button' }}
+        />
+      </ButtonRow>
+    </RedirectModalContent>
+  );
+};
+
+export default InactivityRedirectModal;

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -17,9 +17,7 @@ const DEFAULT_WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
 
 type Props = {
   redirectUrl: string;
-  /** Milliseconds of inactivity before showing the warning modal. Default: 30000 */
   inactivityTimeout?: number;
-  /** Seconds to count down before redirecting. Default: 30 */
   warningCountdown?: number;
 };
 
@@ -78,12 +76,10 @@ const InactivityRedirect: FunctionComponent<Props> = ({
   }, [resetInactivityTimer]);
 
   const handleUserActivity = useCallback(() => {
-    if (isWarningActive) {
-      handleCancelRedirect();
-    } else {
-      resetInactivityTimer();
-    }
-  }, [isWarningActive, handleCancelRedirect, resetInactivityTimer]);
+    if (isWarningActive) return;
+
+    resetInactivityTimer();
+  }, [isWarningActive, resetInactivityTimer]);
 
   // Clean up on route changes
   useEffect(() => {
@@ -144,6 +140,10 @@ const InactivityRedirect: FunctionComponent<Props> = ({
   // Set up activity listeners
   useEffect(() => {
     if (!isKiosk || isRedirectDestination) return;
+
+    if (isWarningActive) {
+      return;
+    }
 
     const events = [
       'mousedown',

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -6,45 +6,32 @@ import {
   useRef,
   useState,
 } from 'react';
-import styled from 'styled-components';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
 import Modal from '@weco/common/views/components/Modal';
 
-const INACTIVITY_TIMEOUT = 30 * 1000; // 30 seconds
-const WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
+import InactivityRedirectModal from './InactivityRedirect.Modal';
 
-const RedirectModalContent = styled.div`
-  padding: 24px;
-  text-align: center;
-
-  p {
-    margin: 16px 0;
-    font-size: 18px;
-    line-height: 1.5;
-  }
-`;
-
-const RedirectModalTitle = styled.h2`
-  font-size: 32px;
-  font-weight: bold;
-  margin: 0 0 24px;
-`;
-
-const CountdownText = styled.strong`
-  font-size: 24px;
-  font-weight: bold;
-`;
+const DEFAULT_INACTIVITY_TIMEOUT = 30 * 1000; // 30 seconds
+const DEFAULT_WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
 
 type Props = {
   redirectUrl: string;
+  /** Milliseconds of inactivity before showing the warning modal. Default: 30000 */
+  inactivityTimeout?: number;
+  /** Seconds to count down before redirecting. Default: 30 */
+  warningCountdown?: number;
 };
 
-const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
+const InactivityRedirect: FunctionComponent<Props> = ({
+  redirectUrl,
+  inactivityTimeout = DEFAULT_INACTIVITY_TIMEOUT,
+  warningCountdown = DEFAULT_WARNING_COUNTDOWN,
+}) => {
   const isKiosk = useKiosk();
   const router = useRouter();
   const [isWarningActive, setIsWarningActive] = useState(false);
-  const [countdown, setCountdown] = useState(WARNING_COUNTDOWN);
+  const [countdown, setCountdown] = useState(warningCountdown);
   const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
   const countdownTimerRef = useRef<NodeJS.Timeout | null>(null);
   const redirectTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -55,6 +42,9 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
 
   const performRedirect = useCallback(() => {
     setIsWarningActive(false);
+
+    gtag('event', 'auto_reset');
+
     router.push(redirectUrl);
   }, [router, redirectUrl]);
 
@@ -67,13 +57,13 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
 
     inactivityTimerRef.current = setTimeout(() => {
       setIsWarningActive(true);
-      setCountdown(WARNING_COUNTDOWN);
-    }, INACTIVITY_TIMEOUT);
-  }, [isWarningActive]);
+      setCountdown(warningCountdown);
+    }, inactivityTimeout);
+  }, [isWarningActive, inactivityTimeout, warningCountdown]);
 
   const handleCancelRedirect = useCallback(() => {
     setIsWarningActive(false);
-    setCountdown(WARNING_COUNTDOWN);
+    setCountdown(warningCountdown);
 
     if (countdownTimerRef.current) {
       clearInterval(countdownTimerRef.current);
@@ -99,7 +89,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
   useEffect(() => {
     const handleRouteChange = () => {
       setIsWarningActive(false);
-      setCountdown(WARNING_COUNTDOWN);
+      setCountdown(warningCountdown);
 
       if (countdownTimerRef.current) {
         clearInterval(countdownTimerRef.current);
@@ -138,7 +128,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
 
       redirectTimerRef.current = setTimeout(() => {
         performRedirect();
-      }, WARNING_COUNTDOWN * 1000);
+      }, warningCountdown * 1000);
 
       return () => {
         if (countdownTimerRef.current) {
@@ -206,15 +196,12 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
       openButtonRef={modalButtonRef}
       showOverlay={true}
     >
-      <RedirectModalContent>
-        <RedirectModalTitle>Are you still there?</RedirectModalTitle>
-        <p>
-          Due to inactivity, you will be redirected in{' '}
-          <CountdownText>{countdown}</CountdownText> second
-          {countdown !== 1 ? 's' : ''}.
-        </p>
-        <p>Tap the screen to stay on this page.</p>
-      </RedirectModalContent>
+      <InactivityRedirectModal
+        countdown={countdown}
+        warningCountdown={warningCountdown}
+        onKeepBrowsing={handleCancelRedirect}
+        onReset={performRedirect}
+      />
     </Modal>
   );
 };

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -12,24 +12,18 @@ import Modal from '@weco/common/views/components/Modal';
 
 import InactivityRedirectModal from './InactivityRedirect.Modal';
 
-const DEFAULT_INACTIVITY_TIMEOUT = 30 * 1000; // 30 seconds
-const DEFAULT_WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
+const INACTIVITY_TIMEOUT = 30 * 1000; // 30 seconds
+const WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
 
 type Props = {
   redirectUrl: string;
-  inactivityTimeout?: number;
-  warningCountdown?: number;
 };
 
-const InactivityRedirect: FunctionComponent<Props> = ({
-  redirectUrl,
-  inactivityTimeout = DEFAULT_INACTIVITY_TIMEOUT,
-  warningCountdown = DEFAULT_WARNING_COUNTDOWN,
-}) => {
+const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
   const isKiosk = useKiosk();
   const router = useRouter();
   const [isWarningActive, setIsWarningActive] = useState(false);
-  const [countdown, setCountdown] = useState(warningCountdown);
+  const [countdown, setCountdown] = useState(WARNING_COUNTDOWN);
   const inactivityTimerRef = useRef<NodeJS.Timeout | null>(null);
   const countdownTimerRef = useRef<NodeJS.Timeout | null>(null);
   const redirectTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -55,13 +49,13 @@ const InactivityRedirect: FunctionComponent<Props> = ({
 
     inactivityTimerRef.current = setTimeout(() => {
       setIsWarningActive(true);
-      setCountdown(warningCountdown);
-    }, inactivityTimeout);
-  }, [isWarningActive, inactivityTimeout, warningCountdown]);
+      setCountdown(WARNING_COUNTDOWN);
+    }, INACTIVITY_TIMEOUT);
+  }, [isWarningActive]);
 
   const handleCancelRedirect = useCallback(() => {
     setIsWarningActive(false);
-    setCountdown(warningCountdown);
+    setCountdown(WARNING_COUNTDOWN);
 
     if (countdownTimerRef.current) {
       clearInterval(countdownTimerRef.current);
@@ -85,7 +79,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({
   useEffect(() => {
     const handleRouteChange = () => {
       setIsWarningActive(false);
-      setCountdown(warningCountdown);
+      setCountdown(WARNING_COUNTDOWN);
 
       if (countdownTimerRef.current) {
         clearInterval(countdownTimerRef.current);
@@ -124,7 +118,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({
 
       redirectTimerRef.current = setTimeout(() => {
         performRedirect();
-      }, warningCountdown * 1000);
+      }, WARNING_COUNTDOWN * 1000);
 
       return () => {
         if (countdownTimerRef.current) {
@@ -198,7 +192,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({
     >
       <InactivityRedirectModal
         countdown={countdown}
-        warningCountdown={warningCountdown}
+        warningCountdown={WARNING_COUNTDOWN}
         onKeepBrowsing={handleCancelRedirect}
         onReset={performRedirect}
       />


### PR DESCRIPTION
- For #13078

## What does this change?

- Adds the `auto_reset` GA4 custom event: when the inactivity timer triggers a redirect, `gtag('event', 'auto_reset')` is fired.
- Redesigns the inactivity timeout modal a little bit according to the [newer mockups](https://www.figma.com/design/eV1e7qHkYvob03Yvg8ptjv/Tenderness-and-rage?node-id=5756-11587), adding `data-gtm-trigger`s to the new buttons.
- Extracts the modal content to a reusable component (`InactivityRedirect.Modal.tsx`) for easier testing and reuse (needed it for Storybook!).
- Only dismiss the modal when clicking outside its bounds or clicking "Keep browsing" (so remove some functionalities).
- Adds a Cardigan story for the modal, with a live countdown for visual/UX review. The story is JUST for the visual, not for functionality.

## How to test

1. `yarn cardigan`, open the [InactivityRedirect story](http://localhost:9001/?path=/story/components-inactivityredirect--default) — the modal should render immediately with a countdown and two buttons.
2. Activate [the kiosk toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=storiesKiosk) (or the [mode](https://dash.wellcomecollection.org/toggles/?enableToggle=storiesKiosk), if it was activated since) and go on the a [Stories kiosk page](https://www-dev.wellcomecollection.org/stories/medieval-doodles). Wait 30 seconds and the new modal should appear.
3. Click "Keep browsing" — modal dismisses, timer resets.
4. Let it count down to 0 (or click "Reset now") — should redirect and fire `auto_reset` in the data layer (check via browser console: `dataLayer.filter(e => e.event === 'auto_reset')`).
5. Moving your mouse shouldn't dismiss the modal.

## Have we considered potential risks?

Low risk. The modal redesign is cosmetic and only affects kiosk mode. The GA4 event is additive. The extracted component is tested via the Cardigan story.
