### PR TITLE
Skip failing rotate test IIIF

### DIFF
--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -159,7 +159,9 @@ test('(8) | Licence information should be available', async ({
   await expect(page.getByText('Credit:')).toBeVisible();
 });
 
-test('(9) | The image should rotate', async ({ page, context }) => {
+// Please unskip once this is fixed by Digirati
+// https://wellcome.slack.com/archives/CBT40CMKQ/p1779797736981459
+test.skip('(9) | The image should rotate', async ({ page, context }) => {
   await itemWithSearchAndStructures(context, page);
   await page.getByRole('button', { name: 'Rotate' }).click();
   const currentIndex = await page.getByTestId('active-index').textContent();


### PR DESCRIPTION
## What does this change?

[It's failing too much](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/7984#_) because of a [bug with Digirati](https://wellcome.slack.com/archives/CBT40CMKQ/p1779797736981459) so we have to skip it for now.

## How to test

Do e2es pass


## Have we considered potential risks?
Remember to revert this https://github.com/wellcomecollection/wellcomecollection.org/issues/13109