### PR TITLE
Remove `storiesKiosk` feature flag

### DIFF
--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -8,7 +8,7 @@ import {
   WebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
-import { useFeatureFlags, useModes } from '@weco/common/server-data/Context';
+import { useModes } from '@weco/common/server-data/Context';
 import { appError } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -41,13 +41,11 @@ import ArticleSeriesPage, {
 } from '@weco/content/views/pages/series/series';
 
 const Page: NextPage<ArticleSeriesPageProps> = props => {
-  const { storiesKiosk } = useFeatureFlags();
   const { kioskMode } = useModes();
-  const isKiosk = !!storiesKiosk || !!kioskMode;
 
   return (
-    <KioskProvider isActive={isKiosk}>
-      {isKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
+    <KioskProvider isActive={!!kioskMode}>
+      {!!kioskMode && <InactivityRedirect redirectUrl="/stories/kiosk" />}
       <ArticleSeriesPage {...props} />
     </KioskProvider>
   );

--- a/content/webapp/pages/stories/[articleId].tsx
+++ b/content/webapp/pages/stories/[articleId].tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 
 import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
-import { useFeatureFlags, useModes } from '@weco/common/server-data/Context';
+import { useModes } from '@weco/common/server-data/Context';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -21,13 +21,11 @@ import ArticlePage, {
 } from '@weco/content/views/pages/stories/story';
 
 const Page: NextPage<ArticlePageProps> = props => {
-  const { storiesKiosk } = useFeatureFlags();
   const { kioskMode } = useModes();
-  const isKiosk = !!storiesKiosk || !!kioskMode;
 
   return (
-    <KioskProvider isActive={isKiosk}>
-      {isKiosk && <InactivityRedirect redirectUrl="/stories/kiosk" />}
+    <KioskProvider isActive={!!kioskMode}>
+      {!!kioskMode && <InactivityRedirect redirectUrl="/stories/kiosk" />}
       <ArticlePage {...props} />
     </KioskProvider>
   );

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -32,10 +32,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (
-    !serverData.toggles.featureFlags.storiesKiosk &&
-    !serverData.toggles.modes.kioskMode
-  ) {
+  if (!serverData.toggles.modes.kioskMode) {
     return { notFound: true };
   }
 

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -164,14 +164,6 @@ const toggleConfig = {
         'Enables gallery-specific features such as removing external links and showing an inactivity redirect after a period of inactivity',
       type: 'experimental',
     },
-    {
-      id: 'storiesKiosk',
-      title: 'Stories in kiosk mode',
-      initialValue: false,
-      description:
-        'Allows testing of stories in kiosk mode, for the Reading room iPads.',
-      type: 'experimental',
-    },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth


### PR DESCRIPTION
## What does this change?

Stories kiosk will now be powered by the mode, so we don't need the toggle anymore. This PR removes traces of it in the codebase, I'll deploy the changes to the Dash once it's in prod.

## How to test

- `yarn content`, activate [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes), see if you can see https://www-dev.wellcomecollection.org/stories/kiosk
- deactive kiosk mode, see if https://www-dev.wellcomecollection.org/stories/kiosk returns a 404.

## Have we considered potential risks?
N/A