### PR TITLE
Change onwards journey model to display Themes

### DIFF
--- a/common/customtypes/exhibitions/index.json
+++ b/common/customtypes/exhibitions/index.json
@@ -149,12 +149,15 @@
       }
     },
     "Onward journeys": {
-      "portrait_videos": {
+      "onward_journeys": {
         "type": "Slices",
-        "fieldset": "Onward journeys",
+        "fieldset": "Slice Zone",
         "config": {
           "choices": {
             "portraitVideoList": {
+              "type": "SharedSlice"
+            },
+            "themeCardsList": {
               "type": "SharedSlice"
             }
           }

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -2791,7 +2791,9 @@ type ExhibitionsDocumentDataBodySlice =
   | ThemeCardsListSlice
   | TitledTextListSlice;
 
-type ExhibitionsDocumentDataPortraitVideosSlice = PortraitVideoListSlice;
+type ExhibitionsDocumentDataOnwardJourneysSlice =
+  | PortraitVideoListSlice
+  | ThemeCardsListSlice;
 
 /**
  * Item in *Exhibition → Exhibits*
@@ -3139,15 +3141,15 @@ interface ExhibitionsDocumentData {
    * - **Documentation**: https://prismic.io/docs/slices
    */
   body: prismic.SliceZone<ExhibitionsDocumentDataBodySlice>; /**
-   * Onward journeys field in *Exhibition*
+   * Slice Zone field in *Exhibition*
    *
    * - **Field Type**: Slice Zone
    * - **Placeholder**: *None*
-   * - **API ID Path**: exhibitions.portrait_videos[]
+   * - **API ID Path**: exhibitions.onward_journeys[]
    * - **Tab**: Onward journeys
    * - **Documentation**: https://prismic.io/docs/slices
    */
-  portrait_videos: prismic.SliceZone<ExhibitionsDocumentDataPortraitVideosSlice>; /**
+  onward_journeys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>; /**
    * Exhibits field in *Exhibition*
    *
    * - **Field Type**: Group
@@ -7198,17 +7200,17 @@ export interface PortraitVideoListSliceDefaultPrimary {
  */
 export interface PortraitVideoListSliceDefaultItem {
   /**
-   * Embed field in *PortraitVideoList → Items*
+   * Embed (for YouTube Shorts, replace '/shorts/' with '/watch?v=') field in *PortraitVideoList → Items*
    *
    * - **Field Type**: Embed
-   * - **Placeholder**: For YouTube Shorts, replace '/shorts/' with '/watch?v='
+   * - **Placeholder**: *None*
    * - **API ID Path**: portraitVideoList.items[].embed
    * - **Documentation**: https://prismic.io/docs/fields/embed
    */
   embed: prismic.EmbedField;
 
   /**
-   * Poster image field in *PortraitVideoList → Items*
+   * Poster image (optional) field in *PortraitVideoList → Items*
    *
    * - **Field Type**: Image
    * - **Placeholder**: *None*
@@ -7221,17 +7223,17 @@ export interface PortraitVideoListSliceDefaultItem {
    * Duration field in *PortraitVideoList → Items*
    *
    * - **Field Type**: Text
-   * - **Placeholder**: e.g. 2:30
+   * - **Placeholder**: e.g. 02:30
    * - **API ID Path**: portraitVideoList.items[].duration
    * - **Documentation**: https://prismic.io/docs/fields/text
    */
   duration: prismic.KeyTextField;
 
   /**
-   * Title field in *PortraitVideoList → Items*
+   * Title (optional) field in *PortraitVideoList → Items*
    *
    * - **Field Type**: Text
-   * - **Placeholder**: Leave this blank to use the title from the embed
+   * - **Placeholder**: *None*
    * - **API ID Path**: portraitVideoList.items[].title
    * - **Documentation**: https://prismic.io/docs/fields/text
    */
@@ -7925,7 +7927,7 @@ declare module '@prismicio/client' {
       ExhibitionsDocument,
       ExhibitionsDocumentData,
       ExhibitionsDocumentDataBodySlice,
-      ExhibitionsDocumentDataPortraitVideosSlice,
+      ExhibitionsDocumentDataOnwardJourneysSlice,
       ExhibitionsDocumentDataExhibitsItem,
       ExhibitionsDocumentDataEventsItem,
       ExhibitionsDocumentDataArticlesItem,

--- a/content/webapp/__mocks__/whats-on.ts
+++ b/content/webapp/__mocks__/whats-on.ts
@@ -85,7 +85,7 @@ const beingHuman: Exhibition = {
   exhibits: [],
   seasons: [],
   contributors: [],
-  untransformedPortraitVideos: [],
+  untransformedOnwardJourneys: [],
 };
 
 export const whatsOn: ({

--- a/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/index.tsx
@@ -4,10 +4,6 @@ import {
   exhibitionGuideLinkText,
   visualStoryLinkText,
 } from '@weco/common/data/microcopy';
-import {
-  PagesDocumentDataBodySlice,
-  ThemeCardsListSlice as RawThemeCardsListSlice,
-} from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
@@ -19,7 +15,6 @@ import {
 } from '@weco/common/views/pages/_app';
 import { createClient } from '@weco/content/services/prismic/fetch';
 import { fetchExhibition } from '@weco/content/services/prismic/fetch/exhibitions';
-import { transformThemeCardsList } from '@weco/content/services/prismic/transformers/body';
 import { transformExhibition } from '@weco/content/services/prismic/transformers/exhibitions';
 import { exhibitionLd } from '@weco/content/services/prismic/transformers/json-ld';
 import { transformPage } from '@weco/content/services/prismic/transformers/pages';
@@ -67,24 +62,6 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     const exhibitionDoc = transformExhibition(exhibition);
     const relatedPages = transformQuery(pages, transformPage);
 
-    // Extract themeCardsList from body to render separately
-    const rawThemeCardsListSlice = exhibitionDoc.untransformedBody.find(
-      (slice: PagesDocumentDataBodySlice) =>
-        slice.slice_type === 'themeCardsList'
-    ) as RawThemeCardsListSlice | undefined;
-
-    const themeCardsListSlice =
-      rawThemeCardsListSlice &&
-      serverData.toggles.featureFlags.exhibitionAndCollection
-        ? transformThemeCardsList(rawThemeCardsListSlice)
-        : undefined;
-
-    // Filter out themeCardsList from body since we render it separately
-    const bodyWithoutThemeCardsList = exhibitionDoc.untransformedBody.filter(
-      (slice: PagesDocumentDataBodySlice) =>
-        slice.slice_type !== 'themeCardsList'
-    ) as typeof exhibitionDoc.untransformedBody;
-
     const visualStoriesLinks = visualStories.results.map(visualStory => {
       const url = linkResolver(visualStory);
       return {
@@ -107,15 +84,11 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
     return {
       props: serialiseProps<Props>({
-        exhibition: {
-          ...exhibitionDoc,
-          untransformedBody: bodyWithoutThemeCardsList,
-        },
+        exhibition: exhibitionDoc,
         relatedPages: relatedPages?.results || [],
         accessResourceLinks: [...exhibitionGuidesLinks, ...visualStoriesLinks],
         exhibitionTexts,
         exhibitionHighlightTours,
-        themeCardsListSlice,
         jsonLd,
         serverData,
       }),

--- a/content/webapp/services/prismic/transformers/exhibitions.ts
+++ b/content/webapp/services/prismic/transformers/exhibitions.ts
@@ -144,7 +144,7 @@ export function transformExhibition(
     accessResourcesText,
     bslLeafletVideo,
     labels,
-    untransformedPortraitVideos: data.portrait_videos || [],
+    untransformedOnwardJourneys: data.onward_journeys || [],
   };
 }
 

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -2,6 +2,7 @@ import * as prismic from '@prismicio/client';
 
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
+import { ExhibitionsDocumentDataOnwardJourneysSlice } from '@weco/common/prismicio-types';
 import { Props as VideoEmbedProps } from '@weco/common/views/components/VideoEmbed';
 import { Link } from '@weco/content/types/link';
 
@@ -57,7 +58,7 @@ export type Exhibition = GenericContentFields & {
   accessResourcesPdfs: AccessPDF[];
   accessResourcesText?: prismic.RichTextField;
   bslLeafletVideo?: VideoEmbedProps & { title?: string };
-  untransformedPortraitVideos: prismic.SliceZone<prismic.Content.ExhibitionsDocumentDataPortraitVideosSlice>;
+  untransformedOnwardJourneys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>;
 };
 
 export type Exhibit = {

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -1,7 +1,8 @@
+import * as prismic from '@prismicio/client';
 import { SliceZone } from '@prismicio/react';
 import styled from 'styled-components';
 
-import { PortraitVideoListSlice } from '@weco/common/prismicio-types';
+import { ExhibitionsDocumentDataOnwardJourneysSlice } from '@weco/common/prismicio-types';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import { gridSize12 } from '@weco/common/views/components/Layout';
@@ -9,14 +10,11 @@ import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
 import { components } from '@weco/common/views/slices';
-import { ThemeCardsListSliceValue } from '@weco/content/services/prismic/transformers/body';
-import { Slice } from '@weco/content/types/body';
 import { convertItemToCardProps } from '@weco/content/types/card';
 import { AboutThisExhibitionContent } from '@weco/content/types/exhibitions';
 import Card from '@weco/content/views/components/Card';
 import SectionHeader from '@weco/content/views/components/SectionHeader';
 import StoryCard from '@weco/content/views/components/StoryCard';
-import ThemeCardsList from '@weco/content/views/components/ThemeCardsList';
 
 export const Wrapper = styled(Space).attrs({
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
@@ -31,29 +29,38 @@ const SectionHeaderWrapper = styled.div`
 
 const ExhibitionCollectionsContent = ({
   isTendernessAndRageExhibition,
-  themeCardsListSlice,
-  videos,
+  onwardJourneys,
   aboutThisExhibitionContent,
 }: {
   isTendernessAndRageExhibition: boolean;
-  themeCardsListSlice?: Slice<'themeCardsList', ThemeCardsListSliceValue>;
-  videos: PortraitVideoListSlice[];
+  onwardJourneys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>;
   aboutThisExhibitionContent: AboutThisExhibitionContent[];
 }) => {
+  const { verticalVideos } = useFeatureFlags();
+
   // For now, we only want to trial displaying stories here for the Tenderness and Rage exhibition.
   // If this trial is successful, we will want to expand this to other exhibitions in the future.
   const shouldDisplayStories =
     isTendernessAndRageExhibition && aboutThisExhibitionContent.length > 0;
-  const shouldDisplayThemes = Boolean(
-    themeCardsListSlice && themeCardsListSlice.value.conceptIds.length > 0
+
+  const shouldDisplayThemes = onwardJourneys.some(
+    (slice: prismic.Slice) =>
+      slice.slice_type === 'themeCardsList' &&
+      Array.isArray(slice.primary.concepts_list) &&
+      slice.primary.concepts_list.length > 0
   );
 
-  const { verticalVideos } = useFeatureFlags();
+  const shouldDisplayVideos =
+    verticalVideos &&
+    onwardJourneys.some(
+      (slice: prismic.Slice) =>
+        slice.slice_type === 'portraitVideoList' &&
+        Array.isArray(slice.items) &&
+        slice.items.length > 0
+    );
 
   const shouldDisplay =
-    shouldDisplayStories ||
-    shouldDisplayThemes ||
-    (videos.length > 0 && verticalVideos);
+    shouldDisplayStories || shouldDisplayThemes || shouldDisplayVideos;
 
   if (!shouldDisplay) return null;
 
@@ -102,26 +109,16 @@ const ExhibitionCollectionsContent = ({
         )}
       </Container>
 
-      {shouldDisplayThemes && themeCardsListSlice && (
-        <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
-          <ThemeCardsList
-            conceptIds={themeCardsListSlice.value.conceptIds}
-            gtmData={{
-              'category-label': themeCardsListSlice.value.title,
-              'category-position-in-list': undefined,
-            }}
-            sliceTitle={themeCardsListSlice.value.title}
-            description={themeCardsListSlice.value.description}
-            headingLevel={3}
-            fontFamily="brand-bold"
-            useShim
-          />
-        </Space>
-      )}
-
-      {verticalVideos && videos?.length > 0 && (
+      {shouldDisplayThemes && (
         <SliceZone
-          slices={videos}
+          // filter out videos if verticalVideos is false
+          slices={onwardJourneys.filter(
+            (slice: prismic.Slice) =>
+              verticalVideos ||
+              slice.slice_type !== 'portraitVideoList' ||
+              !Array.isArray(slice.items) ||
+              slice.items.length === 0
+          )}
           components={components}
           context={{ gridSizes: gridSize12(), hasNoShim: false }}
         />

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -109,20 +109,15 @@ const ExhibitionCollectionsContent = ({
         )}
       </Container>
 
-      {shouldDisplayThemes && (
-        <SliceZone
-          // filter out videos if verticalVideos is false
-          slices={onwardJourneys.filter(
-            (slice: prismic.Slice) =>
-              verticalVideos ||
-              slice.slice_type !== 'portraitVideoList' ||
-              !Array.isArray(slice.items) ||
-              slice.items.length === 0
-          )}
-          components={components}
-          context={{ gridSizes: gridSize12(), hasNoShim: false }}
-        />
-      )}
+      <SliceZone
+        // filter out videos if verticalVideos is false
+        slices={onwardJourneys.filter(
+          (slice: prismic.Slice) =>
+            verticalVideos || slice.slice_type !== 'portraitVideoList'
+        )}
+        components={components}
+        context={{ gridSizes: gridSize12(), hasNoShim: false }}
+      />
     </Wrapper>
   );
 };

--- a/content/webapp/views/pages/exhibitions/exhibition/index.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/index.tsx
@@ -11,8 +11,6 @@ import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import PageLayout from '@weco/common/views/layouts/PageLayout';
 import { fetchExhibitionRelatedContentClientSide } from '@weco/content/services/prismic/fetch/exhibitions';
-import { ThemeCardsListSliceValue } from '@weco/content/services/prismic/transformers/body';
-import { Slice } from '@weco/content/types/body';
 import { EventBasic } from '@weco/content/types/events';
 import {
   AboutThisExhibitionContent,
@@ -32,7 +30,6 @@ export type Props = {
   accessResourceLinks: (Link & { type: string })[];
   exhibitionTexts: ExhibitionTextsDocument[];
   exhibitionHighlightTours: ExhibitionHighlightToursDocument[];
-  themeCardsListSlice?: Slice<'themeCardsList', ThemeCardsListSliceValue>;
 };
 
 /**
@@ -46,7 +43,6 @@ const ExhibitionPage: NextPage<Props> = ({
   accessResourceLinks,
   exhibitionTexts,
   exhibitionHighlightTours,
-  themeCardsListSlice,
   jsonLd,
 }) => {
   const [relatedContent, setRelatedContent] =
@@ -139,8 +135,7 @@ const ExhibitionPage: NextPage<Props> = ({
         <ExhibitionCollectionsContent
           isTendernessAndRageExhibition={isTendernessAndRageExhibition}
           aboutThisExhibitionContent={aboutThisExhibitionContent}
-          themeCardsListSlice={themeCardsListSlice}
-          videos={exhibition.untransformedPortraitVideos}
+          onwardJourneys={exhibition.untransformedOnwardJourneys}
         />
       )}
     </PageLayout>


### PR DESCRIPTION
- For #13081

## What does this change?

- The Prismic model naming had to change as it had defaulted to "portrait videos" for the Onwards Journey section, but now it could contain more. I had to re-push it to staging which deleted all existing Onward Journeys content - sorry! I added one video for testing.
- I added the ThemeCardsList slice to Onward Journeys allowed slices.
- Tidied up the code that filtered out the slice from the body, much nicer now.
- Use SliceZone to render that content now <3 

## How to test

- `yarn && yarn content`
- [Prismic staging](https://dash.wellcomecollection.org/toggles/?enableToggle=prismicStage), [Exhibition/Collection](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection) and [Vertical vids](https://dash.wellcomecollection.org/toggles/?enableToggle=verticalVideos) toggles.
- Go to [T&R exhibition](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage)
- Check the content renders well (Themes & vertical videos)
- Test without the Vertical video toggle - it shouldn't display them.

## Have we considered potential risks?
The videos will be deleted from Prismic prod once we deploy it there - we will need to re-add them.