### PR TITLE
Pass Kiosk context across the website when mode is active

### DIFF
--- a/common/views/components/Caption/index.tsx
+++ b/common/views/components/Caption/index.tsx
@@ -2,9 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 
-import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { font } from '@weco/common/utils/classnames';
-import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -48,8 +46,6 @@ const Caption: FunctionComponent<Props> = ({
   preCaptionNode,
   width,
 }: Props) => {
-  const isKiosk = useKiosk();
-
   return (
     // In order to be valid html, a figcaption should appear as the first or
     // last element in a figure. We have previously made this happen
@@ -63,10 +59,7 @@ const Caption: FunctionComponent<Props> = ({
         <CaptionWrapper>
           {preCaptionNode}
           <CaptionText>
-            <PrismicHtmlBlock
-              html={caption}
-              htmlSerializer={createSerializer({ stripExternalLinks: isKiosk })}
-            />
+            <PrismicHtmlBlock html={caption} />
           </CaptionText>
         </CaptionWrapper>
       </figcaption>

--- a/common/views/components/HTMLSerializers/HTMLSerializers.test.tsx
+++ b/common/views/components/HTMLSerializers/HTMLSerializers.test.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { render } from '@testing-library/react';
 import { createElement, ReactNode } from 'react';
 
-import { createSerializer, dropCapSerializer } from './index';
+import { dropCapSerializer, withExternalLinkStripping } from './index';
 
 describe('HTMLSerializers', () => {
   describe('dropCapSerializer', () => {
@@ -218,14 +218,14 @@ describe('HTMLSerializers', () => {
     });
   });
 
-  describe('createSerializer', () => {
+  describe('withExternalLinkStripping', () => {
     const hyperlinkType = prismic.RichTextNodeType.hyperlink;
     const mockKey = 'link-key';
     const mockContent = '';
     const children = ['Click here'] as unknown as ReactNode[];
+    const serializer = withExternalLinkStripping(dropCapSerializer);
 
-    it('strips external links when stripExternalLinks is true', () => {
-      const serializer = createSerializer({ stripExternalLinks: true });
+    it('strips external links', () => {
       const element = {
         type: hyperlinkType,
         data: { link_type: 'Web', url: 'https://www.bbc.co.uk/news' },
@@ -247,8 +247,7 @@ describe('HTMLSerializers', () => {
       expect(container).toHaveTextContent('Click here');
     });
 
-    it('keeps internal links when stripExternalLinks is true', () => {
-      const serializer = createSerializer({ stripExternalLinks: true });
+    it('keeps internal links', () => {
       const element = {
         type: hyperlinkType,
         data: {
@@ -277,32 +276,25 @@ describe('HTMLSerializers', () => {
       );
     });
 
-    it('keeps all links when stripExternalLinks is false', () => {
-      const serializer = createSerializer({ stripExternalLinks: false });
-      const element = {
-        type: hyperlinkType,
-        data: { link_type: 'Web', url: 'https://www.bbc.co.uk/news' },
-        text: '',
-        start: 0,
-        end: 10,
-      } as unknown as prismic.RTAnyNode;
-
+    it('preserves the wrapped serializer for non-hyperlink nodes', () => {
       const result = serializer(
-        hyperlinkType,
-        element,
-        mockContent,
-        children,
+        prismic.RichTextNodeType.paragraph,
+        {
+          type: prismic.RichTextNodeType.paragraph,
+          text: 'Hello world',
+          spans: [],
+        } as unknown as prismic.RTAnyNode,
+        'Hello world',
+        ['Hello world'] as unknown as ReactNode[],
         mockKey
       );
 
       const { container } = render(<>{result}</>);
-      const link = container.querySelector('a');
-      expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute('href', 'https://www.bbc.co.uk/news');
+      expect(container.querySelector('p')).toBeInTheDocument();
+      expect(container).toHaveTextContent('Hello world');
     });
 
     it('strips protocol-relative URLs as external', () => {
-      const serializer = createSerializer({ stripExternalLinks: true });
       const element = {
         type: hyperlinkType,
         data: { link_type: 'Web', url: '//example.com/page' },

--- a/common/views/components/HTMLSerializers/index.tsx
+++ b/common/views/components/HTMLSerializers/index.tsx
@@ -79,6 +79,11 @@ export const defaultSerializer: JSXFunctionSerializer = (
       const wrapperClassList = ['block-img'];
       const img = <img src={element.url} alt={element.alt || ''} />;
 
+      // Note: none of our custom types allow image insertion in rich text fields,
+      // so the linkTo branch is never reached in practice. If that changes,
+      // withExternalLinkStripping does not cover this case (it only intercepts
+      // hyperlink nodes), so external link stripping in kiosk mode would need
+      // to be added here too.
       return (
         <p key={key} className={wrapperClassList.join(' ')}>
           {url ? (
@@ -268,19 +273,13 @@ export const dropCapSerializer: JSXFunctionSerializer = (
 };
 
 /**
- * Creates a serializer that optionally strips external links and/or
- * applies drop cap styling to the first paragraph.
+ * Wraps an existing serializer and replaces external hyperlinks with plain text,
+ * while preserving the wrapped serializer's behaviour for internal links and all
+ * other rich text nodes.
  */
-export const createSerializer = ({
-  stripExternalLinks = false,
-  dropCap = false,
-}: {
-  stripExternalLinks?: boolean;
-  dropCap?: boolean;
-} = {}): JSXFunctionSerializer => {
-  if (!stripExternalLinks && !dropCap) return defaultSerializer;
-  if (!stripExternalLinks && dropCap) return dropCapSerializer;
-
+export function withExternalLinkStripping(
+  serializer: JSXFunctionSerializer
+): JSXFunctionSerializer {
   return (type, element, content, children, key) => {
     if (element.type === prismic.RichTextNodeType.hyperlink) {
       const linkUrl = prismic.asLink(element.data, { linkResolver }) || '';
@@ -289,13 +288,9 @@ export const createSerializer = ({
       }
     }
 
-    if (dropCap) {
-      return dropCapSerializer(type, element, content, children, key);
-    }
-
-    return defaultSerializer(type, element, content, children, key);
+    return serializer(type, element, content, children, key);
   };
-};
+}
 
 const ACCESSIBILITY_ICON_MAP: Record<string, IconSvg> = {
   bsl: bslSquare,

--- a/common/views/components/PageHeaderStandfirst/index.tsx
+++ b/common/views/components/PageHeaderStandfirst/index.tsx
@@ -1,8 +1,6 @@
 import { ComponentPropsWithoutRef, FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { useKiosk } from '@weco/common/contexts/KioskContext';
-import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -17,20 +15,10 @@ const Wrapper = styled(Space).attrs({
 
 export type Props = ComponentPropsWithoutRef<typeof PrismicHtmlBlock>;
 
-const PageHeaderStandfirst: FunctionComponent<Props> = props => {
-  const isKiosk = useKiosk();
-
-  return (
-    <Wrapper data-component="page-header-standfirst">
-      <PrismicHtmlBlock
-        {...props}
-        htmlSerializer={
-          props.htmlSerializer ||
-          createSerializer({ stripExternalLinks: isKiosk })
-        }
-      />
-    </Wrapper>
-  );
-};
+const PageHeaderStandfirst: FunctionComponent<Props> = props => (
+  <Wrapper data-component="page-header-standfirst">
+    <PrismicHtmlBlock {...props} />
+  </Wrapper>
+);
 
 export default PageHeaderStandfirst;

--- a/common/views/components/PrismicHtmlBlock/index.tsx
+++ b/common/views/components/PrismicHtmlBlock/index.tsx
@@ -20,11 +20,10 @@ const PrismicHtmlBlock: FunctionComponent<Props> = ({
   htmlSerializer,
 }) => {
   const isKiosk = useKiosk();
+  const baseSerializer = htmlSerializer ?? defaultSerializer;
   const serializer = isKiosk
-    ? htmlSerializer
-      ? withExternalLinkStripping(htmlSerializer)
-      : withExternalLinkStripping(defaultSerializer)
-    : htmlSerializer;
+    ? withExternalLinkStripping(baseSerializer)
+    : baseSerializer;
 
   return (
     <PrismicRichText

--- a/common/views/components/PrismicHtmlBlock/index.tsx
+++ b/common/views/components/PrismicHtmlBlock/index.tsx
@@ -3,7 +3,12 @@ import * as prismic from '@prismicio/client';
 import { JSXFunctionSerializer, PrismicRichText } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
+import {
+  defaultSerializer,
+  withExternalLinkStripping,
+} from '@weco/common/views/components/HTMLSerializers';
 
 type Props = {
   html: prismic.RichTextField;
@@ -13,12 +18,21 @@ type Props = {
 const PrismicHtmlBlock: FunctionComponent<Props> = ({
   html,
   htmlSerializer,
-}) => (
-  <PrismicRichText
-    field={html}
-    components={htmlSerializer}
-    linkResolver={linkResolver}
-  />
-);
+}) => {
+  const isKiosk = useKiosk();
+  const serializer = isKiosk
+    ? htmlSerializer
+      ? withExternalLinkStripping(htmlSerializer)
+      : withExternalLinkStripping(defaultSerializer)
+    : htmlSerializer;
+
+  return (
+    <PrismicRichText
+      field={html}
+      components={serializer}
+      linkResolver={linkResolver}
+    />
+  );
+};
 
 export default PrismicHtmlBlock;

--- a/common/views/layouts/ErrorPage/index.tsx
+++ b/common/views/layouts/ErrorPage/index.tsx
@@ -63,6 +63,7 @@ const TogglesMessage: FunctionComponent = () => {
   // here -- we can't use getServerSideProps on an error page.
   // See https://nextjs.org/docs/messages/404-get-initial-props
   const [toggles, setToggles] = useState<string[]>([]);
+  const [hasActiveMode, setHasActiveMode] = useState(false);
 
   useEffect(() => {
     setToggles(() => {
@@ -72,11 +73,18 @@ const TogglesMessage: FunctionComponent = () => {
         getCookies()
       ).filter(v => !v.startsWith('!'));
 
+      const activeModes = activeTogglesInBrowser.filter(id =>
+        togglesList.modes.some(mode => mode.id === id)
+      );
+
+      setHasActiveMode(activeModes.length > 0);
+
       // Get the readable name
       if (activeTogglesInBrowser.length > 0) {
         const flattenedTogglesList = [
           ...togglesList.featureFlags,
           ...togglesList.tests,
+          ...togglesList.modes,
         ];
         const activeToggleNames = activeTogglesInBrowser
           .map(
@@ -110,10 +118,28 @@ const TogglesMessage: FunctionComponent = () => {
               ))}
             </ul>
             This could be what is causing this page to error,{' '}
-            <a href="https://dash.wellcomecollection.org/toggles">
+            <a
+              href="https://dash.wellcomecollection.org/toggles"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               please try resetting your toggles
             </a>
             .
+            {hasActiveMode && (
+              <Space $v={{ size: 'xs', properties: ['margin-top'] }}>
+                <strong>You are also not using the default view mode</strong>,
+                which could be changing the default experience.{' '}
+                <a
+                  href="https://dash.wellcomecollection.org/toggles/#modes"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  You can reset them here
+                </a>
+                .
+              </Space>
+            )}
           </Space>
         </MessageBar>
       </ContaineredLayout>

--- a/common/views/layouts/PageLayout/index.tsx
+++ b/common/views/layouts/PageLayout/index.tsx
@@ -8,6 +8,7 @@ import {
   GlobalInfoBarContextProvider,
   useGlobalInfoBarContext,
 } from '@weco/common/contexts/GlobalInfoBarContext';
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { useSearchContext } from '@weco/common/contexts/SearchContext';
 import cookies from '@weco/common/data/cookies';
 import { collectionVenueId } from '@weco/common/data/hardcoded-ids';
@@ -94,6 +95,7 @@ const PageLayoutComponent: NextPage<Props> = ({
   isNoIndex = false,
 }) => {
   const { apiToolbar, issuesBanner } = useFeatureFlags();
+  const isKiosk = useKiosk();
   const urlString = convertUrlToString(url);
   const fullTitle =
     title !== ''
@@ -287,7 +289,9 @@ const PageLayoutComponent: NextPage<Props> = ({
         <a className="visually-hidden visually-hidden-focusable" href="#main">
           Skip to main content
         </a>
-        {!hideHeader && <Header siteSection={siteSection} {...headerProps} />}
+        {!hideHeader && !isKiosk && (
+          <Header siteSection={siteSection} {...headerProps} />
+        )}
         {issuesBanner && <InfoBanner variant="websiteIssues" />}
         {globalAlert.data.isShown === 'show' &&
           (!globalAlert.data.routeRegex ||
@@ -320,12 +324,12 @@ const PageLayoutComponent: NextPage<Props> = ({
           {children}
         </div>
 
-        {!hideNewsletterPromo && <NewsletterPromo />}
+        {!hideNewsletterPromo && !isKiosk && <NewsletterPromo />}
 
         {/* The no javascript version of the burger menu relies on the footer being present on the page,
         as we then use an anchor link to take people to the navigation links in the footer.
         We only completely remove the footer if you've got JS. If we've hidden the header, then we don't need to worry about this because the navigation links aren't there at all */}
-        {(!hideFooter || !isEnhanced) && <Footer venues={venues} />}
+        {(!hideFooter || !isEnhanced) && !isKiosk && <Footer venues={venues} />}
       </div>
     </>
   );

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'styled-components';
 
 import { ApmContextProvider } from '@weco/common/contexts/ApmContext';
 import { AppContextProvider } from '@weco/common/contexts/AppContext';
+import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { SearchContextProvider } from '@weco/common/contexts/SearchContext';
 import { UserContextProvider } from '@weco/common/contexts/UserContext';
 import { useScrollTracking } from '@weco/common/hooks/useScrollTracking';
@@ -23,6 +24,7 @@ import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
 import { deserialiseProps } from '@weco/common/utils/json';
 import CivicUK from '@weco/common/views/components/CivicUK';
 import GlobalSvgDefinitions from '@weco/common/views/components/GlobalSvgDefinitions';
+import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator';
 import ErrorPage from '@weco/common/views/layouts/ErrorPage';
 import themeValues, { GlobalStyle } from '@weco/common/views/themes/default';
@@ -104,6 +106,8 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
 
   const serverData = isServerDataSet ? pageProps.serverData : defaultServerData;
 
+  const isKiosk = !!serverData.toggles.modes.kioskMode;
+
   useMaintainPageHeight();
 
   const onConsentChanged = (event: CookieConsentEvent) => {
@@ -153,13 +157,13 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
   const componentProps = deserialiseProps(pageProps) as Record<string, unknown>;
 
   return (
-    <>
-      <ApmContextProvider>
-        <ServerDataContext.Provider value={serverData}>
-          <ThemeProvider theme={themeValues}>
-            <UserContextProvider>
-              <AppContextProvider>
-                <SearchContextProvider>
+    <ApmContextProvider>
+      <ServerDataContext.Provider value={serverData}>
+        <ThemeProvider theme={themeValues}>
+          <UserContextProvider>
+            <AppContextProvider>
+              <SearchContextProvider>
+                <KioskProvider isActive={isKiosk}>
                   <GlobalStyle />
 
                   <GlobalSvgDefinitions />
@@ -181,13 +185,17 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                       title={pageProps.err.message}
                     />
                   )}
-                </SearchContextProvider>
-              </AppContextProvider>
-            </UserContextProvider>
-          </ThemeProvider>
-        </ServerDataContext.Provider>
-      </ApmContextProvider>
-    </>
+
+                  {isKiosk && (
+                    <InactivityRedirect redirectUrl="/stories/kiosk" />
+                  )}
+                </KioskProvider>
+              </SearchContextProvider>
+            </AppContextProvider>
+          </UserContextProvider>
+        </ThemeProvider>
+      </ServerDataContext.Provider>
+    </ApmContextProvider>
   );
 };
 

--- a/common/views/slices/Text/index.tsx
+++ b/common/views/slices/Text/index.tsx
@@ -2,13 +2,12 @@ import * as prismic from '@prismicio/client';
 import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
-import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { TextSlice as RawTextSlice } from '@weco/common/prismicio-types';
 import { classNames } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import {
   accessibilitySerializer,
-  createSerializer,
+  dropCapSerializer,
 } from '@weco/common/views/components/HTMLSerializers';
 import { ContaineredLayout } from '@weco/common/views/components/Layout';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
@@ -21,7 +20,6 @@ import {
 export type TextProps = SliceComponentProps<RawTextSlice, SliceZoneContext>;
 
 const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
-  const isKiosk = useKiosk();
   const options = { ...defaultContext, ...context };
   const shouldBeDroppedCap =
     options.firstTextSliceIndex === slice.id && options.isDropCapped;
@@ -31,9 +29,7 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
     options.pageUid === 'accessibility' ||
     options.pageUid === 'prototype-a11y-november-2025';
 
-  const serializer = isAccessibilityPage
-    ? accessibilitySerializer
-    : createSerializer({ stripExternalLinks: isKiosk });
+  const serializer = isAccessibilityPage ? accessibilitySerializer : undefined;
 
   return (
     <SpacingComponent $sliceType={slice.slice_type}>
@@ -55,10 +51,7 @@ const Text: FunctionComponent<TextProps> = ({ slice, context }) => {
             <>
               <PrismicHtmlBlock
                 html={[slice.primary.text[0]] as prismic.RichTextField}
-                htmlSerializer={createSerializer({
-                  stripExternalLinks: isKiosk,
-                  dropCap: true,
-                })}
+                htmlSerializer={dropCapSerializer}
               />
               <PrismicHtmlBlock
                 html={slice.primary.text.slice(1) as prismic.RichTextField}

--- a/content/webapp/pages/series/[seriesId].tsx
+++ b/content/webapp/pages/series/[seriesId].tsx
@@ -1,18 +1,15 @@
 import * as prismic from '@prismicio/client';
 import { NextPage } from 'next';
 
-import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { bodySquabblesSeries as bodySquabblesSeriesId } from '@weco/common/data/hardcoded-ids';
 import {
   SeriesDocument,
   WebcomicSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { getServerData } from '@weco/common/server-data';
-import { useModes } from '@weco/common/server-data/Context';
 import { appError } from '@weco/common/services/app';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
-import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -41,14 +38,7 @@ import ArticleSeriesPage, {
 } from '@weco/content/views/pages/series/series';
 
 const Page: NextPage<ArticleSeriesPageProps> = props => {
-  const { kioskMode } = useModes();
-
-  return (
-    <KioskProvider isActive={!!kioskMode}>
-      {!!kioskMode && <InactivityRedirect redirectUrl="/stories/kiosk" />}
-      <ArticleSeriesPage {...props} />
-    </KioskProvider>
-  );
+  return <ArticleSeriesPage {...props} />;
 };
 
 type Props = ServerSideProps<ArticleSeriesPageProps>;

--- a/content/webapp/pages/stories/[articleId].tsx
+++ b/content/webapp/pages/stories/[articleId].tsx
@@ -1,12 +1,9 @@
 import { NextPage } from 'next';
 
-import { KioskProvider } from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
-import { useModes } from '@weco/common/server-data/Context';
 import { looksLikePrismicId } from '@weco/common/services/prismic';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
-import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import {
   ServerSideProps,
   ServerSidePropsOrAppError,
@@ -21,14 +18,7 @@ import ArticlePage, {
 } from '@weco/content/views/pages/stories/story';
 
 const Page: NextPage<ArticlePageProps> = props => {
-  const { kioskMode } = useModes();
-
-  return (
-    <KioskProvider isActive={!!kioskMode}>
-      {!!kioskMode && <InactivityRedirect redirectUrl="/stories/kiosk" />}
-      <ArticlePage {...props} />
-    </KioskProvider>
-  );
+  return <ArticlePage {...props} />;
 };
 
 type Props = ServerSideProps<ArticlePageProps>;

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -3,14 +3,12 @@ import { SliceZone } from '@prismicio/react';
 import { Fragment, FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { officialLandingPagesUid } from '@weco/common/data/hardcoded-ids';
 import { ContentListSlice as RawContentListSlice } from '@weco/common/prismicio-types';
 import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { classNames, font } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
-import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import {
   ContaineredLayout,
   gridSize12,
@@ -143,7 +141,6 @@ const Body: FunctionComponent<Props> = ({
   contentType,
   bodySliceContexts,
 }: Props) => {
-  const isKiosk = useKiosk();
   const filteredUntransformedBody = untransformedBody.filter(
     (slice: prismic.Slice) => slice.slice_type !== 'standfirst'
   );
@@ -335,12 +332,7 @@ const Body: FunctionComponent<Props> = ({
                     properties: ['margin-bottom'],
                   }}
                 >
-                  <FeaturedText
-                    html={introText}
-                    htmlSerializer={createSerializer({
-                      stripExternalLinks: isKiosk,
-                    })}
-                  />
+                  <FeaturedText html={introText} />
                 </Space>
               </div>
             </ContaineredLayout>

--- a/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
+++ b/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { getCrop } from '@weco/common/model/image';
 import { font } from '@weco/common/utils/classnames';
-import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
@@ -142,12 +141,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
 
           {descriptionToRender && (
             <Description>
-              <PrismicHtmlBlock
-                html={descriptionToRender}
-                htmlSerializer={createSerializer({
-                  stripExternalLinks: isKiosk,
-                })}
-              />
+              <PrismicHtmlBlock html={descriptionToRender} />
             </Description>
           )}
         </div>

--- a/content/webapp/views/components/TextAndImageOrIcons/index.tsx
+++ b/content/webapp/views/components/TextAndImageOrIcons/index.tsx
@@ -2,9 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { ImageType } from '@weco/common/model/image';
-import { createSerializer } from '@weco/common/views/components/HTMLSerializers';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -91,7 +89,6 @@ export type Props = {
 };
 
 const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
-  const isKiosk = useKiosk();
   // Icons can be added indefinitely without necessarily having an image, so we are filtering it here
   const icons: ImageType[] = [];
   if (item.type === 'icons') {
@@ -124,10 +121,7 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
           </ImageOrIcons>
         )}
         <Text>
-          <PrismicHtmlBlock
-            html={item.text}
-            htmlSerializer={createSerializer({ stripExternalLinks: isKiosk })}
-          />
+          <PrismicHtmlBlock html={item.text} />
         </Text>
       </MediaAndTextWrap>
     </DividingLine>

--- a/content/webapp/views/pages/series/series/index.tsx
+++ b/content/webapp/views/pages/series/series/index.tsx
@@ -92,9 +92,6 @@ const ArticleSeriesPage: NextPage<Props> = props => {
       openGraphType="website"
       image={series.image}
       apiToolbarLinks={[createPrismicLink(series.id)]}
-      hideHeader={isKiosk}
-      hideFooter={isKiosk}
-      hideNewsletterPromo={isKiosk}
     >
       <ContentPage
         id={series.id}

--- a/content/webapp/views/pages/stories/story/index.tsx
+++ b/content/webapp/views/pages/stories/story/index.tsx
@@ -174,9 +174,6 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
       siteSection="stories"
       image={article.image}
       apiToolbarLinks={[createPrismicLink(article.id)]}
-      hideHeader={isKiosk}
-      hideFooter={isKiosk}
-      hideNewsletterPromo={isKiosk}
     >
       <ContentPage
         id={article.id}


### PR DESCRIPTION
- For #13118

## What does this change?

Applies the three kiosk behaviours from the ticket site-wide rather than only on stories and series pages:

1. Inactivity redirect: `InactivityRedirect` and `KioskProvider` moved from individual page components into `_app.tsx`.
2. Header/footer removal: `PageLayout` now reads `useKiosk()` directly and suppresses the header, footer, and newsletter promo, so the per-page `hideHeader`/`hideFooter`/`hideNewsletterPromo` props are removed.
3. External link stripping: moved into `PrismicHtmlBlock` so all Prismic rich text is covered automatically. The now-redundant `createSerializer()` helper is removed; `withExternalLinkStripping()` is exported directly.

The error page also now surfaces active view modes (not just feature flags) in its toggle warning message.

## How to test

Check that tests passed.

Enable [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes) via the toggles dashboard, then:

On PROD: visit an exhibition or event page and you'll see the header, footer, and newsletter promo. Navigate away from the page and stay idle — nothing happens. Rich-text external links are clickable.

On this branch: the same pages have no header, footer, or newsletter promo. Idle on any page and you'll be redirected. Rich-text external links are plain text; internal links still work.

A few good pages to check for mixed link types:
- https://wellcomecollection.org/stories/the-search-for-a-cure-for-endometriosis (external + internal + PDF links)
- https://wellcomecollection.org/exhibitions/expecting-birth-belief-and-protection (external + works + internal links)

## Have we considered potential risks?

- Kiosk behaviours now apply to every page, not just stories/series. Worth checking a few non-story pages (events, exhibitions, collections) in kiosk mode before merging.
- External PDF/document links are stripped in kiosk mode — intentional, it is a public iPad.
- The `Card` component renders its `link` field directly as an `<a href>` with no kiosk check. The card custom type allows external web URLs, so an editor could create a card that links off-site. Not addressed in this PR. We could address it, but I think it's such a low occurrence that it might not be worth the work. Worth discussing with @LaurenFBaily perhaps.