### PR TITLE
Only send auto reset event on actual auto reset

### DIFF
--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -32,13 +32,18 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
   // Don't run on the redirect destination itself
   const isRedirectDestination = router.asPath === redirectUrl;
 
-  const performRedirect = useCallback(() => {
-    setIsWarningActive(false);
+  const performRedirect = useCallback(
+    ({ isAutomated }: { isAutomated: boolean }) => {
+      setIsWarningActive(false);
 
-    gtag('event', 'auto_reset');
+      if (isAutomated) {
+        gtag('event', 'auto_reset');
+      }
 
-    router.push(redirectUrl);
-  }, [router, redirectUrl]);
+      router.push(redirectUrl);
+    },
+    [router, redirectUrl]
+  );
 
   const resetInactivityTimer = useCallback(() => {
     if (inactivityTimerRef.current) {
@@ -117,7 +122,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
       }, 1000);
 
       redirectTimerRef.current = setTimeout(() => {
-        performRedirect();
+        performRedirect({ isAutomated: true });
       }, WARNING_COUNTDOWN * 1000);
 
       return () => {
@@ -194,7 +199,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
         countdown={countdown}
         warningCountdown={WARNING_COUNTDOWN}
         onKeepBrowsing={handleCancelRedirect}
-        onReset={performRedirect}
+        onReset={() => performRedirect({ isAutomated: false })}
       />
     </Modal>
   );


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13078#issuecomment-4565736361

## What does this change?

As Mankeet outlined in his QA, the `auto_reset` event was sent on every reset (so also when the user clicked "reset now"), but it should only be when it ... auto resets.

So I added a prop to pass in to indicate whether or not to send the event.

## How to test


- [Story kiosk mode set](https://dash.wellcomecollection.org/toggles/#modes)
- Preview https://www-dev.wellcomecollection.org/stories/medieval-doodles in GTM (make sure you allow analytics)
- Wait 30 seconds, the modal will show. 
- Test both scenarios of letting it reset itself (should send the event) and clicking "Reset now" (should not send the event).

## Have we considered potential risks?
N/A