### PR TITLE
Remove `ThemeCardsList` from Exhibition slices and alphabetise them all

### DIFF
--- a/common/customtypes/articles/index.json
+++ b/common/customtypes/articles/index.json
@@ -19,7 +19,9 @@
         "config": {
           "label": "Format",
           "select": "document",
-          "customtypes": ["article-formats"]
+          "customtypes": [
+            "article-formats"
+          ]
         }
       },
       "uid": {
@@ -34,37 +36,37 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "embed": {
-              "type": "SharedSlice"
-            },
             "audioPlayer": {
-              "type": "SharedSlice"
-            },
-            "tagList": {
-              "type": "SharedSlice"
-            },
-            "iframe": {
-              "type": "SharedSlice"
-            },
-            "editorialImageGallery": {
               "type": "SharedSlice"
             },
             "editorialImage": {
               "type": "SharedSlice"
             },
+            "editorialImageGallery": {
+              "type": "SharedSlice"
+            },
+            "embed": {
+              "type": "SharedSlice"
+            },
             "gifVideo": {
               "type": "SharedSlice"
             },
-            "text": {
-              "type": "SharedSlice"
-            },
-            "standfirst": {
+            "iframe": {
               "type": "SharedSlice"
             },
             "infoBlock": {
               "type": "SharedSlice"
             },
             "quote": {
+              "type": "SharedSlice"
+            },
+            "standfirst": {
+              "type": "SharedSlice"
+            },
+            "tagList": {
+              "type": "SharedSlice"
+            },
+            "text": {
               "type": "SharedSlice"
             }
           }
@@ -82,7 +84,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -90,7 +94,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {
@@ -181,7 +188,10 @@
         "config": {
           "label": "\"Explore more\" document",
           "select": "document",
-          "customtypes": ["articles", "exhibitions"]
+          "customtypes": [
+            "articles",
+            "exhibitions"
+          ]
         }
       },
       "series": {
@@ -194,7 +204,9 @@
               "config": {
                 "label": "Series",
                 "select": "document",
-                "customtypes": ["series"]
+                "customtypes": [
+                  "series"
+                ]
               }
             },
             "positionInSeries": {
@@ -216,7 +228,9 @@
               "config": {
                 "label": "Season",
                 "select": "document",
-                "customtypes": ["seasons"],
+                "customtypes": [
+                  "seasons"
+                ],
                 "placeholder": "Select a Season"
               }
             }
@@ -239,7 +253,9 @@
               "config": {
                 "label": "Parent",
                 "select": "document",
-                "customtypes": ["exhibitions"],
+                "customtypes": [
+                  "exhibitions"
+                ],
                 "placeholder": "Select a parent"
               }
             }

--- a/common/customtypes/books/index.json
+++ b/common/customtypes/books/index.json
@@ -93,10 +93,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -105,28 +111,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -135,19 +138,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }
@@ -165,7 +165,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -173,7 +175,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {
@@ -269,7 +274,9 @@
               "config": {
                 "label": "Season",
                 "select": "document",
-                "customtypes": ["seasons"],
+                "customtypes": [
+                  "seasons"
+                ],
                 "placeholder": "Select a Season"
               }
             }
@@ -292,7 +299,9 @@
               "config": {
                 "label": "Parent",
                 "select": "document",
-                "customtypes": ["exhibitions"],
+                "customtypes": [
+                  "exhibitions"
+                ],
                 "placeholder": "Select a parent"
               }
             }

--- a/common/customtypes/event-series/index.json
+++ b/common/customtypes/event-series/index.json
@@ -26,10 +26,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -38,28 +44,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -68,19 +71,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }
@@ -98,7 +98,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -106,7 +108,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {

--- a/common/customtypes/events/index.json
+++ b/common/customtypes/events/index.json
@@ -19,7 +19,9 @@
         "config": {
           "label": "Format",
           "select": "document",
-          "customtypes": ["event-formats"]
+          "customtypes": [
+            "event-formats"
+          ]
         }
       },
       "locations": {
@@ -32,7 +34,9 @@
               "config": {
                 "label": "Location",
                 "select": "document",
-                "customtypes": ["places"]
+                "customtypes": [
+                  "places"
+                ]
               }
             }
           }
@@ -73,14 +77,18 @@
               "type": "Select",
               "config": {
                 "label": "In-venue fully booked",
-                "options": ["yes"]
+                "options": [
+                  "yes"
+                ]
               }
             },
             "onlineIsFullyBooked": {
               "type": "Select",
               "config": {
                 "label": "Online fully booked",
-                "options": ["yes"]
+                "options": [
+                  "yes"
+                ]
               }
             }
           }
@@ -105,10 +113,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -117,28 +131,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -147,19 +158,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }
@@ -177,14 +185,18 @@
               "config": {
                 "label": "Interpretation",
                 "select": "document",
-                "customtypes": ["interpretation-types"]
+                "customtypes": [
+                  "interpretation-types"
+                ]
               }
             },
             "isPrimary": {
               "type": "Select",
               "config": {
                 "label": "Primary interprtation",
-                "options": ["yes"]
+                "options": [
+                  "yes"
+                ]
               }
             },
             "extraInformation": {
@@ -207,7 +219,9 @@
               "config": {
                 "label": "Audience",
                 "select": "document",
-                "customtypes": ["audiences"]
+                "customtypes": [
+                  "audiences"
+                ]
               }
             }
           }
@@ -226,7 +240,9 @@
         "config": {
           "label": "Booking enquiry team",
           "select": "document",
-          "customtypes": ["teams"]
+          "customtypes": [
+            "teams"
+          ]
         }
       },
       "eventbriteEvent": {
@@ -266,7 +282,9 @@
               "config": {
                 "label": "Policy",
                 "select": "document",
-                "customtypes": ["event-policies"]
+                "customtypes": [
+                  "event-policies"
+                ]
               }
             }
           }
@@ -276,7 +294,9 @@
         "type": "Select",
         "config": {
           "label": "Early registration",
-          "options": ["yes"]
+          "options": [
+            "yes"
+          ]
         }
       },
       "cost": {
@@ -298,7 +318,9 @@
         "config": {
           "label": "Booking enquiry team",
           "select": "document",
-          "customtypes": ["teams"]
+          "customtypes": [
+            "teams"
+          ]
         }
       },
       "onlineEventbriteEvent": {
@@ -338,7 +360,9 @@
               "config": {
                 "label": "Policy",
                 "select": "document",
-                "customtypes": ["event-policies"]
+                "customtypes": [
+                  "event-policies"
+                ]
               }
             }
           }
@@ -348,7 +372,9 @@
         "type": "Select",
         "config": {
           "label": "Early registration",
-          "options": ["yes"]
+          "options": [
+            "yes"
+          ]
         }
       },
       "onlineCost": {
@@ -369,14 +395,18 @@
               "config": {
                 "label": "Event",
                 "select": "document",
-                "customtypes": ["events"]
+                "customtypes": [
+                  "events"
+                ]
               }
             },
             "isNotLinked": {
               "type": "Select",
               "config": {
                 "label": "Suppress link to event",
-                "options": ["yes"]
+                "options": [
+                  "yes"
+                ]
               }
             }
           }
@@ -394,7 +424,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -402,7 +434,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {
@@ -498,7 +533,9 @@
               "config": {
                 "label": "Series",
                 "select": "document",
-                "customtypes": ["event-series"]
+                "customtypes": [
+                  "event-series"
+                ]
               }
             }
           }
@@ -514,7 +551,9 @@
               "config": {
                 "label": "Season",
                 "select": "document",
-                "customtypes": ["seasons"],
+                "customtypes": [
+                  "seasons"
+                ],
                 "placeholder": "Select a Season"
               }
             }
@@ -537,7 +576,9 @@
               "config": {
                 "label": "Parent",
                 "select": "document",
-                "customtypes": ["exhibitions"],
+                "customtypes": [
+                  "exhibitions"
+                ],
                 "placeholder": "Select a parent"
               }
             }

--- a/common/customtypes/exhibitions/index.json
+++ b/common/customtypes/exhibitions/index.json
@@ -138,9 +138,6 @@
             "textAndImage": {
               "type": "SharedSlice"
             },
-            "themeCardsList": {
-              "type": "SharedSlice"
-            },
             "titledTextList": {
               "type": "SharedSlice"
             }

--- a/common/customtypes/guides/index.json
+++ b/common/customtypes/guides/index.json
@@ -19,7 +19,9 @@
         "config": {
           "label": "Format",
           "select": "document",
-          "customtypes": ["guide-formats"]
+          "customtypes": [
+            "guide-formats"
+          ]
         }
       },
       "datePublished": {
@@ -47,10 +49,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -59,28 +67,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -89,19 +94,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }

--- a/common/customtypes/places/index.json
+++ b/common/customtypes/places/index.json
@@ -43,10 +43,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -55,28 +61,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -85,19 +88,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }

--- a/common/customtypes/projects/index.json
+++ b/common/customtypes/projects/index.json
@@ -19,7 +19,9 @@
         "config": {
           "label": "Format",
           "select": "document",
-          "customtypes": ["project-formats"]
+          "customtypes": [
+            "project-formats"
+          ]
         }
       },
       "start": {
@@ -46,10 +48,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -58,28 +66,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -88,19 +93,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }
@@ -118,7 +120,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -126,7 +130,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {
@@ -213,7 +220,9 @@
               "config": {
                 "label": "Season",
                 "select": "document",
-                "customtypes": ["seasons"],
+                "customtypes": [
+                  "seasons"
+                ],
                 "placeholder": "Select a Season"
               }
             }

--- a/common/customtypes/seasons/index.json
+++ b/common/customtypes/seasons/index.json
@@ -38,10 +38,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -50,28 +56,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -80,19 +83,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }

--- a/common/customtypes/series/index.json
+++ b/common/customtypes/series/index.json
@@ -19,7 +19,9 @@
         "config": {
           "label": "Format",
           "select": "document",
-          "customtypes": ["article-formats"]
+          "customtypes": [
+            "article-formats"
+          ]
         }
       },
       "color": {
@@ -46,10 +48,16 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "gifVideo": {
+            "audioPlayer": {
               "type": "SharedSlice"
             },
-            "iframe": {
+            "collectionVenue": {
+              "type": "SharedSlice"
+            },
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "contentList": {
               "type": "SharedSlice"
             },
             "editorialImage": {
@@ -58,28 +66,25 @@
             "editorialImageGallery": {
               "type": "SharedSlice"
             },
-            "map": {
-              "type": "SharedSlice"
-            },
-            "contentList": {
-              "type": "SharedSlice"
-            },
             "embed": {
               "type": "SharedSlice"
             },
-            "titledTextList": {
+            "gifVideo": {
               "type": "SharedSlice"
             },
-            "textAndImage": {
+            "iframe": {
               "type": "SharedSlice"
             },
-            "text": {
+            "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "map": {
+              "type": "SharedSlice"
+            },
+            "quote": {
               "type": "SharedSlice"
             },
             "searchResults": {
-              "type": "SharedSlice"
-            },
-            "textAndIcons": {
               "type": "SharedSlice"
             },
             "standfirst": {
@@ -88,19 +93,16 @@
             "tagList": {
               "type": "SharedSlice"
             },
-            "quote": {
+            "text": {
               "type": "SharedSlice"
             },
-            "infoBlock": {
+            "textAndIcons": {
               "type": "SharedSlice"
             },
-            "contact": {
+            "textAndImage": {
               "type": "SharedSlice"
             },
-            "collectionVenue": {
-              "type": "SharedSlice"
-            },
-            "audioPlayer": {
+            "titledTextList": {
               "type": "SharedSlice"
             }
           }
@@ -142,7 +144,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -150,7 +154,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {
@@ -246,7 +253,9 @@
               "config": {
                 "label": "Season",
                 "select": "document",
-                "customtypes": ["seasons"],
+                "customtypes": [
+                  "seasons"
+                ],
                 "placeholder": "Select a Season"
               }
             }

--- a/common/customtypes/visual-stories/index.json
+++ b/common/customtypes/visual-stories/index.json
@@ -19,7 +19,10 @@
         "config": {
           "label": "Related Document (e.g. Exhibition or Event)",
           "select": "document",
-          "customtypes": ["exhibitions", "events"]
+          "customtypes": [
+            "exhibitions",
+            "events"
+          ]
         }
       },
       "datePublished": {
@@ -47,28 +50,28 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
+            "contact": {
+              "type": "SharedSlice"
+            },
+            "editorialImage": {
+              "type": "SharedSlice"
+            },
+            "embed": {
+              "type": "SharedSlice"
+            },
             "infoBlock": {
+              "type": "SharedSlice"
+            },
+            "standfirst": {
+              "type": "SharedSlice"
+            },
+            "text": {
               "type": "SharedSlice"
             },
             "textAndIcons": {
               "type": "SharedSlice"
             },
             "textAndImage": {
-              "type": "SharedSlice"
-            },
-            "embed": {
-              "type": "SharedSlice"
-            },
-            "editorialImage": {
-              "type": "SharedSlice"
-            },
-            "text": {
-              "type": "SharedSlice"
-            },
-            "contact": {
-              "type": "SharedSlice"
-            },
-            "standfirst": {
               "type": "SharedSlice"
             }
           }

--- a/common/customtypes/webcomics/index.json
+++ b/common/customtypes/webcomics/index.json
@@ -19,7 +19,9 @@
         "config": {
           "label": "Format",
           "select": "document",
-          "customtypes": ["article-formats"]
+          "customtypes": [
+            "article-formats"
+          ]
         }
       },
       "image": {
@@ -40,37 +42,37 @@
         "fieldset": "Slice Zone",
         "config": {
           "choices": {
-            "embed": {
-              "type": "SharedSlice"
-            },
             "audioPlayer": {
-              "type": "SharedSlice"
-            },
-            "tagList": {
-              "type": "SharedSlice"
-            },
-            "iframe": {
-              "type": "SharedSlice"
-            },
-            "editorialImageGallery": {
               "type": "SharedSlice"
             },
             "editorialImage": {
               "type": "SharedSlice"
             },
+            "editorialImageGallery": {
+              "type": "SharedSlice"
+            },
+            "embed": {
+              "type": "SharedSlice"
+            },
             "gifVideo": {
               "type": "SharedSlice"
             },
-            "text": {
-              "type": "SharedSlice"
-            },
-            "standfirst": {
+            "iframe": {
               "type": "SharedSlice"
             },
             "infoBlock": {
               "type": "SharedSlice"
             },
             "quote": {
+              "type": "SharedSlice"
+            },
+            "standfirst": {
+              "type": "SharedSlice"
+            },
+            "tagList": {
+              "type": "SharedSlice"
+            },
+            "text": {
               "type": "SharedSlice"
             }
           }
@@ -88,7 +90,9 @@
               "config": {
                 "label": "Role",
                 "select": "document",
-                "customtypes": ["editorial-contributor-roles"]
+                "customtypes": [
+                  "editorial-contributor-roles"
+                ]
               }
             },
             "contributor": {
@@ -96,7 +100,10 @@
               "config": {
                 "label": "Contributor",
                 "select": "document",
-                "customtypes": ["people", "organisations"]
+                "customtypes": [
+                  "people",
+                  "organisations"
+                ]
               }
             },
             "description": {
@@ -192,7 +199,9 @@
               "config": {
                 "label": "Series",
                 "select": "document",
-                "customtypes": ["webcomic-series"]
+                "customtypes": [
+                  "webcomic-series"
+                ]
               }
             }
           }

--- a/common/prismicio-types.d.ts
+++ b/common/prismicio-types.d.ts
@@ -2788,7 +2788,6 @@ type ExhibitionsDocumentDataBodySlice =
   | TextSlice
   | TextAndIconsSlice
   | TextAndImageSlice
-  | ThemeCardsListSlice
   | TitledTextListSlice;
 
 type ExhibitionsDocumentDataOnwardJourneysSlice =


### PR DESCRIPTION
## What does this change?

`ThemeCardsList` was moved to Onward Journeys for exhibitions, so I wanted to remove it from the list of options for its Body.

I then though; hey, let's order them all alphabetically, because we have so many of them and I feel like it's not a great experience for Editorial. Or even for us, when we have to do it. I've no idea why they don't do it automatically.

https://github.com/user-attachments/assets/2ed82d2f-905a-4600-bbce-51f8e516b099

This did make me create a ["tidy up slices" ticket in the Backlog](https://github.com/wellcomecollection/wellcomecollection.org/issues/13122), because I don't think we should have that many that are unused. 

## How to test

I read them all one by one and found all the matching slices.
I also think that because `prismic-types` only shows the removed slice, it's proof it hasn't affected anything else.
Plus all the Bodies have the same number of lines.

## Have we considered potential risks?
I have but can't think of any as explained above.

Copilot agrees:

<img width="797" height="693" alt="Screenshot 2026-05-29 at 12 23 36" src="https://github.com/user-attachments/assets/e0f6539f-9033-4df3-b19f-f22cfa9937e1" />
