### PR TITLE
Hide search forms on works and CLP if kiosk mode is active

### DIFF
--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -3,6 +3,7 @@ import { SliceZone } from '@prismicio/react';
 import { NextPage } from 'next';
 import styled, { useTheme } from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { ImageType } from '@weco/common/model/image';
 import {
@@ -83,6 +84,7 @@ const CollectionsLandingPage: NextPage<Props> = ({
 }) => {
   const { data: collectionStats } = useCollectionStats();
   const theme = useTheme();
+  const isKiosk = useKiosk();
 
   return (
     <PageLayout
@@ -106,20 +108,22 @@ const CollectionsLandingPage: NextPage<Props> = ({
         </DecorativeEdgeContainer>
       </ContaineredLayout>
 
-      <div style={{ backgroundColor: theme.color('accent.lightBlue') }}>
-        <ContaineredLayout gridSizes={gridSize10(false)}>
-          <Space
-            $v={{ size: 'sm', properties: ['padding-top', 'padding-bottom'] }}
-          >
-            <SearchForm
-              searchCategory="works"
-              location="page"
-              isNew
-              hasAvailableOnlineOnly
-            />
-          </Space>
-        </ContaineredLayout>
-      </div>
+      {!isKiosk && (
+        <div style={{ backgroundColor: theme.color('accent.lightBlue') }}>
+          <ContaineredLayout gridSizes={gridSize10(false)}>
+            <Space
+              $v={{ size: 'sm', properties: ['padding-top', 'padding-bottom'] }}
+            >
+              <SearchForm
+                searchCategory="works"
+                location="page"
+                isNew
+                hasAvailableOnlineOnly
+              />
+            </Space>
+          </ContaineredLayout>
+        </div>
+      )}
 
       {hasValidThemeCardSlices(themeCardsListSlices) && (
         <MainBackground

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -1,10 +1,12 @@
 import { NextPage } from 'next';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Divider from '@weco/common/views/components/Divider';
 import SearchForm from '@weco/common/views/components/SearchForm';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -61,6 +63,7 @@ export const WorkPage: NextPage<Props> = ({
   transformedManifest,
 }) => {
   const { extendedViewer } = useFeatureFlags();
+  const isKiosk = useKiosk();
   const { userIsStaffWithRestricted } = useUserContext();
   const isArchive = !!(
     work.parts.length || getArchiveAncestorArray(work).length > 0
@@ -125,76 +128,89 @@ export const WorkPage: NextPage<Props> = ({
         apiToolbarLinks={createApiToolbarWorkLinks(work, apiUrl)}
         hideNewsletterPromo={true}
       >
-        <Container>
-          <Space $v={{ size: 'md', properties: ['padding-top'] }}>
-            <SearchForm searchCategory="works" location="page" />
-          </Space>
+        {!isKiosk && (
+          <Container>
+            <Space $v={{ size: 'md', properties: ['padding-top'] }}>
+              <SearchForm searchCategory="works" location="page" />
+            </Space>
 
-          <Space
-            $v={{ size: 'xs', properties: ['padding-top', 'padding-bottom'] }}
-          >
-            <BackToResults />
-          </Space>
-        </Container>
-
-        {isArchive ? (
-          <>
-            <Container>
-              <Space
-                $v={{
-                  size: 'xs',
-                  properties: ['padding-top', 'padding-bottom'],
-                }}
-              >
-                <ArchiveBreadcrumb work={work} />
-              </Space>
-            </Container>
-            <Container>
-              <WorkHeader
-                work={toWorkBasic(work)}
-                collectionManifestsCount={
-                  shouldShowItemLink ? collectionManifestsCount : undefined
-                }
-              />
-            </Container>
-
-            <Container>
-              <Divider />
-              <ArchiveDetailsContainer>
-                <ArchiveTree work={work} />
-                <WorkDetailsWrapper>
-                  <WorkDetails
-                    work={work}
-                    shouldShowItemLink={shouldShowItemLink}
-                    iiifImageLocation={iiifImageLocation}
-                    digitalLocation={digitalLocation}
-                    digitalLocationInfo={digitalLocationInfo}
-                    transformedManifest={transformedManifest}
-                  />
-                </WorkDetailsWrapper>
-              </ArchiveDetailsContainer>
-            </Container>
-          </>
-        ) : (
-          <>
-            <Container>
-              <WorkHeader
-                work={toWorkBasic(work)}
-                collectionManifestsCount={
-                  shouldShowItemLink ? collectionManifestsCount : undefined
-                }
-              />
-            </Container>
-            <WorkDetails
-              work={work}
-              shouldShowItemLink={shouldShowItemLink}
-              iiifImageLocation={iiifImageLocation}
-              digitalLocation={digitalLocation}
-              digitalLocationInfo={digitalLocationInfo}
-              transformedManifest={transformedManifest}
-            />
-          </>
+            <Space
+              $v={{ size: 'xs', properties: ['padding-top', 'padding-bottom'] }}
+            >
+              <BackToResults />
+            </Space>
+          </Container>
         )}
+
+        <ConditionalWrapper
+          condition={isKiosk}
+          wrapper={children => (
+            <Space $v={{ size: 'md', properties: ['padding-top'] }}>
+              {children}
+            </Space>
+          )}
+        >
+          <>
+            {isArchive ? (
+              <>
+                <Container>
+                  <Space
+                    $v={{
+                      size: 'xs',
+                      properties: ['padding-top', 'padding-bottom'],
+                    }}
+                  >
+                    <ArchiveBreadcrumb work={work} />
+                  </Space>
+                </Container>
+                <Container>
+                  <WorkHeader
+                    work={toWorkBasic(work)}
+                    collectionManifestsCount={
+                      shouldShowItemLink ? collectionManifestsCount : undefined
+                    }
+                  />
+                </Container>
+
+                <Container>
+                  <Divider />
+                  <ArchiveDetailsContainer>
+                    <ArchiveTree work={work} />
+                    <WorkDetailsWrapper>
+                      <WorkDetails
+                        work={work}
+                        shouldShowItemLink={shouldShowItemLink}
+                        iiifImageLocation={iiifImageLocation}
+                        digitalLocation={digitalLocation}
+                        digitalLocationInfo={digitalLocationInfo}
+                        transformedManifest={transformedManifest}
+                      />
+                    </WorkDetailsWrapper>
+                  </ArchiveDetailsContainer>
+                </Container>
+              </>
+            ) : (
+              <>
+                <Container>
+                  <WorkHeader
+                    work={toWorkBasic(work)}
+                    collectionManifestsCount={
+                      shouldShowItemLink ? collectionManifestsCount : undefined
+                    }
+                  />
+                </Container>
+                <WorkDetails
+                  work={work}
+                  shouldShowItemLink={shouldShowItemLink}
+                  iiifImageLocation={iiifImageLocation}
+                  digitalLocation={digitalLocation}
+                  digitalLocationInfo={digitalLocationInfo}
+                  transformedManifest={transformedManifest}
+                />
+              </>
+            )}
+          </>
+        </ConditionalWrapper>
 
         <StoriesOnWorks
           workId={work.id}


### PR DESCRIPTION
- For #13117

## What does this change?

- Adds conditionals in Collections Landing page and works pages to hide the Search Forms should the user be in Kiosk mode.
- I added a Conditional Wrapper in `/works/[id]` to add spacing at the top. It didn't look good otherwise as the title was really close to the top - it usually relies on the SearchForm's spacing.



## How to test


Would recommend reviewing the code [without whitespace](https://github.com/wellcomecollection/wellcomecollection.org/pull/13124/changes?w=1).

- [Activate kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- Visit [a work](https://www-dev.wellcomecollection.org/works/esd6gs3s)
- [Visit the CLP](https://www-dev.wellcomecollection.org/collections)
- The Searchbar shouldn't be there and the page should look good on iPads.
- Deactivate the mode and visit both pages again
- The search form should be there and no extra padding be added.

## Have we considered potential risks?
N/A