### PR TITLE
Change modes to default to `null` instead of `undefined`

### DIFF
--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -232,7 +232,7 @@ describe('getTogglesFromContext', () => {
       ],
     };
 
-    it('returns undefined when no cookie is set', () => {
+    it('returns null when no cookie is set', () => {
       const togglesResp = {
         ...defaultTogglesResp,
         modes: [modeDefinition],
@@ -240,9 +240,7 @@ describe('getTogglesFromContext', () => {
 
       const result = getTogglesFromContext(togglesResp, createContext());
 
-      expect(
-        (result.modes as Record<string, unknown>).kioskMode
-      ).toBeUndefined();
+      expect((result.modes as Record<string, unknown>).kioskMode).toBeNull();
     });
 
     it('returns the value when cookie matches a valid option', () => {
@@ -261,7 +259,7 @@ describe('getTogglesFromContext', () => {
       );
     });
 
-    it('returns undefined when cookie is an empty string', () => {
+    it('returns null when cookie is an empty string', () => {
       const togglesResp = {
         ...defaultTogglesResp,
         modes: [modeDefinition],
@@ -272,12 +270,10 @@ describe('getTogglesFromContext', () => {
         createContext({ toggle_kioskMode: '' })
       );
 
-      expect(
-        (result.modes as Record<string, unknown>).kioskMode
-      ).toBeUndefined();
+      expect((result.modes as Record<string, unknown>).kioskMode).toBeNull();
     });
 
-    it('returns undefined when cookie value is not a valid option', () => {
+    it('returns null when cookie value is not a valid option', () => {
       const togglesResp = {
         ...defaultTogglesResp,
         modes: [modeDefinition],
@@ -288,9 +284,7 @@ describe('getTogglesFromContext', () => {
         createContext({ toggle_kioskMode: 'invalid-ipad' })
       );
 
-      expect(
-        (result.modes as Record<string, unknown>).kioskMode
-      ).toBeUndefined();
+      expect((result.modes as Record<string, unknown>).kioskMode).toBeNull();
     });
   });
 });

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -85,7 +85,7 @@ export function getTogglesFromContext(
       cookieValue && mode.options.some(opt => opt.id === cookieValue);
     return {
       ...acc,
-      [mode.id]: isValid ? cookieValue : undefined,
+      [mode.id]: isValid ? cookieValue : null,
     };
   }, {} as Modes);
 

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -82,7 +82,8 @@ export function getTogglesFromContext(
   const modes = modesList.reduce((acc, mode) => {
     const cookieValue = allCookies[`toggle_${mode.id}`];
     const isValid =
-      cookieValue && mode.options.some(opt => opt.id === cookieValue);
+      typeof cookieValue === 'string' &&
+      mode.options.some(opt => opt.id === cookieValue);
     return {
       ...acc,
       [mode.id]: isValid ? cookieValue : null,

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -27,7 +27,7 @@ export type Tests = Record<TestId, boolean | undefined>;
 /**
  * Modes are included in serverData returned from getServerSideProps.
  * We use null for an inactive mode because undefined values in props are not
- * JSON-serializable in Next.js.
+ * JSON-serialisable in Next.js.
  */
 export type ModeValue = string | null;
 export type Modes = Record<ModeId, ModeValue>;

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -24,8 +24,12 @@ export type TogglesResp = {
 export type FeatureFlags = Record<FeatureFlagId, boolean | undefined>;
 export type Tests = Record<TestId, boolean | undefined>;
 
-/** A mode value is the selected option string, or undefined if inactive */
-export type ModeValue = string | undefined;
+/**
+ * Modes are included in serverData returned from getServerSideProps.
+ * We use null for an inactive mode because undefined values in props are not
+ * JSON-serializable in Next.js.
+ */
+export type ModeValue = string | null;
 export type Modes = Record<ModeId, ModeValue>;
 
 export type Toggles = {


### PR DESCRIPTION
## What does this change?

While testing https://github.com/wellcomecollection/wellcomecollection.org/pull/13120 I found the simulator was not working. The root cause was that `getTogglesFromContext` returned `undefined` for inactive modes, but `undefined` values are not JSON-serialisable in Next.js — so when `serverData` (including `toggles.modes`) was passed as `getServerSideProps` props, Next.js would throw a serialisation error.

The fix is to change the `ModeValue` type from `string | undefined` to `string | null`, and update `getTogglesFromContext` to return `null` for inactive modes rather than `undefined`. `null` serialises correctly through `getServerSideProps`.

Unlike feature flags (which always resolve to a boolean via `defaultValue`) or tests (which are not read directly from `serverData` props), modes are the only toggle type where the "inactive" state needs to be represented as an explicit serialisable value — which is why this issue only surfaces here.

### Changes:
- `toggles/webapp/index.ts`: update `ModeValue` type from `string | undefined` to `string | null`, with an explanatory comment
- `common/server-data/toggles.ts`: return `null` instead of `undefined` for inactive modes in `getTogglesFromContext`
- `common/server-data/toggles.test.ts`: update the three affected test assertions from `toBeUndefined()` to `toBeNull()`, and rename the test descriptions to match

## How to test
- Test with and without modes, they should still work as expected
- Run `yarn slicemachine` and test a slice in Simulator, it should load.

All tests should pass in here.

## Have we considered potential risks?

Any code that checks `modes.kioskMode === undefined` will no longer match — but because `ModeValue` was always meant to represent "inactive" rather than "missing", using a falsy check (`!kioskMode` or `!!kioskMode`) is the correct pattern and is already used throughout the codebase (e.g. `kiosk.tsx`, `[articleId].tsx`, `[seriesId].tsx`). There are no places in the codebase doing a strict `=== undefined` check on a mode value.
