### PR TITLE
Readd searchbar in collections landing page

### DIFF
--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -3,7 +3,6 @@ import { SliceZone } from '@prismicio/react';
 import { NextPage } from 'next';
 import styled, { useTheme } from 'styled-components';
 
-import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { ImageType } from '@weco/common/model/image';
 import {
@@ -84,7 +83,6 @@ const CollectionsLandingPage: NextPage<Props> = ({
 }) => {
   const { data: collectionStats } = useCollectionStats();
   const theme = useTheme();
-  const isKiosk = useKiosk();
 
   return (
     <PageLayout
@@ -108,22 +106,20 @@ const CollectionsLandingPage: NextPage<Props> = ({
         </DecorativeEdgeContainer>
       </ContaineredLayout>
 
-      {!isKiosk && (
-        <div style={{ backgroundColor: theme.color('accent.lightBlue') }}>
-          <ContaineredLayout gridSizes={gridSize10(false)}>
-            <Space
-              $v={{ size: 'sm', properties: ['padding-top', 'padding-bottom'] }}
-            >
-              <SearchForm
-                searchCategory="works"
-                location="page"
-                isNew
-                hasAvailableOnlineOnly
-              />
-            </Space>
-          </ContaineredLayout>
-        </div>
-      )}
+      <div style={{ backgroundColor: theme.color('accent.lightBlue') }}>
+        <ContaineredLayout gridSizes={gridSize10(false)}>
+          <Space
+            $v={{ size: 'sm', properties: ['padding-top', 'padding-bottom'] }}
+          >
+            <SearchForm
+              searchCategory="works"
+              location="page"
+              isNew
+              hasAvailableOnlineOnly
+            />
+          </Space>
+        </ContaineredLayout>
+      </div>
 
       {hasValidThemeCardSlices(themeCardsListSlices) && (
         <MainBackground


### PR DESCRIPTION
I removed it as part of https://github.com/wellcomecollection/wellcomecollection.org/issues/13117 but I wasn't mean to

## What does this change?

It re-adds the searchbar in kiosk mode in https://www-dev.wellcomecollection.org/collections


## How to test

- Be in kiosk mode
- https://www-dev.wellcomecollection.org/collections should have searchbar


## Have we considered potential risks?
N/A