### PR TITLE
Remove references to old `articles/[id]` urls

### DIFF
--- a/.buildkite/urls/expected_200_urls.txt
+++ b/.buildkite/urls/expected_200_urls.txt
@@ -37,24 +37,24 @@
 /works/d2mach47
 
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1638456535135800
-/articles/a-brief-history-of-tattoos
+/stories/a-brief-history-of-tattoos
 
 # https://wellcome.slack.com/archives/C8X9YKM5X/p1638800127140100
 /event-series/saturday-studio
-/articles/race--religion-and-the-black-madonna
+/stories/race--religion-and-the-black-madonna
 
 # https://github.com/wellcomecollection/wellcomecollection.org/issues/7438
 /exhibitions/heart-n-soul-s-wall-of-change
 
 # This is an article with a webcomics link in the "Try these next" section
-/articles/how-your-hairdresser-could-save-your-life
+/stories/how-your-hairdresser-could-save-your-life
 
 # This is an article with an event link in the "Try these next" section
-/articles/the-unearthly-children-of-science-fiction-s-cold-war
+/stories/the-unearthly-children-of-science-fiction-s-cold-war
 
 # This is an example of every content type in Prismic (as of November 2022)
 # This is an article which is the 'webcomics' type underneath
-/articles/the-mountain
+/stories/the-mountain
 /books/harlots--whores---hackabouts
 /event-series/smoke-and-mirrors-live-performances
 /events/racial-difference-in-the-anglophone-caribbean

--- a/.buildkite/urls/expected_404_urls.txt
+++ b/.buildkite/urls/expected_404_urls.txt
@@ -4,7 +4,7 @@
 /works/%E2%80%8Cqvku%E2%80%8Czu%E2%80%8C5w?wellcomeImagesUrl=/indexplus/image/L0025863.html
 
 # See https://github.com/wellcomecollection/wellcomecollection.org/issues/7417
-/articles/notfound
+/stories/notfound
 /books/notfound
 /exhibitions/notfound
 

--- a/cache/edge_lambdas/src/test_event_request.ts
+++ b/cache/edge_lambdas/src/test_event_request.ts
@@ -11,7 +11,7 @@ const request: CloudFrontRequestEvent = {
           eventType: 'origin-request',
         },
         request: {
-          uri: '/articles/things',
+          uri: '/stories/things',
           querystring: '',
           method: 'GET',
           clientIp: '2001:cdba::3257:9652',

--- a/cache/edge_lambdas/src/toggler.test.ts
+++ b/cache/edge_lambdas/src/toggler.test.ts
@@ -7,13 +7,16 @@ function copy(obj: unknown) {
 }
 
 test('x-toggled header gets added, and sends the cookie to the client', () => {
+  // Match the exact toggle_outro cookie key only; avoid substring matches like toggle_noutro.
+  const outroCookiePattern = /(^|;\s*)toggle_outro=(true|false)(;|$)/;
+
   abTesting.setTests([
     {
       id: 'outro',
       title: 'Outro',
       range: [0, 100],
       when: request => {
-        return !!request.uri.match(/^\/articles\/*/);
+        return !!request.uri.match(/^\/stories\/*/);
       },
     },
     {
@@ -32,12 +35,8 @@ test('x-toggled header gets added, and sends the cookie to the client', () => {
   const modifiedRequest = testEventRequest.Records[0].cf.request;
 
   // 1. set the new value on the cookie forwarded to the application
-  expect(oldRequest.headers.cookie[0].value).not.toMatch(
-    /toggle_outro=(true|false)/
-  );
-  expect(modifiedRequest.headers.cookie[0].value).toMatch(
-    /toggle_outro=(true|false)/
-  );
+  expect(oldRequest.headers.cookie[0].value).not.toMatch(outroCookiePattern);
+  expect(modifiedRequest.headers.cookie[0].value).toMatch(outroCookiePattern);
 
   // expect toggle_wontwork not to exist before or after modification
   expect(oldRequest.headers.cookie[0].value).not.toMatch(
@@ -50,7 +49,7 @@ test('x-toggled header gets added, and sends the cookie to the client', () => {
   // 2. set the x-toggled that will be forwarded to the response
   expect(oldRequest.headers['x-toggled']).toBeUndefined();
   expect(modifiedRequest.headers['x-toggled'][0].value).toMatch(
-    /toggle_outro=(true|false)/
+    outroCookiePattern
   );
 
   abTesting.response(testEventResponse);
@@ -58,7 +57,7 @@ test('x-toggled header gets added, and sends the cookie to the client', () => {
 
   // 3. set cookie is set from x-toggled to lock the person in for the session
   expect(modifiedResponse.headers['set-cookie'][0].value).toMatch(
-    /toggle_outro=(true|false); Path=\/;/
+    /(^|;\s*)toggle_outro=(true|false); Path=\/;$/
   );
 });
 

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -234,7 +234,7 @@ export function articleLd(article: Article): JsonLdObj {
       image: article.promo?.image?.contentUrl,
       // TODO: isPartOf
       publisher: orgLd(wellcomeCollectionGallery),
-      url: `https://wellcomecollection.org/stories/${article.id}`,
+      url: `https://wellcomecollection.org/stories/${article.uid}`,
     },
     { type: 'Article' }
   );
@@ -276,7 +276,7 @@ export function articleLdContentApi(article: ArticleContentApi) {
           : undefined,
       image: article.image?.url,
       publisher: orgLd(wellcomeCollectionGallery),
-      url: `https://wellcomecollection.org/stories/${article.id}`,
+      url: `https://wellcomecollection.org/stories/${article.uid}`,
     },
     { type: 'Article' }
   );

--- a/content/webapp/services/prismic/transformers/json-ld.ts
+++ b/content/webapp/services/prismic/transformers/json-ld.ts
@@ -234,7 +234,7 @@ export function articleLd(article: Article): JsonLdObj {
       image: article.promo?.image?.contentUrl,
       // TODO: isPartOf
       publisher: orgLd(wellcomeCollectionGallery),
-      url: `https://wellcomecollection.org/articles/${article.id}`,
+      url: `https://wellcomecollection.org/stories/${article.id}`,
     },
     { type: 'Article' }
   );
@@ -276,7 +276,7 @@ export function articleLdContentApi(article: ArticleContentApi) {
           : undefined,
       image: article.image?.url,
       publisher: orgLd(wellcomeCollectionGallery),
-      url: `https://wellcomecollection.org/articles/${article.id}`,
+      url: `https://wellcomecollection.org/stories/${article.id}`,
     },
     { type: 'Article' }
   );

--- a/content/webapp/utils/rss.ts
+++ b/content/webapp/utils/rss.ts
@@ -43,7 +43,7 @@ export async function buildStoriesRss(req) {
     rssFeed.item({
       title: asText(data.title) as string,
       description,
-      url: `https://wellcomecollection.org/articles/${story.id}`,
+      url: `https://wellcomecollection.org/stories/${story.id}`,
       author: contributors.join(', '),
       date: story.first_publication_date,
     });

--- a/content/webapp/utils/rss.ts
+++ b/content/webapp/utils/rss.ts
@@ -43,7 +43,7 @@ export async function buildStoriesRss(req) {
     rssFeed.item({
       title: asText(data.title) as string,
       description,
-      url: `https://wellcomecollection.org/stories/${story.id}`,
+      url: `https://wellcomecollection.org/stories/${story.uid || story.id}`,
       author: contributors.join(', '),
       date: story.first_publication_date,
     });

--- a/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
+++ b/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
@@ -110,7 +110,7 @@ const ComicPreviousNext: FunctionComponent<Props> = ({ previous, next }) => {
   return (
     <Root data-component="comic-previous-next">
       {previous && (
-        <Link href={`/articles/${previous.id}`} $isNext={false}>
+        <Link href={`/stories/${previous.id}`} $isNext={false}>
           <Inner $isNext={false}>
             <TextWrap $isNext={false}>
               <InSeries>Previous in this series</InSeries>
@@ -123,7 +123,7 @@ const ComicPreviousNext: FunctionComponent<Props> = ({ previous, next }) => {
         </Link>
       )}
       {next && (
-        <Link href={`/articles/${next.id}`} $isNext={true}>
+        <Link href={`/stories/${next.id}`} $isNext={true}>
           <Inner $isNext={true}>
             <TextWrap $isNext={true}>
               <InSeries>Next in this series</InSeries>

--- a/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
+++ b/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
@@ -110,7 +110,7 @@ const ComicPreviousNext: FunctionComponent<Props> = ({ previous, next }) => {
   return (
     <Root data-component="comic-previous-next">
       {previous && (
-        <Link href={`/stories/${previous.id}`} $isNext={false}>
+        <Link href={`/stories/${previous.uid}`} $isNext={false}>
           <Inner $isNext={false}>
             <TextWrap $isNext={false}>
               <InSeries>Previous in this series</InSeries>
@@ -123,7 +123,7 @@ const ComicPreviousNext: FunctionComponent<Props> = ({ previous, next }) => {
         </Link>
       )}
       {next && (
-        <Link href={`/stories/${next.id}`} $isNext={true}>
+        <Link href={`/stories/${next.uid}`} $isNext={true}>
           <Inner $isNext={true}>
             <TextWrap $isNext={true}>
               <InSeries>Next in this series</InSeries>

--- a/pa11y/webapp/report-and-deploy.js
+++ b/pa11y/webapp/report-and-deploy.js
@@ -36,8 +36,8 @@ const urls = [
   '/whats-on',
   '/collections',
   '/stories',
-  '/articles/the-birth-of-britain-s-national-health-service',
-  '/articles/art',
+  '/stories/the-birth-of-britain-s-national-health-service',
+  '/stories/art',
   '/works/cjwep3ze?query=health&page=1',
   '/works/e7vav3ss/items?page=1&canvas=1',
   '/works/d2mach47',
@@ -51,7 +51,7 @@ const urls = [
 
   // This is a comic using the new (as of November 2022) approach to
   // comic frames and navigation between issues.
-  '/articles/clinical-detachment',
+  '/stories/clinical-detachment',
 
   // Exhibition guides.  We should test one example of each guide format.
   '/guides/exhibitions/in-plain-sight/audio-without-descriptions',

--- a/prismic-model/scripts/lintPrismicData.ts
+++ b/prismic-model/scripts/lintPrismicData.ts
@@ -198,7 +198,7 @@ function detectBrokenInterpretationTypeLinks(doc: any): string[] {
 }
 
 // Contributor links that don't begin with http or https will be treated as
-// relative URLs on the front-end, e.g. www.example.com becomes wc.org/articles/www.example.com.
+// relative URLs on the front-end, e.g. www.example.com becomes wc.org/stories/www.example.com.
 //
 // This obviously isn't what we want; this will find any cases where the link
 // doesn't have an http[s] prefix.

--- a/prismic-model/scripts/tryAllContentPages.ts
+++ b/prismic-model/scripts/tryAllContentPages.ts
@@ -50,7 +50,7 @@ const nonVisibleTypes = new Set([
 function createUrl(prefix: string, { id, type }: PrismicDocument): string {
   switch (type) {
     case 'webcomics':
-      return `${prefix}/articles/${id}`;
+      return `${prefix}/stories/${id}`;
 
     case 'webcomic-series':
       return `${prefix}/series/${id}`;


### PR DESCRIPTION
## What does this change?

I noticed [here](https://buildkite.com/wellcomecollection/wc-dot-org-end-to-end-tests/builds/8022#019e8364-d536-40b3-b52a-39067fe5c95e) we were still testing `/articles/` links when we changed those to redirect to `/stories/` a while ago. It probably doesn't help the tests run smoothly if they have to deal with a redirect, so I changed those. We're not testing the redirect, here.

I also addressed a few other occurrences, just to align our language.

Copilot also pointed out we were still using the `id` for navigation for a lot of those when we'd moved to `uid` as principal mean of navigating. So I amended those.


## How to test

- Are tests happy here?
- Does it run ok locally?
- If you navigate prev/next here does it work well? https://www-dev.wellcomecollection.org/stories/targeted-adverts


## Have we considered potential risks?
N/A if tests are happy IMO?