### PR TITLE
remove toggle

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -104,14 +104,6 @@ const toggleConfig = {
       type: 'permanent',
     },
     {
-      id: 'extendedViewer',
-      title: 'Allow viewer to render video, audio and pdfs',
-      initialValue: false,
-      description:
-        'Displays a new version of the viewer that can render video, audio and pdfs in addition to images',
-      type: 'experimental',
-    },
-    {
       id: 'thematicBrowsing',
       title: 'Thematic browsing: category pages',
       initialValue: false,


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/11866
- Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/13129

## What does this change?

Removes the toggle from the toggles dash

## How to test

n/a

## Have we considered potential risks?

none as long as https://github.com/wellcomecollection/wellcomecollection.org/pull/13129 is deployed first