### PR TITLE
use stable v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - dependency-name: '@auth0/nextjs-auth0'
       - dependency-name: 'react-window'
       - dependency-name: 'undici'
+      - dependency-name: 'preactjs/compressed-size-action'
     groups:
       all:
         patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
       - dependency-name: '@auth0/nextjs-auth0'
       - dependency-name: 'react-window'
       - dependency-name: 'undici'
-      - dependency-name: 'preactjs/compressed-size-action'
     groups:
       all:
         patterns: ['*']

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: preactjs/compressed-size-action@v3
+      - uses: preactjs/compressed-size-action@v2
         with:
           build-script: "build-webapps"
           clean-script: "clean"


### PR DESCRIPTION
We started getting errors on the performance check that uses [compressed-size-action](https://github.com/preactjs/compressed-size-action)

It looks like dependabot erroneously updated us to v3 (which is a wip) 5 months ago and an update to it last week caused the failure.

There was a change to v3 in December "Automatically uses `yarn`, `pnpm`, `bun`, `deno`, or `npm ci` when lockfiles are present" was removed. And I think the change on Friday must have compiled this change into the action. So we now we would need to prefix the command with yarn ourselves.

## What does this change?

- Changes us back to using the stable v2 version

## How to test

The performance check on this PR works.

## Have we considered potential risks?

We forget to update to v3 when it is ready
