### PR TITLE
Show composite typography changes in storybook

### DIFF
--- a/cardigan/config/decorators.tsx
+++ b/cardigan/config/decorators.tsx
@@ -10,7 +10,7 @@ export const ContextDecorator: FunctionComponent<PropsWithChildren> = ({
 }) => {
   return (
     <ThemeProvider theme={theme}>
-      <GlobalStyle $compositeTypography={false} />
+      <GlobalStyle $compositeTypography={true} />
       <AppContextProvider>
         <div className="enhanced">{children}</div>
       </AppContextProvider>

--- a/cardigan/stories/global/typography/typography.stories.tsx
+++ b/cardigan/stories/global/typography/typography.stories.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
 import MoreLink from '@weco/content/views/components/MoreLink';
 
 const StarPlusStar = styled.div`
@@ -8,51 +7,6 @@ const StarPlusStar = styled.div`
     margin-top: 1.55em;
   }
 `;
-const Font = styled.div`
-  padding: 10px 0 25px;
-  border-bottom: 1px solid ${props => props.theme.color('neutral.500')};
-`;
-
-const FontName = styled.h2.attrs({
-  className: font('sans-bold', -2),
-})`
-  color: ${props => props.theme.color('accent.purple')};
-`;
-
-const sizes = [-2, -1, 0, 1, 2, 4, 5];
-const fontFamilies = ['sans', 'sans-bold', 'brand', 'brand-bold', 'mono'];
-
-const Typography = ({ text }) => {
-  return (
-    <div>
-      {fontFamilies.map(font => (
-        <div key={font}>
-          {sizes.map(size => (
-            <Font key={size}>
-              <FontName>
-                <code>
-                  font-{font} font-size-f{size}
-                </code>
-              </FontName>
-              <p
-                className={`font-size-f${size} font-${font}`}
-                style={{ marginBottom: 0 }}
-              >
-                {text}
-              </p>
-            </Font>
-          ))}
-        </div>
-      ))}
-    </div>
-  );
-};
-
-const Template = args => <Typography {...args} />;
-export const families = Template.bind({});
-families.args = {
-  text: 'The quick brown fox jumped over the lazy dog',
-};
 
 const MiscTemplate = () => (
   <>

--- a/common/views/components/CollapsibleContent/index.tsx
+++ b/common/views/components/CollapsibleContent/index.tsx
@@ -29,7 +29,7 @@ const Control = styled.button.attrs({
   color: inherit;
   display: flex;
   align-items: center;
-
+  line-height: 1;
   cursor: pointer;
   padding: 0;
 `;

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
@@ -23,6 +23,7 @@ const ScrollButtonsContainer = styled(Space)<{
 const ScrollButton = styled('button').attrs({
   className: font('sans', -2),
 })`
+  line-height: 1;
   color: var(--button-color);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- For #12482 

## What does this change?

Hardcodes the `compositeTypography` value (which comes from a toggle in the production apps) to `true`, so that we can get visual diffs of any changes, and potentially catch anything we might have missed in manual QA.

The only component that looked to me like it needed to be 'fixed' was `CollapsibleContent` where the normalize css line-height of `1.15` was previously being applied to the `button` so that the icon and text appeared to be vertically centred. Now the composite typography style is being applied, the line-height would become 1.5. I think the right thing to do here is deliberately make this line-height: 1 (not 1.15) so that it is definitely centred, not just nearly centred.

The typography scale story is no longer fit for purpose so I have removed it. I think we could add a view of the composite styles, but don't think it needs to be in this PR if we do choose to add it.

## How to test

- Look at the branch diff changes in Chromatic? [These were the first set](https://www.chromatic.com/build?appId=62f13cdbd0ff140768a8d87b&number=11024) which I approved, but I noticed that CollapsibleContent didn't look right. [Here's the fix for CollapsibleContent](https://www.chromatic.com/build?appId=62f13cdbd0ff140768a8d87b&number=11031)

## Have we considered potential risks?

n/a