### PR TITLE
Remove heading in onwards journeys section

### DIFF
--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -5,20 +5,14 @@ import styled from 'styled-components';
 import { ExhibitionsDocumentDataOnwardJourneysSlice } from '@weco/common/prismicio-types';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { gridSize12 } from '@weco/common/views/components/Layout';
-import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 import { components } from '@weco/common/views/slices';
-import SectionHeader from '@weco/content/views/components/SectionHeader';
 
 export const Wrapper = styled(Space).attrs({
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
   as: 'section',
 })`
   background: ${props => props.theme.color('warmNeutral.300')};
-`;
-
-const SectionHeaderWrapper = styled.div`
-  margin-bottom: ${props => props.theme.spacingUnits['100']};
 `;
 
 const ExhibitionCollectionsContent = ({
@@ -58,18 +52,6 @@ const ExhibitionCollectionsContent = ({
 
   return (
     <Wrapper>
-      <Container>
-        <SectionHeaderWrapper>
-          <SectionHeader title="Further reading" />
-        </SectionHeaderWrapper>
-        <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
-          <p>
-            Explore the subjects and stories inspired by the topics in the
-            exhibition
-          </p>
-        </Space>
-      </Container>
-
       <SliceZone
         // filter out videos if verticalVideos is false
         slices={onwardJourneys.filter(


### PR DESCRIPTION
- For #13079

[Slack request](https://wellcome.slack.com/archives/CUA669WHH/p1780998599119559?thread_ts=1780913765.473509&cid=CUA669WHH)

## What does this change?

Removed the container with the description and section heading


## How to test

Run https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage with [the toggle on](https://dash.wellcomecollection.org/toggles/?enableToggle=exhibitionAndCollection).


## Have we considered potential risks?
N/A