### PR TITLE
Body typography

### DIFF
--- a/common/utils/classnames.ts
+++ b/common/utils/classnames.ts
@@ -67,7 +67,7 @@ const fontCompositeMap: Partial<Record<string, string>> = {
   'mono:-1': 'type-caption-md-regular', // font('mono', -1) didn't have an exact match. This is the closest available
 };
 
-export function fontFamily(family: FontFamily): string {
+function fontFamily(family: FontFamily): string {
   return `font-${family}`;
 }
 

--- a/common/views/components/StackingTable/index.tsx
+++ b/common/views/components/StackingTable/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
-import { fontFamilyMixin } from '@weco/common/views/themes/typography';
+import { compositeTypographyMixin } from '@weco/common/views/themes/typography';
 
 type TableProps = {
   $useFixedWidth: boolean;
@@ -117,7 +117,10 @@ const StyledTd = styled(Space).attrs<TdProps>(props => ({
       white-space: nowrap;
       content: ${props =>
         props.$cellContent ? `'${props.$cellContent}'` : ''};
-      ${fontFamilyMixin('sans', true)}
+      ${compositeTypographyMixin('body', 'md', 'strong')}
+      font-size: inherit;
+      line-height: inherit;
+      letter-spacing: inherit;
     }
   }
 `;

--- a/common/views/components/StackingTable/index.tsx
+++ b/common/views/components/StackingTable/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
-import { compositeTypographyMixin } from '@weco/common/views/themes/typography';
+import { bodyStrongFontWeight } from '@weco/common/views/themes/typography';
 
 type TableProps = {
   $useFixedWidth: boolean;
@@ -117,10 +117,7 @@ const StyledTd = styled(Space).attrs<TdProps>(props => ({
       white-space: nowrap;
       content: ${props =>
         props.$cellContent ? `'${props.$cellContent}'` : ''};
-      ${compositeTypographyMixin('body', 'md', 'strong')}
-      font-size: inherit;
-      line-height: inherit;
-      letter-spacing: inherit;
+      font-weight: ${bodyStrongFontWeight};
     }
   }
 `;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -14,6 +14,9 @@ import { css } from 'styled-components';
 // version if we encounter a situation where it would be clearly beneficial
 // https://github.com/wellcomecollection/wellcomecollection.org/issues/12324
 
+export const bodyStrongFontWeight =
+  designSystemTheme.typography.body.strong?.lg?.fontWeight;
+
 export const compositeTypographyMixin = (
   category: 'body' | 'caption' | 'display' | 'label' | 'heading',
   size: TypographySizeKey,
@@ -198,10 +201,7 @@ export const typography = css`
 
     strong,
     b {
-      ${compositeTypographyMixin('body', 'lg', 'strong')}
-      font-size: inherit;
-      line-height: inherit;
-      letter-spacing: inherit;
+      font-weight: ${designSystemTheme.typography.body.strong?.lg?.fontWeight};
     }
   }
 

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -15,7 +15,7 @@ import { css } from 'styled-components';
 // https://github.com/wellcomecollection/wellcomecollection.org/issues/12324
 
 export const bodyStrongFontWeight =
-  designSystemTheme.typography.body.strong?.lg?.fontWeight;
+  designSystemTheme.typography.body.strong?.lg?.fontWeight ?? 'bold';
 
 export const compositeTypographyMixin = (
   category: 'body' | 'caption' | 'display' | 'label' | 'heading',
@@ -201,7 +201,7 @@ export const typography = css`
 
     strong,
     b {
-      font-weight: ${designSystemTheme.typography.body.strong?.lg?.fontWeight};
+      font-weight: ${bodyStrongFontWeight};
     }
   }
 

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -14,62 +14,43 @@ import { css } from 'styled-components';
 // version if we encounter a situation where it would be clearly beneficial
 // https://github.com/wellcomecollection/wellcomecollection.org/issues/12324
 
-const fontFamilies = {
-  sans: designSystemTheme.font.family.sans,
-  brand: designSystemTheme.font.family.brand,
-  mono: designSystemTheme.font.family.mono,
-};
+export const compositeTypographyMixin = (
+  category: 'body' | 'caption' | 'display' | 'label' | 'heading',
+  size: TypographySizeKey,
+  weight: 'regular' | 'strong',
+  family?: 'sans' | 'brand'
+) => {
+  const t = designSystemTheme.typography;
+  const weights: Partial<Record<'regular' | 'strong', SizeVariants>> =
+    category === 'heading'
+      ? t.heading[family ?? 'sans']
+      : category === 'body'
+        ? t.body
+        : category === 'display'
+          ? t.display
+          : category === 'caption'
+            ? t.caption
+            : t.label;
+  const style = weights[weight]?.[size];
 
-const fontSizeMixin = (size: -2 | -1 | 0 | 1 | 2 | 4 | 5) => css`
-  font-size: ${designSystemTheme.font.size[`f${size}`]};
-`;
-type FontFamily = keyof typeof fontFamilies;
+  if (!style) return css``;
 
-export const fontFamilyMixin = (
-  family: FontFamily,
-  isBold?: boolean
-): string => {
-  const weight = isBold
-    ? family === 'brand'
-      ? 'bold'
-      : 'semibold'
-    : 'regular';
-
-  return `
-  font-family: ${fontFamilies[family]};
-  font-weight: ${designSystemTheme.font.weight[weight]};
+  return css`
+    font-family: ${style.fontFamily};
+    font-weight: ${style.fontWeight};
+    font-size: ${style.fontSize};
+    line-height: ${style.lineHeight};
+    letter-spacing: ${style.letterSpacing};
   `;
 };
 
 export const typography = css`
-  .font-sans-bold {
-    ${fontFamilyMixin('sans', true)};
-  }
-
-  .font-sans {
-    ${fontFamilyMixin('sans')};
-  }
-
-  .font-brand-bold {
-    ${fontFamilyMixin('brand', true)};
-  }
-
-  .font-brand {
-    ${fontFamilyMixin('brand')};
-  }
-
-  .font-mono {
-    ${fontFamilyMixin('mono')};
-  }
-
   html {
     font-size: 100%;
   }
 
   body {
-    ${fontFamilyMixin('sans')}
-    ${fontSizeMixin(0)}
-    line-height: ${designSystemTheme['line-height'].lg};
+    ${compositeTypographyMixin('body', 'lg', 'regular')}
     color: ${props => props.theme.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
@@ -164,21 +145,16 @@ export const typography = css`
   }
 
   .body-text {
-    letter-spacing: 0.0044em;
-
     h1 {
-      ${fontFamilyMixin('brand', true)}
-      ${fontSizeMixin(4)}
+      ${compositeTypographyMixin('heading', 'xxl', 'strong', 'brand')}
     }
 
     h2 {
-      ${fontFamilyMixin('brand', true)}
-      ${fontSizeMixin(2)}
+      ${compositeTypographyMixin('heading', 'xl', 'strong', 'brand')}
     }
 
     h3 {
-      ${fontFamilyMixin('sans', true)}
-      ${fontSizeMixin(1)}
+      ${compositeTypographyMixin('body', 'xl', 'strong')}
     }
 
     *::selection {
@@ -222,12 +198,15 @@ export const typography = css`
 
     strong,
     b {
-      ${fontFamilyMixin('sans', true)};
+      ${compositeTypographyMixin('body', 'lg', 'strong')}
+      font-size: inherit;
+      line-height: inherit;
+      letter-spacing: inherit;
     }
   }
 
   .drop-cap {
-    ${fontFamilyMixin('brand', true)}
+    ${compositeTypographyMixin('heading', 'xl', 'strong', 'brand')}
     font-size: 3em;
     color: ${props => props.theme.color('black')};
     float: left;
@@ -259,7 +238,7 @@ export const typography = css`
     position: relative;
 
     &::before {
-      ${fontFamilyMixin('brand', true)}
+      ${compositeTypographyMixin('heading', 'xl', 'strong', 'brand')}
       position: absolute;
       content: '“';
       color: ${props => props.theme.color('accent.blue')};

--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.styles.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { font, fontFamily } from '@weco/common/utils/classnames';
+import { compositeTypography, font } from '@weco/common/utils/classnames';
 import AnimatedUnderlineCSS, {
   AnimatedUnderlineProps,
 } from '@weco/common/views/components/styled/AnimatedUnderline';
@@ -145,7 +145,11 @@ type InPageNavAnimatedLinkProps = {
 export const InPageNavAnimatedLink = styled(
   AnimatedLink
 ).attrs<InPageNavAnimatedLinkProps>(props => ({
-  className: fontFamily(props.$isActive ? 'sans-bold' : 'sans'),
+  className: compositeTypography(
+    'body',
+    'md',
+    props.$isActive ? 'strong' : 'regular'
+  ),
 }))<InPageNavAnimatedLinkProps>`
   color: ${props =>
     props.theme.color(


### PR DESCRIPTION
- For #12482 

## What does this change?

Body copy (largely driven by what we get back from Prismic) was still using font size/family mixins not _quite_ aligned with the new composite typography approach. This adds a compositeTypography mixin to unify the approach.

At the point we turn off the toggle (and stop using the `font` function), I think we should rename the `compositeTypography` helper (and this new mixin) to something a bit less verbose – I initially thought `type`, but I think that could cause issues as a reserved word in TypeScript, so maybe just `typography` (or `typo` – but maybe that sounds wrong?). But don't think it belongs in this PR. And any other name ideas welcome.

I accepted the [visual diff changes in Chromatic](https://www.chromatic.com/build?appId=62f13cdbd0ff140768a8d87b&number=11044) which were exclusively as the result of having removed the `letter-spacing` that we previously set on `body`.

## How to test

- Visit e.g. [an article](https://www-dev.wellcomecollection.org/stories/close-encounter-with-a-medieval-birth-scroll) and check body copy looks ok

## Have we considered potential risks?

Can't think of any