### PR TITLE
Add banners for Tenderness and Rage kiosk only

### DIFF
--- a/cardigan/stories/components/Banners/InfoBanner/InfoBanner.stories.tsx
+++ b/cardigan/stories/components/Banners/InfoBanner/InfoBanner.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof InfoBanner> = {
   argTypes: {
     variant: {
       control: { type: 'radio' },
-      options: ['default', 'websiteIssues'],
+      options: ['default', 'websiteIssues', 'kioskTRBanners'],
     },
     document: {
       table: { disable: true },

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -5,13 +5,13 @@ import {
   useContext,
 } from 'react';
 
-type KioskExperience = 'Tenderness and Rage' | 'Reading Room';
+type KioskExperienceName = 'Tenderness and Rage' | 'Reading Room';
 
 type KioskContextType = {
   isKiosk: boolean;
   isTendernessAndRageKiosk?: boolean;
   isReadingRoomKiosk?: boolean;
-  kioskExperience?: KioskExperience;
+  kioskExperienceName?: KioskExperienceName;
 };
 
 const KioskContext = createContext<KioskContextType>({ isKiosk: false });
@@ -27,7 +27,7 @@ export const useKiosk = (): KioskContextType => {
 
 export const getKioskExperienceName = (
   cookieContent: string | null
-): KioskExperience | undefined => {
+): KioskExperienceName | undefined => {
   if (!cookieContent) return undefined;
 
   const experienceId = cookieContent.split('-')[0];
@@ -54,7 +54,7 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
     <KioskContext.Provider
       value={{
         isKiosk: !!cookieContent,
-        kioskExperience: experienceName,
+        kioskExperienceName: experienceName,
         isTendernessAndRageKiosk: experienceName === 'Tenderness and Rage',
         isReadingRoomKiosk: experienceName === 'Reading Room',
       }}

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -9,12 +9,16 @@ type KioskExperienceName = 'Tenderness and Rage' | 'Reading Room';
 
 type KioskContextType = {
   isKiosk: boolean;
-  isTendernessAndRageKiosk?: boolean;
-  isReadingRoomKiosk?: boolean;
+  isTendernessAndRageKiosk: boolean;
+  isReadingRoomKiosk: boolean;
   kioskExperienceName?: KioskExperienceName;
 };
 
-const KioskContext = createContext<KioskContextType>({ isKiosk: false });
+const KioskContext = createContext<KioskContextType>({
+  isKiosk: false,
+  isTendernessAndRageKiosk: false,
+  isReadingRoomKiosk: false,
+});
 
 type KioskProviderProps = PropsWithChildren<{
   cookieContent: string | null;

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -5,11 +5,13 @@ import {
   useContext,
 } from 'react';
 
-type KioskExperience = 'TendernessAndRage' | 'ReadingRoom';
+type KioskExperience = 'Tenderness and Rage' | 'Reading Room';
 
 type KioskContextType = {
   isKiosk: boolean;
-  experience?: KioskExperience;
+  isTendernessAndRageKiosk?: boolean;
+  isReadingRoomKiosk?: boolean;
+  kioskExperience?: KioskExperience;
 };
 
 const KioskContext = createContext<KioskContextType>({ isKiosk: false });
@@ -23,27 +25,39 @@ export const useKiosk = (): KioskContextType => {
   return contextState;
 };
 
-export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
-  cookieContent,
-  children,
-}) => {
-  const experienceId = cookieContent?.split('-')[0];
-  let experienceName: KioskExperience | undefined;
+export const getKioskExperienceName = (
+  cookieContent: string | null
+): KioskExperience | undefined => {
+  if (!cookieContent) return undefined;
+
+  const experienceId = cookieContent.split('-')[0];
 
   switch (experienceId) {
     case 'RR':
-      experienceName = 'ReadingRoom';
-      break;
+      return 'Reading Room';
     case 'TR':
-      experienceName = 'TendernessAndRage';
-      break;
+      return 'Tenderness and Rage';
     default:
       break;
   }
 
+  return undefined;
+};
+
+export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
+  cookieContent,
+  children,
+}) => {
+  const experienceName = getKioskExperienceName(cookieContent);
+
   return (
     <KioskContext.Provider
-      value={{ isKiosk: !!cookieContent, experience: experienceName }}
+      value={{
+        isKiosk: !!cookieContent,
+        kioskExperience: experienceName,
+        isTendernessAndRageKiosk: experienceName === 'Tenderness and Rage',
+        isReadingRoomKiosk: experienceName === 'Reading Room',
+      }}
     >
       {children}
     </KioskContext.Provider>

--- a/common/views/components/InfoBanner/InfoBanner.TRKioskBanners.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.TRKioskBanners.tsx
@@ -10,12 +10,12 @@ import {
 } from './InfoBanners.styles';
 
 const TendernessAndRageKioskBanners = () => (
-  <>
+  <div data-component="kiosk-tr-banners">
     <BannerContainer
       $backgroundColor="warmNeutral.300"
       role="region"
-      aria-labelledby="note"
-      id="notification"
+      aria-label="audio-note"
+      id="audio-notification"
     >
       <BannerWrapper>
         <CopyContainer>
@@ -24,15 +24,19 @@ const TendernessAndRageKioskBanners = () => (
             $v={{ size: '2xs', properties: ['margin-top'] }}
           >
             <Icon icon={mute} />
-            <span className="visually-hidden" id="note">
-              Notification
+            <span className="visually-hidden" id="audio-note">
+              Sound notification
             </span>
           </Space>
           <Copy>Sound will not play on this device.</Copy>
         </CopyContainer>
       </BannerWrapper>
     </BannerContainer>
-    <BannerContainer role="region" aria-labelledby="note" id="notification">
+    <BannerContainer
+      role="region"
+      aria-labelledby="content-note"
+      id="content-notification"
+    >
       <BannerWrapper>
         <CopyContainer>
           <Space
@@ -40,8 +44,8 @@ const TendernessAndRageKioskBanners = () => (
             $v={{ size: '2xs', properties: ['margin-top'] }}
           >
             <Icon icon={exclamation} />
-            <span className="visually-hidden" id="note">
-              Notification
+            <span className="visually-hidden" id="content-note">
+              Content notification
             </span>
           </Space>
           <Copy>
@@ -55,7 +59,7 @@ const TendernessAndRageKioskBanners = () => (
         </CopyContainer>
       </BannerWrapper>
     </BannerContainer>
-  </>
+  </div>
 );
 
 export default TendernessAndRageKioskBanners;

--- a/common/views/components/InfoBanner/InfoBanner.TRKioskBanners.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.TRKioskBanners.tsx
@@ -1,0 +1,61 @@
+import { exclamation, mute } from '@weco/common/icons';
+import Icon from '@weco/common/views/components/Icon';
+import Space from '@weco/common/views/components/styled/Space';
+
+import {
+  BannerContainer,
+  BannerWrapper,
+  Copy,
+  CopyContainer,
+} from './InfoBanners.styles';
+
+const TendernessAndRageKioskBanners = () => (
+  <>
+    <BannerContainer
+      $backgroundColor="warmNeutral.300"
+      role="region"
+      aria-labelledby="note"
+      id="notification"
+    >
+      <BannerWrapper>
+        <CopyContainer>
+          <Space
+            $h={{ size: 'sm', properties: ['margin-right'] }}
+            $v={{ size: '2xs', properties: ['margin-top'] }}
+          >
+            <Icon icon={mute} />
+            <span className="visually-hidden" id="note">
+              Notification
+            </span>
+          </Space>
+          <Copy>Sound will not play on this device.</Copy>
+        </CopyContainer>
+      </BannerWrapper>
+    </BannerContainer>
+    <BannerContainer role="region" aria-labelledby="note" id="notification">
+      <BannerWrapper>
+        <CopyContainer>
+          <Space
+            $h={{ size: 'sm', properties: ['margin-right'] }}
+            $v={{ size: '2xs', properties: ['margin-top'] }}
+          >
+            <Icon icon={exclamation} />
+            <span className="visually-hidden" id="note">
+              Notification
+            </span>
+          </Space>
+          <Copy>
+            <strong>Content note:</strong> This material includes lived
+            experiences and historical perspectives on HIV and AIDS. Some works
+            reference illness, death, bereavement, stigma, racism, homophobia
+            and discrimination. Language may be dated or discriminatory, and
+            some imagery is explicit. For more information, please speak to a
+            member of staff.
+          </Copy>
+        </CopyContainer>
+      </BannerWrapper>
+    </BannerContainer>
+  </>
+);
+
+export default TendernessAndRageKioskBanners;

--- a/common/views/components/InfoBanner/README.mdx
+++ b/common/views/components/InfoBanner/README.mdx
@@ -10,4 +10,4 @@ The `WebsiteIssuesBanner` is for when we need to warn our users about issues acr
 ### KioskBanners
 The `KioskBanners` are for displaying information on kiosk screens. These banners are hardcoded and can be activated through the kiosk mode.
 
-[Edit this Readme on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/InfoBanners/README.mdx)
+[Edit this Readme on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/InfoBanner/README.mdx)

--- a/common/views/components/InfoBanner/README.mdx
+++ b/common/views/components/InfoBanner/README.mdx
@@ -7,4 +7,7 @@ The `InfoBanner` is generic and its content can be changed on Prismic, which is 
 ### WebsiteIssues Banner
 The `WebsiteIssuesBanner` is for when we need to warn our users about issues across the website. Prismic data might be unavailable as part of those issues and so we needed a hardcoded version to be able to communicate it to our users. It can be activated through one of our permanent Toggles.
 
+### KioskBanners
+The `KioskBanners` are for displaying information on kiosk screens. These banners are hardcoded and can be activated through the kiosk mode.
+
 [Edit this Readme on GitHub](https://github.com/wellcomecollection/wellcomecollection.org/edit/main/common/views/components/InfoBanners/README.mdx)

--- a/common/views/components/InfoBanner/index.tsx
+++ b/common/views/components/InfoBanner/index.tsx
@@ -19,10 +19,7 @@ const InfoBanner: FunctionComponent<Props> = props => {
   return (
     <>
       {variant === 'kioskTRBanners' ? (
-        <TendernessAndRageKioskBanners
-          data-component="kiosk-tr-banners"
-          {...props}
-        />
+        <TendernessAndRageKioskBanners />
       ) : variant === 'websiteIssues' ? (
         <WebsiteIssuesBanner
           data-component="website-issues-banner"

--- a/common/views/components/InfoBanner/index.tsx
+++ b/common/views/components/InfoBanner/index.tsx
@@ -3,20 +3,27 @@ import { FunctionComponent } from 'react';
 import InfoBannerDefault, {
   Props as DefaultBannerProps,
 } from './InfoBanner.Default';
+import TendernessAndRageKioskBanners from './InfoBanner.TRKioskBanners';
 import WebsiteIssuesBanner, {
   Props as WebsiteIssuesBannerProps,
 } from './InfoBanner.WebsiteIssues';
 
 type Props =
   | (DefaultBannerProps & { variant: 'default' })
-  | (WebsiteIssuesBannerProps & { variant: 'websiteIssues' });
+  | (WebsiteIssuesBannerProps & { variant: 'websiteIssues' })
+  | { variant: 'kioskTRBanners' };
 
 const InfoBanner: FunctionComponent<Props> = props => {
   const { variant } = props;
 
   return (
     <>
-      {variant === 'websiteIssues' ? (
+      {variant === 'kioskTRBanners' ? (
+        <TendernessAndRageKioskBanners
+          data-component="kiosk-tr-banners"
+          {...props}
+        />
+      ) : variant === 'websiteIssues' ? (
         <WebsiteIssuesBanner
           data-component="website-issues-banner"
           {...props}

--- a/common/views/layouts/PageLayout/index.tsx
+++ b/common/views/layouts/PageLayout/index.tsx
@@ -277,37 +277,44 @@ const PageLayoutComponent: NextPage<Props> = ({
           />
         )}
 
-        {skipToContentLinks.map(({ anchorId, label }) => (
-          <a
-            className="visually-hidden visually-hidden-focusable"
-            href={`#${anchorId}`}
-            key={anchorId}
-          >
-            {label}
-          </a>
-        ))}
-        <a className="visually-hidden visually-hidden-focusable" href="#main">
-          Skip to main content
-        </a>
+        {!isKiosk && (
+          <>
+            {skipToContentLinks.map(({ anchorId, label }) => (
+              <a
+                className="visually-hidden visually-hidden-focusable"
+                href={`#${anchorId}`}
+                key={anchorId}
+              >
+                {label}
+              </a>
+            ))}
+            <a
+              className="visually-hidden visually-hidden-focusable"
+              href="#main"
+            >
+              Skip to main content
+            </a>
 
-        {!hideHeader && !isKiosk && (
-          <Header siteSection={siteSection} {...headerProps} />
+            {!hideHeader && (
+              <Header siteSection={siteSection} {...headerProps} />
+            )}
+
+            {issuesBanner && <InfoBanner variant="websiteIssues" />}
+
+            {globalAlert.data.isShown === 'show' &&
+              (!globalAlert.data.routeRegex ||
+                urlString.match(new RegExp(globalAlert.data.routeRegex))) && (
+                <InfoBanner
+                  variant="default"
+                  document={globalAlert}
+                  cookieName={cookies.globalAlert}
+                  onVisibilityChange={isVisible => {
+                    globalInfoBar.setIsVisible(isVisible);
+                  }}
+                />
+              )}
+          </>
         )}
-
-        {issuesBanner && <InfoBanner variant="websiteIssues" />}
-
-        {globalAlert.data.isShown === 'show' &&
-          (!globalAlert.data.routeRegex ||
-            urlString.match(new RegExp(globalAlert.data.routeRegex))) && (
-            <InfoBanner
-              variant="default"
-              document={globalAlert}
-              cookieName={cookies.globalAlert}
-              onVisibilityChange={isVisible => {
-                globalInfoBar.setIsVisible(isVisible);
-              }}
-            />
-          )}
 
         {popupDialog?.data?.isShown &&
           (!popupDialog.data.routeRegex ||

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -5,7 +5,10 @@ import { ThemeProvider } from 'styled-components';
 
 import { ApmContextProvider } from '@weco/common/contexts/ApmContext';
 import { AppContextProvider } from '@weco/common/contexts/AppContext';
-import { KioskProvider } from '@weco/common/contexts/KioskContext';
+import {
+  getKioskExperienceName,
+  KioskProvider,
+} from '@weco/common/contexts/KioskContext';
 import { SearchContextProvider } from '@weco/common/contexts/SearchContext';
 import { UserContextProvider } from '@weco/common/contexts/UserContext';
 import { useScrollTracking } from '@weco/common/hooks/useScrollTracking';
@@ -25,6 +28,7 @@ import { deserialiseProps } from '@weco/common/utils/json';
 import CivicUK from '@weco/common/views/components/CivicUK';
 import GlobalSvgDefinitions from '@weco/common/views/components/GlobalSvgDefinitions';
 import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
+import InfoBanner from '@weco/common/views/components/InfoBanner';
 import LoadingIndicator from '@weco/common/views/components/LoadingIndicator';
 import ErrorPage from '@weco/common/views/layouts/ErrorPage';
 import themeValues, { GlobalStyle } from '@weco/common/views/themes/default';
@@ -107,6 +111,7 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
   const serverData = isServerDataSet ? pageProps.serverData : defaultServerData;
 
   const kioskModeCookie = serverData.toggles.modes.kioskMode;
+  const experienceName = getKioskExperienceName(kioskModeCookie);
 
   useMaintainPageHeight();
 
@@ -172,6 +177,10 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
 
                   <GlobalSvgDefinitions />
                   <LoadingIndicator />
+
+                  {experienceName === 'Tenderness and Rage' && (
+                    <InfoBanner variant="kioskTRBanners" />
+                  )}
 
                   {displayCookieBanner && (
                     <CivicUK

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -369,6 +369,7 @@ export const themeValues = {
   },
   spacingUnits: designSystemStaticSpacing,
   navHeight: 85,
+  kioskTRBannersHeight: 172, // Specific to the iPad specs
   fontVerticalOffset: '0.15em',
   colors,
   color: getColor,

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
@@ -67,6 +68,7 @@ const ZoomedImage = dynamic(() => import('./ZoomedImage'), {
 
 type GridProps = {
   $isFullSupportBrowser: boolean;
+  $isTRKiosk?: boolean;
   $useFixedList?: boolean;
   $hasMultipleCanvases?: boolean;
 };
@@ -75,7 +77,7 @@ const Grid = styled.div<GridProps>`
   display: grid;
   height: ${props =>
     props.$isFullSupportBrowser
-      ? `calc(100vh - ${props.theme.navHeight}px)`
+      ? `calc(100vh - ${props.$isTRKiosk ? props.theme.kioskTRBannersHeight : props.theme.navHeight}px)`
       : 'auto'};
   overflow: hidden;
   grid-template-columns:
@@ -234,6 +236,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   } = useMemo(() => fromQuery(router.query), [router.query]);
   const [gridVisible, setGridVisible] = useState(false);
   const { isFullSupportBrowser } = useAppContext();
+  const { isTendernessAndRageKiosk } = useKiosk();
   const viewerRef = useRef<HTMLDivElement>(null);
   const mainAreaRef = useRef<HTMLDivElement>(null);
   const [isDesktopSidebarActive, setIsDesktopSidebarActive] = useState(true);
@@ -377,6 +380,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
       <Grid
         ref={viewerRef}
         $isFullSupportBrowser={isFullSupportBrowser}
+        $isTRKiosk={isTendernessAndRageKiosk}
         $useFixedList={useFixedSizeList}
         $hasMultipleCanvases={hasMultipleCanvases}
       >

--- a/content/webapp/views/pages/works/work/IIIFViewer/Thumbnails.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/Thumbnails.tsx
@@ -1,6 +1,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 
@@ -8,7 +9,7 @@ import { queryParamToArrayIndex } from '.';
 import IIIFCanvasThumbnail from './IIIFCanvasThumbnail';
 import { thumbnailsPageSize } from './Paginators';
 
-const ThumbnailsContainer = styled.div`
+const ThumbnailsContainer = styled.div<{ $isTRKiosk?: boolean }>`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-evenly;
@@ -17,7 +18,7 @@ const ThumbnailsContainer = styled.div`
   height: 1800px;
   ${props => `
     ${props.theme.media('lg')(`
-    height: calc(100vh - ${props.theme.navHeight}px);
+    height: calc(100vh - ${props.$isTRKiosk ? props.theme.kioskTRBannersHeight : props.theme.navHeight}px);
     `)}
   `}
 `;
@@ -31,6 +32,7 @@ const ThumbnailLink = styled(NextLink)`
 
 export const Thumbnails = () => {
   const { work, query, transformedManifest } = useItemViewerContext();
+  const { isTendernessAndRageKiosk } = useKiosk();
   const { canvases } = { ...transformedManifest };
   const navigationCanvases = canvases
     ? [...Array(thumbnailsPageSize)]
@@ -42,7 +44,7 @@ export const Thumbnails = () => {
     : [];
 
   return (
-    <ThumbnailsContainer id="xyz">
+    <ThumbnailsContainer id="xyz" $isTRKiosk={isTendernessAndRageKiosk}>
       {navigationCanvases &&
         navigationCanvases.map((canvas, i) => {
           const canvasParam =


### PR DESCRIPTION
- For #13153 
- Follows https://github.com/wellcomecollection/wellcomecollection.org/pull/13158

## What does this change?

- Tweaks context idea further, offering a boolean for finding out whether or not it's Tenderness & Rage or Reading Room. Might be overkill but it felt nicer than comparing `experienceName` to a string everywhere? More straightfoward?
- Adds a new variant to `InfoBanner` so I could use the same styles. To be honest I didn't focus too much on the a11y bits as it's only for public iPads, I mostly copy/pasted, flagged if there's an issue.
- Adds it in [Cardigan](https://62f13cdbd0ff140768a8d87b-hzdzvdbuvn.chromatic.com/?path=/story/components-banners-infobanner--basic&args=variant:kioskTRBanners)
- Hides other info banners on all kiosk modes
- Changes the height of the Thumbnails and ItemViewer if the experience is TR; it happened elsewhere that I chose to ignore (Identity and No Javascript bits) as they don't concern kiosk mode. The height is calculated off the very specifics of the devices we were told would be used.

## How to test

- Run locally
- View the website without a mode set
- View the website with a Reading Room mode; the banner should not display anywhere
- View the website with a T&R mode; the banner should display everywhere

## Have we considered potential risks?
I think the conditionals cover it all?