### PR TITLE
Bot crawler policy changes

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -5,7 +5,8 @@ User-agent: anthropic-ai
 Disallow: /
 
 User-agent: Applebot
-Disallow: /
+Disallow: /works/*/items
+Disallow: /_next/data/*/works/*/items
 
 User-agent: Applebot-Extended
 Disallow: /

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -13,13 +13,7 @@ Disallow: /
 User-agent: Bytespider
 Disallow: /
 
-User-agent: ChatGPT-User
-Disallow: /
-
 User-agent: ClaudeBot
-Disallow: /
-
-User-agent: Claude-SearchBot
 Disallow: /
 
 User-agent: Claude-Web
@@ -34,16 +28,10 @@ Disallow: /
 User-agent: magpie-crawler
 Disallow: /
 
-User-agent: OAI-SearchBot
-Disallow: /
-
 User-agent: omgili
 Disallow: /
 
 User-agent: omgilibot
-Disallow: /
-
-User-agent: PerplexityBot
 Disallow: /
 
 User-agent: PetalBot

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,13 +1,19 @@
 User-agent: *
 Allow: /
 
-User-agent: magpie-crawler
+User-agent: anthropic-ai
 Disallow: /
 
-User-Agent: omgili
+User-agent: Applebot
 Disallow: /
 
-User-Agent: omgilibot
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: ChatGPT-User
 Disallow: /
 
 User-agent: ClaudeBot
@@ -16,31 +22,31 @@ Disallow: /
 User-agent: Claude-Web
 Disallow: /
 
-User-agent: anthropic-ai
-Disallow: /
-
 User-agent: cohere-ai
 Disallow: /
 
-User-agent: Bytespider
+User-agent: GPTBot
+Disallow: /
+
+User-agent: magpie-crawler
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+User-agent: PerplexityBot
 Disallow: /
 
 User-agent: PetalBot
 Disallow: /
 
 User-agent: Scrapy
-Disallow: /
-
-User-agent: GPTBot
-Disallow: /
-
-User-agent: ChatGPT-User
-Disallow: /
-
-User-Agent: PerplexityBot
-Disallow: /
-
-User-agent: OAI-SearchBot
 Disallow: /
 
 User-agent: YandexAdditional

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -19,6 +19,9 @@ Disallow: /
 User-agent: ClaudeBot
 Disallow: /
 
+User-agent: Claude-SearchBot
+Disallow: /
+
 User-agent: Claude-Web
 Disallow: /
 

--- a/cache/README.md
+++ b/cache/README.md
@@ -125,7 +125,7 @@ terraform apply terraform.plan
 Automated Lambda function that keeps the WAF IP allowlist for Google bots up to date.
 
 **What it does:**
-- Fetches latest Google bot IP ranges from Google's published lists [of common](https://developers.google.com/static/crawling/ipranges/common-crawlers.json) and [special](https://developers.google.com/static/crawling/ipranges/special-crawlers.json) crawlers.
+- Fetches latest Google bot IP ranges from Google's published list of [common crawlers](https://developers.google.com/static/crawling/ipranges/common-crawlers.json). The special-crawlers list is intentionally excluded — those bots (AdsBot, APIs-Google, etc.) don't send a `Googlebot` user agent, so including their IPs serves no purpose given how the WAF rule is configured.
 - Updates the `google-bots` WAF IP set daily at 2 AM UTC
 - Has a 10% change gate to prevent unexpected large changes
 - Sends alerts on failures via SNS

--- a/cache/ip-updaters/google-bots.js
+++ b/cache/ip-updaters/google-bots.js
@@ -23,32 +23,22 @@ const wafClient = new WAFV2Client({ region: 'us-east-1' });
 const IP_SET_NAME = 'google-bots';
 const IP_SET_SCOPE = 'CLOUDFRONT';
 
-// Google's IP range sources
-const GOOGLE_IP_SOURCES = [
-  'https://developers.google.com/static/crawling/ipranges/common-crawlers.json',
-  'https://developers.google.com/static/crawling/ipranges/special-crawlers.json',
-];
+// Google's IP range source.
+// Only common-crawlers is needed: the WAF rule requires both a Google IP and
+// a "Googlebot" user-agent string, and special-crawlers (AdsBot, APIs-Google,
+// etc.) never send a Googlebot UA so their IPs would never satisfy both conditions.
+const GOOGLE_IP_SOURCE =
+  'https://developers.google.com/static/crawling/ipranges/common-crawlers.json';
 
 /**
- * Fetch all Google bot IPv4 addresses from both sources
+ * Fetch all Google bot IPv4 addresses
  */
 async function fetchGoogleBotIPs() {
   logInfo('Fetching Google bot IP ranges...');
 
-  const results = await Promise.all(
-    GOOGLE_IP_SOURCES.map(async url => {
-      try {
-        const data = await fetchJson(url);
-        return extractIpv4Addresses(data);
-      } catch (error) {
-        logError(`Error fetching ${url}: ${error}`);
-        throw error;
-      }
-    })
-  );
+  const data = await fetchJson(GOOGLE_IP_SOURCE);
+  const allIPs = extractIpv4Addresses(data);
 
-  // Flatten and deduplicate
-  const allIPs = [...new Set(results.flat())];
   logInfo(`Fetched ${allIPs.length} unique IPv4 addresses`);
 
   return allIPs.sort();

--- a/cache/ip-updaters/google-bots.js
+++ b/cache/ip-updaters/google-bots.js
@@ -37,7 +37,7 @@ async function fetchGoogleBotIPs() {
   logInfo('Fetching Google bot IP ranges...');
 
   const data = await fetchJson(GOOGLE_IP_SOURCE);
-  const allIPs = extractIpv4Addresses(data);
+  const allIPs = [...new Set(extractIpv4Addresses(data))];
 
   logInfo(`Fetched ${allIPs.length} unique IPv4 addresses`);
 

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -168,8 +168,29 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
 
     statement {
-      ip_set_reference_statement {
-        arn = var.google_bots_ip_set_arn
+      and_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = var.google_bots_ip_set_arn
+          }
+        }
+        statement {
+          byte_match_statement {
+            positional_constraint = "CONTAINS"
+            search_string         = "Googlebot"
+
+            field_to_match {
+              single_header {
+                name = "user-agent"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
       }
     }
 
@@ -630,75 +651,24 @@ resource "aws_wafv2_web_acl" "wc_org" {
             statement {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
-                search_string         = "PetalBot"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "ClaudeBot"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "GPTBot"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "GoogleOther"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
                 search_string         = "Applebot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "ChatGPT-User"
 
                 field_to_match {
                   single_header {
@@ -732,7 +702,41 @@ resource "aws_wafv2_web_acl" "wc_org" {
             statement {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
-                search_string         = "ChatGPT-User"
+                search_string         = "ClaudeBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "GoogleOther"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "GPTBot"
 
                 field_to_match {
                   single_header {
@@ -767,6 +771,23 @@ resource "aws_wafv2_web_acl" "wc_org" {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
                 search_string         = "PerplexityBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "PetalBot"
 
                 field_to_match {
                   single_header {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -668,23 +668,6 @@ resource "aws_wafv2_web_acl" "wc_org" {
             statement {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
-                search_string         = "ChatGPT-User"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
                 search_string         = "Claude-SearchBot"
 
                 field_to_match {
@@ -737,40 +720,6 @@ resource "aws_wafv2_web_acl" "wc_org" {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
                 search_string         = "GPTBot"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "OAI-SearchBot"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "PerplexityBot"
 
                 field_to_match {
                   single_header {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -695,6 +695,91 @@ resource "aws_wafv2_web_acl" "wc_org" {
                 }
               }
             }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "Applebot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "Claude-SearchBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "ChatGPT-User"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "OAI-SearchBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "PerplexityBot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
           }
         }
       }

--- a/cache/waf_shared_resources.tf
+++ b/cache/waf_shared_resources.tf
@@ -3,7 +3,7 @@
 
 resource "aws_wafv2_ip_set" "google_bots" {
   name        = "google-bots"
-  description = "Google bot IP ranges automatically updated from https://developers.google.com/static/crawling/ipranges/common-crawlers.json and https://developers.google.com/static/crawling/ipranges/special-crawlers.json"
+  description = "Google bot IP ranges automatically updated from https://developers.google.com/static/crawling/ipranges/common-crawlers.json"
 
   scope              = "CLOUDFRONT"
   ip_address_version = "IPV4"


### PR DESCRIPTION
- For #13144

# What's going on?

We use two controls to manage bot traffic:

- **`assets/robots.txt`** — signals to well-behaved bots that we don't want them to crawl. Advisory only; compliant bots will stop crawling after their next fetch of this file.
- **WAF rate-limiting rule `bot-user-agent-manual`** (`cache/modules/wc_org_cloudfront/waf.tf`) — caps all listed bots collectively at 300 requests per 60 seconds, regardless of robots.txt compliance. Takes effect immediately on deploy.

These two controls serve different purposes and don't need to match exactly. robots.txt is the long-term signal; the WAF is the immediate enforcement layer.

---

## robots.txt — bots we ask not to crawl at all

These are AI training crawlers with a clear rationale for blocking: they collect data to train models, not to serve user queries or power search results, so there's no discovery value to weigh against the crawling cost.

| Bot | Company | Why blocked |
|---|---|---|
| `anthropic-ai` | Anthropic | AI training crawler |
| `Applebot-Extended` | Apple | Apple Intelligence AI training (Apple's equivalent of GPTBot) |
| `Bytespider` | ByteDance (TikTok) | AI training crawler |
| `ClaudeBot` | Anthropic | AI training crawler |
| `Claude-Web` | Anthropic | Earlier Anthropic training crawler UA; possibly retired but harmless to keep |
| `cohere-ai` | Cohere | AI training crawler; not a consumer-facing search product |
| `GPTBot` | OpenAI | AI training crawler |

---

## robots.txt — bots to review

These are also in robots.txt but are not training crawlers. The rationale for blocking them is based on judgement rather than data — it's worth verifying against referral analytics before treating these as settled.

| Bot | Company | What it does | Assumption made | Worth revisiting? |
|---|---|---|---|---|
| `Applebot` | Apple | Siri and Spotlight indexing | That indexing individual viewer pages (`/works/{id}/items?canvas=NNN`) has no discovery value. Top-level works/exhibitions pages might be worth indexing. | Yes — see discussion in Notes below |
| `magpie-crawler` | Brandwatch | Social listening and brand monitoring | That brand monitoring has no value for us | Low priority — no user discovery impact either way |
| `omgili` / `omgilibot` | Webz.io | News and web content aggregation | That aggregation doesn't drive traffic back to us | Low priority |
| `PetalBot` | Huawei | Huawei Petal Search indexing | That Huawei Petal Search audience doesn't overlap with ours (UK market share is low but not zero) | Worth a quick referral analytics check |
| `Scrapy` | — | Generic Python scraping framework | Any request with the default Scrapy UA is a low-effort scraper, not a real bot | Reasonable assumption; keep |
| `YandexAdditional` / `YandexAdditionalBot` | Yandex | Supplementary Yandex crawlers (not core search) | That these are not meaningful SEO bots | Reasonable; core `Yandexbot` is not blocked |

---

## WAF rate-limiting rule

All bots in this list are subject to a collective rate limit of 300 requests per 60 seconds. The "In robots.txt?" column shows whether the bot is also asked not to crawl via robots.txt. For those that aren't, the reason is usually that they serve real-time user queries — fully disallowing them would mean we don't appear in those results, so the WAF rate limit is the only restriction.

| Bot | Company | Type | In robots.txt? | Notes |
|---|---|---|---|---|
| `Applebot` | Apple | Siri/Spotlight indexing | Partial* | Path-scoped for `/works/*/items` only; WAF rate limit is backstop |
| `Claude-SearchBot` | Anthropic | Real-time search crawler | No | Powers live Anthropic search results; disallowing would remove us from those results |
| `ClaudeBot` | Anthropic | AI training crawler | Yes | WAF is the backstop |
| `GoogleOther` | Google | Google internal/marketing tools | No | Not a named indexing crawler that respects robots.txt; was previously bypassing all rate limiting due to to being whitelisted along with all Google IPs |
| `GPTBot` | OpenAI | AI training crawler | Yes | WAF is the backstop |
| `PetalBot` | Huawei | Petal Search indexing | Yes | WAF is the backstop |

---

## Bots we don't restrict at all

- **`Googlebot`** — core Google Search SEO. Allowed unconditionally. The WAF `allow-google-bots` rule (priority 3) requires both a verified Google IP address **and** a `Googlebot` user agent, preventing spoofing and preventing other Google crawlers from getting the same free pass.
- **`bingbot`** — Microsoft Bing SEO. Falls through all rules as normal traffic.
- All other search engine crawlers — the AWS Bot Control rule `CategorySearchEngine` is set to count rather than block.

---

## Notes

**On the `allow-google-bots` WAF rule**: This rule was originally an IP-only allow that unconditionally bypassed all rate limiting for any Google IP address. It was updated to require both a Google IP *and* a `Googlebot` user agent. This means `GoogleOther` and other Google crawlers from Google IPs no longer bypass rate limiting.

The IP set is kept current by a Lambda (`cache/ip-updaters/google-bots.js`). As part of this change, that Lambda was updated to fetch only `common-crawlers.json` from Google's published IP ranges, removing `special-crawlers.json`. The special crawlers list covers bots like `AdsBot-Google` and `APIs-Google` which never send a `Googlebot` user agent, so their IPs can never satisfy both conditions of the updated rule and were redundant to include.

**On Applebot**: Confirmed genuine Apple infrastructure in June 2026 by cross-referencing all observed IP subnets against Apple's published list at `https://search.developer.apple.com/applebot.json` — all 9 /24 subnets matched exactly. Based on a single day's logs (9 June 2026), it was responsible for ~30% of all CloudFront cache misses due to systematically crawling `/works/{id}/items` pages with unique `canvas=NNN` query parameters, each of which creates a separate cache entry. This figure should be treated as indicative rather than a precise ongoing baseline.

**Discussion: should we allow Applebot on some paths?** Applebot powers Siri and Spotlight search, which is a legitimate discovery channel — someone asking Siri about Wellcome Collection or searching on an iPhone could surface indexed content. However, in practice the crawl we observed was almost entirely deep item viewer pages (`/works/{id}/items?canvas=243`, etc.), not exhibition, story, or search pages where Siri discovery would actually be useful. A path-scoped robots.txt entry would allow Apple to index the useful content while stopping the high-volume crawl:

```
User-agent: Applebot
Disallow: /works/*/items
Disallow: /_next/data/*/works/*/items
```

This is now implemented. The path-scoped disallows target the exact URLs Applebot was observed crawling (catalogue item pages and their Next.js data routes). This allows Apple to index top-level works and exhibitions while preventing the high-volume deep crawl (~1.97M requests/week in June 2026) of individual item canvas pages. The WAF rate limit (300 req/60s collective) acts as a backstop in case Applebot ignores robots.txt.

**On user agent spoofing**: The WAF rate-limit rule does not grant any additional trust to listed bots — it restricts them. A spoofer faking `PerplexityBot` is subject to the tighter 300 req/60s collective cap rather than the per-IP 2,500 req/60s blanket limit, so they are not better off. The `allow-google-bots` rule is the one that requires the most care, which is why it now combines IP verification with user agent matching.
