### PR TITLE
Add a "developer mode" to kiosk mode.

### DIFF
--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -5,10 +5,16 @@ import {
   useContext,
 } from 'react';
 
+import { KioskExperienceId } from '@weco/toggles';
+
+export const kioskExperienceNames = {
+  developerMode: 'Developer mode',
+  tendernessAndRage: 'Tenderness and Rage',
+  readingRoom: 'Reading Room',
+} as const;
+
 type KioskExperienceName =
-  | 'Developer mode'
-  | 'Tenderness and Rage'
-  | 'Reading Room';
+  (typeof kioskExperienceNames)[keyof typeof kioskExperienceNames];
 
 type KioskContextType = {
   isKiosk: boolean;
@@ -39,15 +45,15 @@ export const getKioskExperienceName = (
 ): KioskExperienceName | undefined => {
   if (!cookieContent) return undefined;
 
-  const experienceId = cookieContent.split('-')[0];
+  const experienceId = cookieContent.split('-')[0] as KioskExperienceId;
 
   switch (experienceId) {
     case 'RR':
-      return 'Reading Room';
+      return kioskExperienceNames.readingRoom;
     case 'TR':
-      return 'Tenderness and Rage';
+      return kioskExperienceNames.tendernessAndRage;
     case 'devMode':
-      return 'Developer mode';
+      return kioskExperienceNames.developerMode;
     default:
       break;
   }
@@ -66,9 +72,10 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
       value={{
         isKiosk: !!cookieContent,
         kioskExperienceName: experienceName,
-        isDevModeKiosk: experienceName === 'Developer mode',
-        isTendernessAndRageKiosk: experienceName === 'Tenderness and Rage',
-        isReadingRoomKiosk: experienceName === 'Reading Room',
+        isDevModeKiosk: experienceName === kioskExperienceNames.developerMode,
+        isTendernessAndRageKiosk:
+          experienceName === kioskExperienceNames.tendernessAndRage,
+        isReadingRoomKiosk: experienceName === kioskExperienceNames.readingRoom,
       }}
     >
       {children}

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -5,10 +5,14 @@ import {
   useContext,
 } from 'react';
 
-type KioskExperienceName = 'Tenderness and Rage' | 'Reading Room';
+type KioskExperienceName =
+  | 'Developer mode'
+  | 'Tenderness and Rage'
+  | 'Reading Room';
 
 type KioskContextType = {
   isKiosk: boolean;
+  isDevModeKiosk: boolean;
   isTendernessAndRageKiosk: boolean;
   isReadingRoomKiosk: boolean;
   kioskExperienceName?: KioskExperienceName;
@@ -16,6 +20,7 @@ type KioskContextType = {
 
 const KioskContext = createContext<KioskContextType>({
   isKiosk: false,
+  isDevModeKiosk: false,
   isTendernessAndRageKiosk: false,
   isReadingRoomKiosk: false,
 });
@@ -41,6 +46,8 @@ export const getKioskExperienceName = (
       return 'Reading Room';
     case 'TR':
       return 'Tenderness and Rage';
+    case 'devMode':
+      return 'Developer mode';
     default:
       break;
   }
@@ -59,6 +66,7 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
       value={{
         isKiosk: !!cookieContent,
         kioskExperienceName: experienceName,
+        isDevModeKiosk: experienceName === 'Developer mode',
         isTendernessAndRageKiosk: experienceName === 'Tenderness and Rage',
         isReadingRoomKiosk: experienceName === 'Reading Room',
       }}

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -29,7 +29,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
   const redirectTimerRef = useRef<NodeJS.Timeout | null>(null);
   const modalButtonRef = useRef<HTMLElement | null>(null);
 
-  // Don't run on the redirect destination itself, or if in developer mode
+  // Don't run outside kiosk mode, on the redirect destination itself, or if in developer mode
   const isRedirectDestination = router.asPath === redirectUrl;
   const shouldNotBeActive = !isKiosk || isDevModeKiosk || isRedirectDestination;
 

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -83,6 +83,8 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
 
   // Clean up on route changes
   useEffect(() => {
+    if (shouldNotBeActive) return;
+
     const handleRouteChange = () => {
       setIsWarningActive(false);
       setCountdown(WARNING_COUNTDOWN);
@@ -105,10 +107,12 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
     return () => {
       router.events.off('routeChangeStart', handleRouteChange);
     };
-  }, [router]);
+  }, [router, shouldNotBeActive]);
 
   // Countdown and redirect when warning is active
   useEffect(() => {
+    if (shouldNotBeActive) return;
+
     if (isWarningActive) {
       countdownTimerRef.current = setInterval(() => {
         setCountdown(prev => {
@@ -135,7 +139,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
         }
       };
     }
-  }, [isWarningActive, performRedirect]);
+  }, [shouldNotBeActive, isWarningActive, performRedirect]);
 
   // Set up activity listeners
   useEffect(() => {
@@ -176,8 +180,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
       }
     };
   }, [
-    isKiosk,
-    isRedirectDestination,
+    shouldNotBeActive,
     isWarningActive,
     handleUserActivity,
     resetInactivityTimer,

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 
 const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
-  const { isKiosk } = useKiosk();
+  const { isKiosk, isDevModeKiosk } = useKiosk();
   const router = useRouter();
   const [isWarningActive, setIsWarningActive] = useState(false);
   const [countdown, setCountdown] = useState(WARNING_COUNTDOWN);
@@ -29,8 +29,9 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
   const redirectTimerRef = useRef<NodeJS.Timeout | null>(null);
   const modalButtonRef = useRef<HTMLElement | null>(null);
 
-  // Don't run on the redirect destination itself
+  // Don't run on the redirect destination itself, or if in developer mode
   const isRedirectDestination = router.asPath === redirectUrl;
+  const shouldNotBeActive = !isKiosk || isDevModeKiosk || isRedirectDestination;
 
   const performRedirect = useCallback(
     ({ isAutomated }: { isAutomated: boolean }) => {
@@ -138,7 +139,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
 
   // Set up activity listeners
   useEffect(() => {
-    if (!isKiosk || isRedirectDestination) return;
+    if (shouldNotBeActive) return;
 
     if (isWarningActive) {
       return;
@@ -182,9 +183,7 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
     resetInactivityTimer,
   ]);
 
-  if (!isKiosk || isRedirectDestination) {
-    return null;
-  }
+  if (shouldNotBeActive) return null;
 
   return (
     <Modal

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -7,6 +7,7 @@ import { ApmContextProvider } from '@weco/common/contexts/ApmContext';
 import { AppContextProvider } from '@weco/common/contexts/AppContext';
 import {
   getKioskExperienceName,
+  kioskExperienceNames,
   KioskProvider,
 } from '@weco/common/contexts/KioskContext';
 import { SearchContextProvider } from '@weco/common/contexts/SearchContext';
@@ -178,7 +179,8 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                   <GlobalSvgDefinitions />
                   <LoadingIndicator />
 
-                  {experienceName === 'Tenderness and Rage' && (
+                  {experienceName ===
+                    kioskExperienceNames.tendernessAndRage && (
                     <InfoBanner variant="kioskTRBanners" />
                   )}
 

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -23,7 +23,8 @@ export type KioskModeOptionId = Extract<
 type ExtractPrefix<T extends string> = T extends `${infer Prefix}-${string}`
   ? Prefix
   : T;
-// The distinct experience prefixes stored in the kiosk cookie, e.g. 'devMode' | 'RR' | 'TR'.
+// The distinct experience prefixes derived from the kiosk cookie value, e.g. 'devMode' | 'RR' | 'TR'.
+// The cookie stores the full option ID (e.g. 'RR-iPad1'); the prefix is the part before the first '-'.
 // Exported for use across the codebase wherever the cookie prefix is parsed or compared.
 export type KioskExperienceId = ExtractPrefix<KioskModeOptionId>;
 

--- a/toggles/webapp/index.ts
+++ b/toggles/webapp/index.ts
@@ -11,6 +11,22 @@ export type FeatureFlagId = (typeof toggleConfig.featureFlags)[number]['id'];
 export type TestId = (typeof toggleConfig.tests)[number]['id'];
 export type ModeId = (typeof toggleConfig.modes)[number]['id'];
 
+// The full option IDs for the kioskMode toggle, e.g. 'devMode' | 'RR-iPad1' | 'TR-iPad1'.
+// Exported so the rest of the codebase can reference kiosk option IDs without hardcoding strings.
+export type KioskModeOptionId = Extract<
+  (typeof toggleConfig.modes)[number],
+  { id: 'kioskMode' }
+>['options'][number]['id'];
+
+// Extracts the experience prefix from a kiosk option ID.
+// e.g. 'RR-iPad1' -> 'RR', 'devMode' -> 'devMode'
+type ExtractPrefix<T extends string> = T extends `${infer Prefix}-${string}`
+  ? Prefix
+  : T;
+// The distinct experience prefixes stored in the kiosk cookie, e.g. 'devMode' | 'RR' | 'TR'.
+// Exported for use across the codebase wherever the cookie prefix is parsed or compared.
+export type KioskExperienceId = ExtractPrefix<KioskModeOptionId>;
+
 // As togglesConfig is what is served at https://toggles.wellcomecollection.org/toggles.json
 // This allows methods fetching that URL to type the data fetched
 export type TogglesResp = {

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -149,14 +149,6 @@ const toggleConfig = {
       type: 'experimental',
     },
     {
-      id: 'inGallery',
-      title: 'Gallery display mode',
-      initialValue: false,
-      description:
-        'Enables gallery-specific features such as removing external links and showing an inactivity redirect after a period of inactivity',
-      type: 'experimental',
-    },
-    {
       id: 'compositeTypography',
       title: 'Composite typography',
       initialValue: false,
@@ -177,6 +169,7 @@ const toggleConfig = {
       description:
         'Select which kiosk device this browser represents and it will activate kiosk-specific behaviour and layout.',
       options: [
+        { id: 'devMode', label: 'Developer mode' },
         { id: 'RR-iPad1', label: 'Reading Room: iPad 1' },
         { id: 'RR-iPad2', label: 'Reading Room: iPad 2' },
         { id: 'RR-iPad3', label: 'Reading Room: iPad 3' },

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -167,7 +167,7 @@ const toggleConfig = {
       id: 'kioskMode',
       title: 'Kiosk mode',
       description:
-        'Select which kiosk device this browser represents and it will activate kiosk-specific behaviour and layout.',
+        'Select which kiosk device this browser represents and it will activate kiosk-specific behaviour and layout. Developer mode is also available to allow testing of kiosk features without setting off the Inactivity modal.',
       options: [
         { id: 'devMode', label: 'Developer mode' },
         { id: 'RR-iPad1', label: 'Reading Room: iPad 1' },

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -172,7 +172,6 @@ const toggleConfig = {
         { id: 'devMode', label: 'Developer mode' },
         { id: 'RR-iPad1', label: 'Reading Room: iPad 1' },
         { id: 'RR-iPad2', label: 'Reading Room: iPad 2' },
-        { id: 'RR-iPad3', label: 'Reading Room: iPad 3' },
         { id: 'TR-iPad1', label: 'Tenderness & Rage: iPad 1' },
         { id: 'TR-iPad2', label: 'Tenderness & Rage: iPad 2' },
       ],


### PR DESCRIPTION
## What does this change?

Adds a "Developer mode" option to kiosk mode so I can test kiosk features without being endlessly redirected by the InactivityRedirect. You might think it's overkill, do let me know; I think it could be used for other things like filtering us out from analytics 🤷‍♀️ .

While I was in there, Claude flagged improvements for the `InactivityRedirect` component. Looks like previously the `useEffect`s for route cleanup, countdown timers, and activity listeners all ran even when they shouldn't have (outside kiosk mode, on the redirect destination, or in dev mode), because we can't return `null` until after the `useEffect`s. Now they all bail early via a shared `shouldNotBeActive` flag, so none of the listeners or timers fire when the redirect logic isn't active.

On the TypeScript side: the kiosk experience names are now defined as constants (`kioskExperienceNames`) and there are two new types derived directly from `toggleConfig` — `KioskModeOptionId` (the full option IDs like `'RR-iPad1'`) and `KioskExperienceId` (the cookie prefixes like `'RR'`, `'TR'`, `'devMode'`). Everything in the codebase that compares against these values now goes through those constants/types rather than raw strings, so a label change is a one-line edit.

Also removed an unused feature flag.

## How to test

I'll deploy the toggles when we're ready 🙈 In the meantime you can make sure the inactivity redirect works as expected.

## Have we considered potential risks?
We'll have to make sure Developer mode isn't used on the iPads, but then again that's the same risk as setting it for the wrong experience.


