### PR TITLE
Increase size above titles when breadcrumbs aren't rendered

### DIFF
--- a/common/views/components/PageHeader/PagerHeader.Basic.tsx
+++ b/common/views/components/PageHeader/PagerHeader.Basic.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { font } from '@weco/common/utils/classnames';
 import AccessibilityProvision from '@weco/common/views/components/AccessibilityProvision';
 import Breadcrumb from '@weco/common/views/components/Breadcrumb';
@@ -96,10 +97,12 @@ const BasicPageHeader: FunctionComponent<Props> = ({
   );
 
   const hasMedia = FeaturedMedia || HeroPicture;
+  const { isKiosk } = useKiosk();
 
-  // As <Breadcrumb> will automatically add "Home" as the first breadcrumb unless "noHomeLink" is true
-  // This checks whether or not there are actually any items.
+  // As <Breadcrumb> will automatically add "Home" as the first breadcrumb unless "noHomeLink" is true,
+  // this checks whether or not there are actually any visible items.
   const hasBreadcrumbItems =
+    !isKiosk &&
     breadcrumbs &&
     (breadcrumbs.items.length > 0 ||
       !(breadcrumbs.items.length === 0 && breadcrumbs.noHomeLink));
@@ -137,7 +140,7 @@ const BasicPageHeader: FunctionComponent<Props> = ({
             <ConditionalWrapper
               condition={!hasBreadcrumbItems}
               wrapper={children => (
-                <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+                <Space $v={{ size: 'lg', properties: ['margin-top'] }}>
                   {children}
                 </Space>
               )}

--- a/common/views/components/PageHeader/PagerHeader.Basic.tsx
+++ b/common/views/components/PageHeader/PagerHeader.Basic.tsx
@@ -104,8 +104,8 @@ const BasicPageHeader: FunctionComponent<Props> = ({
   const hasBreadcrumbItems =
     !isKiosk &&
     breadcrumbs &&
-    (breadcrumbs.items.length > 0 ||
-      !(breadcrumbs.items.length === 0 && breadcrumbs.noHomeLink));
+    (!breadcrumbs.noHomeLink ||
+      breadcrumbs.items.some(item => !item.isHidden));
 
   return (
     <>


### PR DESCRIPTION
- For #13105 

## What does this change?

Increases the size above titles when there aren't any breadcrumbs (or we've chosen not to render them).

<img width="725" height="536" alt="image" src="https://github.com/user-attachments/assets/21e3aeee-35dc-4585-808d-a17f81819def" />

## How to test

- Turn on a kiosk mode and visit a [story](https://www-dev.wellcomecollection.org/stories/medieval-doodles) – there should be more responsive space above the title

## Have we considered potential risks?

n/a
