### PR TITLE
Disallow /account and add Amazonbot to targeted bot control

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -9,6 +9,7 @@ User-agent: anthropic-ai
 Disallow: /
 
 User-agent: Applebot
+Disallow: /account
 Disallow: /works/*/items
 Disallow: /_next/data/*/works/*/items
 

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,5 +1,9 @@
 User-agent: *
 Allow: /
+Disallow: /account
+
+User-agent: Amazonbot
+Disallow: /
 
 User-agent: anthropic-ai
 Disallow: /

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -651,6 +651,24 @@ resource "aws_wafv2_web_acl" "wc_org" {
             statement {
               byte_match_statement {
                 positional_constraint = "CONTAINS"
+                search_string         = "Amazonbot"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
                 search_string         = "Applebot"
 
                 field_to_match {


### PR DESCRIPTION
- For #13144

## What does this change?

We've identified aggressive Amazonbot crawler activity hitting our site: **2.58M requests across June 2-5** (730K-850K per day), primarily targeting `/_next/static/chunks/` JavaScript bundles.

https://developer.amazon.com/amazonbot

**Changes:**
1. **robots.txt** - Added `Disallow: /` for Amazonbot (global block) and `Disallow: /account` for all bots
2. **WAF rule** - Added Amazonbot to `bot-user-agent-manual` rate-limiting rule (300 req/60s) as enforcement layer

**Design:**
- Amazonbot is completely blocked via robots.txt (respects RFC 9309 per their docs)
- Amzn-SearchBot remains allowed for Alexa search indexing, as well as Amzn-User for up-to-date query answers.
- `/account` blocked from all bots globally to protect auth endpoints
- WAF rule provides backup enforcement; if Amazonbot ignores robots.txt, WAF will rate-limit to 300 req/60s

## How to test

We will monitor it in Cloudfront

## Have we considered potential risks?
This is a reduce-noise change, not a high-risk addition. Standard CloudWatch metrics on the WAF rule will indicate if the blocks are working as expected.

## Notes

- Amazonbot is used for Amazon's AI model training and product data
- Amzn-SearchBot (different user-agent) remains allowed for Alexa search results
- `/account` protection benefits all bots—reduces attack surface for auth endpoints
