### PR TITLE
Adjust item viewer height on different kiosks

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -69,6 +69,7 @@ const ZoomedImage = dynamic(() => import('./ZoomedImage'), {
 type GridProps = {
   $isFullSupportBrowser: boolean;
   $isTRKiosk?: boolean;
+  $isNonTRKiosk?: boolean;
   $useFixedList?: boolean;
   $hasMultipleCanvases?: boolean;
 };
@@ -77,7 +78,9 @@ const Grid = styled.div<GridProps>`
   display: grid;
   height: ${props =>
     props.$isFullSupportBrowser
-      ? `calc(100vh - ${props.$isTRKiosk ? props.theme.kioskTRBannersHeight : props.theme.navHeight}px)`
+      ? props.$isNonTRKiosk
+        ? '100vh'
+        : `calc(100vh - ${props.$isTRKiosk ? props.theme.kioskTRBannersHeight : props.theme.navHeight}px)`
       : 'auto'};
   overflow: hidden;
   grid-template-columns:
@@ -236,7 +239,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   } = useMemo(() => fromQuery(router.query), [router.query]);
   const [gridVisible, setGridVisible] = useState(false);
   const { isFullSupportBrowser } = useAppContext();
-  const { isTendernessAndRageKiosk } = useKiosk();
+  const { isKiosk, isTendernessAndRageKiosk } = useKiosk();
   const viewerRef = useRef<HTMLDivElement>(null);
   const mainAreaRef = useRef<HTMLDivElement>(null);
   const [isDesktopSidebarActive, setIsDesktopSidebarActive] = useState(true);
@@ -256,6 +259,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     () => getTreeCanvasIndexById(archiveTree),
     [archiveTree]
   );
+  console.log({ isTendernessAndRageKiosk });
   const currentCanvas =
     transformedManifest?.canvases[queryParamToArrayIndex(canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };
@@ -381,6 +385,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         ref={viewerRef}
         $isFullSupportBrowser={isFullSupportBrowser}
         $isTRKiosk={isTendernessAndRageKiosk}
+        $isNonTRKiosk={isKiosk && !isTendernessAndRageKiosk}
         $useFixedList={useFixedSizeList}
         $hasMultipleCanvases={hasMultipleCanvases}
       >

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -259,7 +259,6 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     () => getTreeCanvasIndexById(archiveTree),
     [archiveTree]
   );
-  console.log({ isTendernessAndRageKiosk });
   const currentCanvas =
     transformedManifest?.canvases[queryParamToArrayIndex(canvas)];
   const mainImageService = { '@id': currentCanvas?.imageServiceId };

--- a/content/webapp/views/pages/works/work/IIIFViewer/Thumbnails.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/Thumbnails.tsx
@@ -9,7 +9,10 @@ import { queryParamToArrayIndex } from '.';
 import IIIFCanvasThumbnail from './IIIFCanvasThumbnail';
 import { thumbnailsPageSize } from './Paginators';
 
-const ThumbnailsContainer = styled.div<{ $isTRKiosk?: boolean }>`
+const ThumbnailsContainer = styled.div<{
+  $isTRKiosk?: boolean;
+  $isNonTRKiosk?: boolean;
+}>`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-evenly;
@@ -18,7 +21,7 @@ const ThumbnailsContainer = styled.div<{ $isTRKiosk?: boolean }>`
   height: 1800px;
   ${props => `
     ${props.theme.media('lg')(`
-    height: calc(100vh - ${props.$isTRKiosk ? props.theme.kioskTRBannersHeight : props.theme.navHeight}px);
+    height: ${props.$isNonTRKiosk ? '100vh' : `calc(100vh - ${props.$isTRKiosk ? props.theme.kioskTRBannersHeight : props.theme.navHeight}px)`};
     `)}
   `}
 `;
@@ -32,7 +35,7 @@ const ThumbnailLink = styled(NextLink)`
 
 export const Thumbnails = () => {
   const { work, query, transformedManifest } = useItemViewerContext();
-  const { isTendernessAndRageKiosk } = useKiosk();
+  const { isKiosk, isTendernessAndRageKiosk } = useKiosk();
   const { canvases } = { ...transformedManifest };
   const navigationCanvases = canvases
     ? [...Array(thumbnailsPageSize)]
@@ -44,7 +47,11 @@ export const Thumbnails = () => {
     : [];
 
   return (
-    <ThumbnailsContainer id="xyz" $isTRKiosk={isTendernessAndRageKiosk}>
+    <ThumbnailsContainer
+      id="xyz"
+      $isTRKiosk={isTendernessAndRageKiosk}
+      $isNonTRKiosk={isKiosk && !isTendernessAndRageKiosk}
+    >
       {navigationCanvases &&
         navigationCanvases.map((canvas, i) => {
           const canvasParam =


### PR DESCRIPTION


## What does this change?

Just noticed that the item viewer height was wrong when on a RR kiosk. This is because when we did the banners, we changed it for T&R, but didn't consider that other kiosk mode still didn't have a header, so shouldn't be `100vh - navHeight`. Tbf it was probably wrong before adding the banners but hey ho we'll get there !


## How to test

https://www-dev.wellcomecollection.org/works/dj9fxm66/items

View it with and without a kiosk mode, then try both RR and TR and make sure it looks good

## Have we considered potential risks?
N/A