### PR TITLE
Add dates to dashboard toggles

### DIFF
--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.StatusBadge.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.StatusBadge.tsx
@@ -13,9 +13,10 @@ const BadgeContainer = styled.div<{ $active: boolean }>`
     props.$active
       ? tokens.colors.success.light
       : tokens.colors.background.paper};
-  border: 1px solid
-    ${props =>
-      props.$active ? tokens.colors.success.main : tokens.colors.text.disabled};
+  border: ${props =>
+    props.$active
+      ? `4px double ${tokens.colors.success.main}`
+      : `1px solid ${tokens.colors.text.disabled}`};
   font-size: ${tokens.typography.fontSize.small};
   font-weight: 600;
   color: ${props =>

--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
@@ -9,18 +9,27 @@ type ToggleDatesProps = {
   children: ReactNode;
 };
 
-const formatDate = (isoString: string): string =>
-  new Date(isoString).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
+const formatDate = (isoString: string): string => {
+  // Display first 10 chars (YYYY-MM-DD format)
+  return isoString.slice(0, 10);
+};
 
 const calculateTimeAgo = (isoString: string): string => {
   const now = new Date();
   const then = new Date(isoString);
+
+  // Guard against invalid dates
+  if (isNaN(then.getTime())) {
+    return 'invalid date';
+  }
+
   const diffMs = now.getTime() - then.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  // Guard against future dates (treat as invalid)
+  if (diffDays < 0) {
+    return 'invalid date';
+  }
 
   const weeks = Math.round(diffDays / 7);
 
@@ -66,6 +75,7 @@ const Tooltip = styled.div<{ $visible: boolean }>`
 
 const HeadingWrapper = styled.div`
   position: relative;
+  cursor: help;
 `;
 
 const ToggleDates: FunctionComponent<ToggleDatesProps> = ({
@@ -83,7 +93,7 @@ const ToggleDates: FunctionComponent<ToggleDatesProps> = ({
       onMouseLeave={() => setShowTooltip(false)}
     >
       {children}
-      <Tooltip $visible={showTooltip}>
+      <Tooltip $visible={showTooltip} role="tooltip" aria-hidden={!showTooltip}>
         {dateCreated && (
           <div>
             <strong>Created:</strong> {formatDate(dateCreated)} (

--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
@@ -18,7 +18,7 @@ const calculateTimeAgo = (isoString: string): string => {
   const now = new Date();
   const then = new Date(isoString);
 
-  // Guard against invalid dates
+  // Guard against invalid dates or unparseable strings
   if (isNaN(then.getTime())) {
     return 'invalid date';
   }
@@ -26,7 +26,7 @@ const calculateTimeAgo = (isoString: string): string => {
   const diffMs = now.getTime() - then.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-  // Guard against future dates (treat as invalid)
+  // Guard against clock skew or future dates
   if (diffDays < 0) {
     return 'invalid date';
   }

--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
@@ -91,6 +91,8 @@ const ToggleDates: FunctionComponent<ToggleDatesProps> = ({
     <HeadingWrapper
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}
+      onFocusCapture={() => setShowTooltip(true)}
+      onBlurCapture={() => setShowTooltip(false)}
     >
       {children}
       <Tooltip $visible={showTooltip} role="tooltip" aria-hidden={!showTooltip}>

--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.ToggleDates.tsx
@@ -1,0 +1,104 @@
+import { FunctionComponent, ReactNode, useState } from 'react';
+import styled from 'styled-components';
+
+import { tokens } from '@weco/dash/views/themes/tokens';
+
+type ToggleDatesProps = {
+  dateCreated?: string;
+  dateActivated?: string;
+  children: ReactNode;
+};
+
+const formatDate = (isoString: string): string =>
+  new Date(isoString).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+const calculateTimeAgo = (isoString: string): string => {
+  const now = new Date();
+  const then = new Date(isoString);
+  const diffMs = now.getTime() - then.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  const weeks = Math.round(diffDays / 7);
+
+  if (weeks === 0) return 'less than a week ago';
+  return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+};
+
+const Tooltip = styled.div<{ $visible: boolean }>`
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: ${tokens.colors.text.primary};
+  color: ${tokens.colors.background.default};
+  padding: ${tokens.spacing.xs} ${tokens.spacing.sm};
+  border-radius: 4px;
+  font-size: ${tokens.typography.fontSize.small};
+  white-space: normal;
+  pointer-events: none;
+  opacity: ${props => (props.$visible ? 1 : 0)};
+  visibility: ${props => (props.$visible ? 'visible' : 'hidden')};
+  transition: opacity 200ms ease;
+  z-index: 10;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 4px solid ${tokens.colors.text.primary};
+  }
+
+  div {
+    line-height: 1.4;
+    white-space: nowrap;
+  }
+`;
+
+const HeadingWrapper = styled.div`
+  position: relative;
+`;
+
+const ToggleDates: FunctionComponent<ToggleDatesProps> = ({
+  dateCreated,
+  dateActivated,
+  children,
+}) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  if (!dateCreated && !dateActivated) return <>{children}</>;
+
+  return (
+    <HeadingWrapper
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      {children}
+      <Tooltip $visible={showTooltip}>
+        {dateCreated && (
+          <div>
+            <strong>Created:</strong> {formatDate(dateCreated)} (
+            {calculateTimeAgo(dateCreated)})
+          </div>
+        )}
+        {dateActivated && (
+          <div>
+            <strong>Activated:</strong> {formatDate(dateActivated)} (
+            {calculateTimeAgo(dateActivated)})
+          </div>
+        )}
+      </Tooltip>
+    </HeadingWrapper>
+  );
+};
+
+export default ToggleDates;

--- a/dash/webapp/views/pages/toggles/ListOfToggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '../toggles.styles';
 import CopyLinkIcon from './ListOfToggles.CopyLinkIcon';
 import StatusBadge from './ListOfToggles.StatusBadge';
+import ToggleDates from './ListOfToggles.ToggleDates';
 import ToggleSwitch from './ListOfToggles.ToggleSwitch';
 
 type ListOfTogglesProps = {
@@ -49,20 +50,30 @@ const ListOfToggles: FunctionComponent<ListOfTogglesProps> = ({
         {featureFlags.map(toggle => {
           const isPublicOn = toggle.defaultValue === true;
           const currentState = toggleStates[toggle.id];
-          const isOn = (currentState ?? toggle.defaultValue) === true;
+          const isOn = isPublicOn
+            ? true
+            : (currentState ?? toggle.defaultValue) === true;
 
           return (
             <ToggleListItem key={toggle.id} id={`toggle-${toggle.id}`}>
               <ToggleRow>
                 <ToggleInfo>
                   <ToggleHeadingRow>
-                    <h3
-                      style={{ margin: 0 }}
-                      aria-labelledby={`heading-${toggle.id}`}
+                    <ToggleDates
+                      dateCreated={toggle.dateCreated}
+                      dateActivated={toggle.dateActivated}
                     >
-                      <span id={`heading-${toggle.id}`}>{toggle.title}</span>{' '}
-                      <CopyLinkIcon toggleId={toggle.id} title={toggle.title} />
-                    </h3>
+                      <h3
+                        style={{ margin: 0, cursor: 'help' }}
+                        aria-labelledby={`heading-${toggle.id}`}
+                      >
+                        <span id={`heading-${toggle.id}`}>{toggle.title}</span>{' '}
+                        <CopyLinkIcon
+                          toggleId={toggle.id}
+                          title={toggle.title}
+                        />
+                      </h3>
+                    </ToggleDates>
                   </ToggleHeadingRow>
 
                   <div style={{ marginBottom: tokens.spacing.xs }}>

--- a/dash/webapp/views/pages/toggles/ListOfToggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/index.tsx
@@ -64,7 +64,7 @@ const ListOfToggles: FunctionComponent<ListOfTogglesProps> = ({
                       dateActivated={toggle.dateActivated}
                     >
                       <h3
-                        style={{ margin: 0, cursor: 'help' }}
+                        style={{ margin: 0 }}
                         aria-labelledby={`heading-${toggle.id}`}
                       >
                         <span id={`heading-${toggle.id}`}>{toggle.title}</span>{' '}

--- a/dash/webapp/views/pages/toggles/toggles.helpers.ts
+++ b/dash/webapp/views/pages/toggles/toggles.helpers.ts
@@ -7,6 +7,8 @@ export type FeatureFlag = {
   description: string;
   type: 'permanent' | 'experimental' | 'test' | 'stage';
   documentationLink?: string;
+  dateCreated?: string;
+  dateActivated?: string;
 };
 
 export type ToggleStates = { [id: string]: boolean | undefined };

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -39,19 +39,11 @@ export const withDefaultValuesUnmodified = (
       : matchingToggle.defaultValue;
 
     // Set dateCreated only when the toggle first appears in S3.
-    // Falls back to the date defined in the toggle definition for pre-existing
-    // toggles that were created before this field was introduced.
-    const dateCreated = isNew
-      ? (toggle.dateCreated ?? new Date().toISOString())
-      : (matchingToggle.dateCreated ?? toggle.dateCreated);
+    const dateCreated = matchingToggle?.dateCreated ?? new Date().toISOString();
 
     // Set dateActivated only when the deployed toggle is actually active.
-    // Preserve the existing value for toggles already in S3, or use the definition date if provided.
-    // Clear dateActivated if the toggle is inactive to avoid showing activation dates for off toggles.
     const dateActivated = defaultValue
-      ? isNew
-        ? (toggle.dateActivated ?? new Date().toISOString())
-        : (matchingToggle.dateActivated ?? toggle.dateActivated)
+      ? (matchingToggle?.dateActivated ?? new Date().toISOString())
       : undefined;
 
     const { initialValue, ...otherFields } = toggle;

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -38,13 +38,19 @@ export const withDefaultValuesUnmodified = (
       ? toggle.initialValue
       : matchingToggle.defaultValue;
 
-    // Set dateCreated only when the toggle first appears in S3.
-    const dateCreated = matchingToggle?.dateCreated ?? new Date().toISOString();
+    // Only set dates for experimental toggles
+    const isExperimental = toggle.type === 'experimental';
 
-    // Set dateActivated only when the deployed toggle is actually active.
-    const dateActivated = defaultValue
-      ? (matchingToggle?.dateActivated ?? new Date().toISOString())
+    // Set dateCreated only when the toggle first appears in S3 (experimental toggles only).
+    const dateCreated = isExperimental
+      ? (matchingToggle?.dateCreated ?? new Date().toISOString())
       : undefined;
+
+    // Set dateActivated only when the deployed toggle is actually active (experimental toggles only).
+    const dateActivated =
+      isExperimental && defaultValue
+        ? (matchingToggle?.dateActivated ?? new Date().toISOString())
+        : undefined;
 
     const { initialValue, ...otherFields } = toggle;
 

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -23,11 +23,9 @@ export const withDefaultValuesUnmodified = (
    */
   return definitions.map(toggle => {
     const matchingToggle = publishedToggles.find(({ id }) => id === toggle.id);
+    const isNew = typeof matchingToggle === 'undefined';
 
-    if (
-      typeof matchingToggle !== 'undefined' &&
-      matchingToggle.defaultValue !== toggle.initialValue
-    ) {
+    if (!isNew && matchingToggle.defaultValue !== toggle.initialValue) {
       info(
         `${toggle.id}: the published value is ${matchingToggle.defaultValue} and will not be replaced`
       );
@@ -36,16 +34,33 @@ export const withDefaultValuesUnmodified = (
       info('');
     }
 
-    const defaultValue =
-      typeof matchingToggle !== 'undefined'
-        ? matchingToggle?.defaultValue
-        : toggle.initialValue;
+    const defaultValue = isNew
+      ? toggle.initialValue
+      : matchingToggle.defaultValue;
+
+    // Set dateCreated only when the toggle first appears in S3.
+    // Falls back to the date defined in the toggle definition for pre-existing
+    // toggles that were created before this field was introduced.
+    const dateCreated = isNew
+      ? (toggle.dateCreated ?? new Date().toISOString())
+      : (matchingToggle.dateCreated ?? toggle.dateCreated);
+
+    // Set dateActivated when a new toggle starts as active; otherwise preserve the existing value.
+    // Falls back to the date defined in the toggle definition for pre-existing
+    // toggles that were activated before this field was introduced.
+    const dateActivated = isNew
+      ? toggle.initialValue
+        ? (toggle.dateActivated ?? new Date().toISOString())
+        : undefined
+      : (matchingToggle.dateActivated ?? toggle.dateActivated);
 
     const { initialValue, ...otherFields } = toggle;
 
     return {
       ...otherFields,
       defaultValue,
+      dateCreated,
+      dateActivated,
     };
   });
 };

--- a/toggles/webapp/deploy.ts
+++ b/toggles/webapp/deploy.ts
@@ -45,14 +45,14 @@ export const withDefaultValuesUnmodified = (
       ? (toggle.dateCreated ?? new Date().toISOString())
       : (matchingToggle.dateCreated ?? toggle.dateCreated);
 
-    // Set dateActivated when a new toggle starts as active; otherwise preserve the existing value.
-    // Falls back to the date defined in the toggle definition for pre-existing
-    // toggles that were activated before this field was introduced.
-    const dateActivated = isNew
-      ? toggle.initialValue
+    // Set dateActivated only when the deployed toggle is actually active.
+    // Preserve the existing value for toggles already in S3, or use the definition date if provided.
+    // Clear dateActivated if the toggle is inactive to avoid showing activation dates for off toggles.
+    const dateActivated = defaultValue
+      ? isNew
         ? (toggle.dateActivated ?? new Date().toISOString())
-        : undefined
-      : (matchingToggle.dateActivated ?? toggle.dateActivated);
+        : (matchingToggle.dateActivated ?? toggle.dateActivated)
+      : undefined;
 
     const { initialValue, ...otherFields } = toggle;
 

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -18,6 +18,9 @@ export async function setDefaultValueFor(client: S3Client): Promise<void> {
       return {
         ...toggle,
         defaultValue,
+        // dateActivated tracks the most recent activation. Cleared on deactivation
+        // so it only ever reflects a currently-active toggle's activation date.
+        dateActivated: defaultValue ? new Date().toISOString() : undefined,
       };
     }
     return toggle;

--- a/toggles/webapp/setDefaultValueFor.ts
+++ b/toggles/webapp/setDefaultValueFor.ts
@@ -15,12 +15,14 @@ export async function setDefaultValueFor(client: S3Client): Promise<void> {
     const arg = argv[toggle.id];
     if (arg && (arg === 'true' || arg === 'false')) {
       const defaultValue = arg === 'true';
+      const isExperimental = toggle.type === 'experimental';
       return {
         ...toggle,
         defaultValue,
-        // dateActivated tracks the most recent activation. Cleared on deactivation
-        // so it only ever reflects a currently-active toggle's activation date.
-        dateActivated: defaultValue ? new Date().toISOString() : undefined,
+        // dateActivated tracks the most recent activation (experimental toggles only).
+        // Cleared on deactivation so it only ever reflects a currently-active toggle's activation date.
+        dateActivated:
+          isExperimental && defaultValue ? new Date().toISOString() : undefined,
       };
     }
     return toggle;

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -6,8 +6,6 @@ type ToggleBase = {
   description: string;
   type: ToggleTypes;
   documentationLink?: string;
-  dateCreated?: string;
-  dateActivated?: string;
 };
 
 export type FeatureFlagDefinition = ToggleBase & {
@@ -16,6 +14,8 @@ export type FeatureFlagDefinition = ToggleBase & {
 
 export type PublishedFeatureFlag = ToggleBase & {
   defaultValue: boolean;
+  dateCreated?: string;
+  dateActivated?: string;
 };
 
 export type ABTest = {
@@ -111,7 +111,6 @@ const toggleConfig = {
       initialValue: false,
       description: 'Enables access to new thematic browsing category pages.',
       type: 'experimental',
-      dateCreated: '2026-01-23T00:00:00Z',
     },
     {
       id: 'thematicBrowsingSubCategory',
@@ -120,7 +119,6 @@ const toggleConfig = {
       description:
         'Enables access to new thematic browsing sub-category pages.',
       type: 'experimental',
-      dateCreated: '2026-02-26T00:00:00Z',
     },
     {
       id: 'semanticSearchPrototype',
@@ -129,7 +127,6 @@ const toggleConfig = {
       description:
         'Enables the semantic search prototype with predefined search terms and API selection. If enabled, please ensure the Semantic search comparison toggle is disabled.',
       type: 'experimental',
-      dateCreated: '2026-02-09T00:00:00Z',
     },
     {
       id: 'semanticSearchComparison',
@@ -138,7 +135,6 @@ const toggleConfig = {
       description:
         'Allows use of semantic searches and facilitates the display of the semantic search results side by side with the standard search results for comparison. If enabled, please ensure the Semantic search prototype toggle is disabled.',
       type: 'experimental',
-      dateCreated: '2026-02-12T00:00:00Z',
     },
     {
       id: 'exhibitionAndCollection',
@@ -146,8 +142,6 @@ const toggleConfig = {
       initialValue: false,
       description: 'Adds Collection content to Exhibition pages.',
       type: 'experimental',
-      dateCreated: '2026-04-02T00:00:00Z',
-      dateActivated: '2026-06-09T00:00:00Z',
     },
     {
       id: 'verticalVideos',
@@ -155,7 +149,6 @@ const toggleConfig = {
       initialValue: false,
       description: 'Allows testing of vertical videos.',
       type: 'experimental',
-      dateCreated: '2026-04-28T00:00:00Z',
     },
     {
       id: 'compositeTypography',
@@ -164,8 +157,6 @@ const toggleConfig = {
       description:
         'Uses the composite typography classes (.type-{x}) instead of the font classes (.font-{x}).',
       type: 'experimental',
-      dateCreated: '2026-06-03T00:00:00Z',
-      dateActivated: '2026-06-08T00:00:00Z',
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -10,10 +10,14 @@ type ToggleBase = {
 
 export type FeatureFlagDefinition = ToggleBase & {
   initialValue: boolean;
+  dateCreated?: string;
+  dateActivated?: string;
 };
 
 export type PublishedFeatureFlag = ToggleBase & {
   defaultValue: boolean;
+  dateCreated?: string;
+  dateActivated?: string;
 };
 
 export type ABTest = {
@@ -109,6 +113,7 @@ const toggleConfig = {
       initialValue: false,
       description: 'Enables access to new thematic browsing category pages.',
       type: 'experimental',
+      dateCreated: '2026-01-23',
     },
     {
       id: 'thematicBrowsingSubCategory',
@@ -117,6 +122,7 @@ const toggleConfig = {
       description:
         'Enables access to new thematic browsing sub-category pages.',
       type: 'experimental',
+      dateCreated: '2026-02-26',
     },
     {
       id: 'semanticSearchPrototype',
@@ -125,6 +131,7 @@ const toggleConfig = {
       description:
         'Enables the semantic search prototype with predefined search terms and API selection. If enabled, please ensure the Semantic search comparison toggle is disabled.',
       type: 'experimental',
+      dateCreated: '2026-02-09',
     },
     {
       id: 'semanticSearchComparison',
@@ -133,6 +140,7 @@ const toggleConfig = {
       description:
         'Allows use of semantic searches and facilitates the display of the semantic search results side by side with the standard search results for comparison. If enabled, please ensure the Semantic search prototype toggle is disabled.',
       type: 'experimental',
+      dateCreated: '2026-02-12',
     },
     {
       id: 'exhibitionAndCollection',
@@ -140,6 +148,8 @@ const toggleConfig = {
       initialValue: false,
       description: 'Adds Collection content to Exhibition pages.',
       type: 'experimental',
+      dateCreated: '2026-04-02',
+      dateActivated: '2026-06-09',
     },
     {
       id: 'verticalVideos',
@@ -147,14 +157,7 @@ const toggleConfig = {
       initialValue: false,
       description: 'Allows testing of vertical videos.',
       type: 'experimental',
-    },
-    {
-      id: 'inGallery',
-      title: 'Gallery display mode',
-      initialValue: false,
-      description:
-        'Enables gallery-specific features such as removing external links and showing an inactivity redirect after a period of inactivity',
-      type: 'experimental',
+      dateCreated: '2026-04-28',
     },
     {
       id: 'compositeTypography',
@@ -163,6 +166,8 @@ const toggleConfig = {
       description:
         'Uses the composite typography classes (.type-{x}) instead of the font classes (.font-{x}).',
       type: 'experimental',
+      dateCreated: '2026-06-03',
+      dateActivated: '2026-06-08',
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -6,18 +6,16 @@ type ToggleBase = {
   description: string;
   type: ToggleTypes;
   documentationLink?: string;
+  dateCreated?: string;
+  dateActivated?: string;
 };
 
 export type FeatureFlagDefinition = ToggleBase & {
   initialValue: boolean;
-  dateCreated?: string;
-  dateActivated?: string;
 };
 
 export type PublishedFeatureFlag = ToggleBase & {
   defaultValue: boolean;
-  dateCreated?: string;
-  dateActivated?: string;
 };
 
 export type ABTest = {
@@ -113,7 +111,7 @@ const toggleConfig = {
       initialValue: false,
       description: 'Enables access to new thematic browsing category pages.',
       type: 'experimental',
-      dateCreated: '2026-01-23',
+      dateCreated: '2026-01-23T00:00:00Z',
     },
     {
       id: 'thematicBrowsingSubCategory',
@@ -122,7 +120,7 @@ const toggleConfig = {
       description:
         'Enables access to new thematic browsing sub-category pages.',
       type: 'experimental',
-      dateCreated: '2026-02-26',
+      dateCreated: '2026-02-26T00:00:00Z',
     },
     {
       id: 'semanticSearchPrototype',
@@ -131,7 +129,7 @@ const toggleConfig = {
       description:
         'Enables the semantic search prototype with predefined search terms and API selection. If enabled, please ensure the Semantic search comparison toggle is disabled.',
       type: 'experimental',
-      dateCreated: '2026-02-09',
+      dateCreated: '2026-02-09T00:00:00Z',
     },
     {
       id: 'semanticSearchComparison',
@@ -140,7 +138,7 @@ const toggleConfig = {
       description:
         'Allows use of semantic searches and facilitates the display of the semantic search results side by side with the standard search results for comparison. If enabled, please ensure the Semantic search prototype toggle is disabled.',
       type: 'experimental',
-      dateCreated: '2026-02-12',
+      dateCreated: '2026-02-12T00:00:00Z',
     },
     {
       id: 'exhibitionAndCollection',
@@ -148,8 +146,8 @@ const toggleConfig = {
       initialValue: false,
       description: 'Adds Collection content to Exhibition pages.',
       type: 'experimental',
-      dateCreated: '2026-04-02',
-      dateActivated: '2026-06-09',
+      dateCreated: '2026-04-02T00:00:00Z',
+      dateActivated: '2026-06-09T00:00:00Z',
     },
     {
       id: 'verticalVideos',
@@ -157,7 +155,7 @@ const toggleConfig = {
       initialValue: false,
       description: 'Allows testing of vertical videos.',
       type: 'experimental',
-      dateCreated: '2026-04-28',
+      dateCreated: '2026-04-28T00:00:00Z',
     },
     {
       id: 'compositeTypography',
@@ -166,8 +164,8 @@ const toggleConfig = {
       description:
         'Uses the composite typography classes (.type-{x}) instead of the font classes (.font-{x}).',
       type: 'experimental',
-      dateCreated: '2026-06-03',
-      dateActivated: '2026-06-08',
+      dateCreated: '2026-06-03T00:00:00Z',
+      dateActivated: '2026-06-08T00:00:00Z',
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -14,6 +14,7 @@ export type FeatureFlagDefinition = ToggleBase & {
 
 export type PublishedFeatureFlag = ToggleBase & {
   defaultValue: boolean;
+  // Dates are only populated for experimental toggles
   dateCreated?: string;
   dateActivated?: string;
 };


### PR DESCRIPTION
- For #12615

## What does this change?

This will display a tooltip on hover over EXPERIMENTAL feature flags (didn't feel relevant for the others?), indicating when a toggle was added and when it was made public. This should help us in planning.

The "x week" numbers are rounded (up/down whatever is closest).

I've added the dates manually for the existing toggles, then deployed it to S3. The logic dictates they will stay as is (only write them if they are undefined to start with). From now on, dates will be added automatically when we deploy a new toggle (created date) and when we activate it (through the `setDefaultValue` script when the value is true), **but only if experimental**.

I also changed the "public" status border so it's a little bit more different to the "Internal" one, as Lauren asked for it to be more visually different - hopefully that's good enough.

<img width="788" height="203" alt="Screenshot 2026-06-15 at 17 17 57" src="https://github.com/user-attachments/assets/b8fd04fb-51d3-48e2-8e76-6550b031bd60" />


## How to test

Add a new experimental toggle to our list, deploy it, make sure it has an automated created date by looking here: https://toggles.wellcomecollection.org/toggles.json

Activate it publicly, a activation date should get added.

If you add a permanent toggle, no date should be added or displayed for it.

**Please remember to then remove it.**

You can view it in the dashboard by `cd dash/webapp && yarn dev` 
`yarn build` might be required first.

> [!NOTE]
> Halfway through I changed the dates from YYYY-MM-DD to ISO format. Because they'd already been pushed to S3 they didn't change. It's still supported.

## Have we considered potential risks?
Nah, it's an internal tool :) we don't touch anything that could make it show everything to the user.