### PR TITLE
Inactivity redirect URL logic

### DIFF
--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -22,6 +22,7 @@ type KioskContextType = {
   isTendernessAndRageKiosk: boolean;
   isReadingRoomKiosk: boolean;
   kioskExperienceName?: KioskExperienceName;
+  kioskHomepageUrl?: string;
 };
 
 const KioskContext = createContext<KioskContextType>({
@@ -65,17 +66,30 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
   cookieContent,
   children,
 }) => {
-  const experienceName = getKioskExperienceName(cookieContent);
+  const kioskExperienceName = getKioskExperienceName(cookieContent);
+
+  const isDevModeKiosk =
+    kioskExperienceName === kioskExperienceNames.developerMode;
+  const isTendernessAndRageKiosk =
+    kioskExperienceName === kioskExperienceNames.tendernessAndRage;
+  const isReadingRoomKiosk =
+    kioskExperienceName === kioskExperienceNames.readingRoom;
+
+  const kioskHomepageUrl = isTendernessAndRageKiosk
+    ? '/exhibitions/tenderness-and-rage/explore-more'
+    : isReadingRoomKiosk
+      ? '/stories/kiosk'
+      : undefined;
 
   return (
     <KioskContext.Provider
       value={{
         isKiosk: !!cookieContent,
-        kioskExperienceName: experienceName,
-        isDevModeKiosk: experienceName === kioskExperienceNames.developerMode,
-        isTendernessAndRageKiosk:
-          experienceName === kioskExperienceNames.tendernessAndRage,
-        isReadingRoomKiosk: experienceName === kioskExperienceNames.readingRoom,
+        kioskExperienceName,
+        isDevModeKiosk,
+        isTendernessAndRageKiosk,
+        isReadingRoomKiosk,
+        kioskHomepageUrl,
       }}
     >
       {children}

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -15,12 +15,8 @@ import InactivityRedirectModal from './InactivityRedirect.Modal';
 const INACTIVITY_TIMEOUT = 60 * 1000; // 60 seconds of inactivity before showing the warning modal
 const WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
 
-type Props = {
-  redirectUrl: string;
-};
-
-const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
-  const { isKiosk, isDevModeKiosk } = useKiosk();
+const InactivityRedirect: FunctionComponent = () => {
+  const { isKiosk, isDevModeKiosk, kioskHomepageUrl } = useKiosk();
   const router = useRouter();
   const [isWarningActive, setIsWarningActive] = useState(false);
   const [countdown, setCountdown] = useState(WARNING_COUNTDOWN);
@@ -30,8 +26,9 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
   const modalButtonRef = useRef<HTMLElement | null>(null);
 
   // Don't run outside kiosk mode, on the redirect destination itself, or if in developer mode
-  const isRedirectDestination = router.asPath === redirectUrl;
-  const shouldNotBeActive = !isKiosk || isDevModeKiosk || isRedirectDestination;
+  const isRedirectDestination = router.asPath === kioskHomepageUrl;
+  const shouldNotBeActive =
+    !isKiosk || isDevModeKiosk || !kioskHomepageUrl || isRedirectDestination;
 
   const performRedirect = useCallback(
     ({ isAutomated }: { isAutomated: boolean }) => {
@@ -41,9 +38,11 @@ const InactivityRedirect: FunctionComponent<Props> = ({ redirectUrl }) => {
         gtag('event', 'auto_reset');
       }
 
-      router.push(redirectUrl);
+      // kioskHomepageUrl is guaranteed to be defined here because shouldNotBeActive
+      // would have returned null if it were undefined
+      router.push(kioskHomepageUrl!);
     },
-    [router, redirectUrl]
+    [router, kioskHomepageUrl]
   );
 
   const resetInactivityTimer = useCallback(() => {

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -201,9 +201,7 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                     />
                   )}
 
-                  {!!kioskModeCookie && (
-                    <InactivityRedirect redirectUrl="/stories/kiosk" />
-                  )}
+                  {!!kioskModeCookie && <InactivityRedirect />}
                 </KioskProvider>
               </SearchContextProvider>
             </AppContextProvider>

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   const experienceName = getKioskExperienceName(kioskModeCookie);
 
   if (
-    !serverData.toggles.modes.kioskMode ||
+    !kioskModeCookie ||
     (experienceName !== kioskExperienceNames.readingRoom &&
       experienceName !== kioskExperienceNames.developerMode)
   ) {

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -36,7 +36,8 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   if (
     !serverData.toggles.modes.kioskMode ||
-    experienceName !== kioskExperienceNames.readingRoom
+    (experienceName !== kioskExperienceNames.readingRoom &&
+      experienceName !== kioskExperienceNames.developerMode)
   ) {
     return { notFound: true };
   }

--- a/content/webapp/pages/stories/kiosk.tsx
+++ b/content/webapp/pages/stories/kiosk.tsx
@@ -1,5 +1,9 @@
 import { NextPage } from 'next';
 
+import {
+  getKioskExperienceName,
+  kioskExperienceNames,
+} from '@weco/common/contexts/KioskContext';
 import { getServerData } from '@weco/common/server-data';
 import { serialiseProps } from '@weco/common/utils/json';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -27,7 +31,13 @@ export const getServerSideProps: ServerSidePropsOrAppError<
   setCacheControl(context.res);
   const serverData = await getServerData(context);
 
-  if (!serverData.toggles.modes.kioskMode) {
+  const kioskModeCookie = serverData.toggles.modes.kioskMode;
+  const experienceName = getKioskExperienceName(kioskModeCookie);
+
+  if (
+    !serverData.toggles.modes.kioskMode ||
+    experienceName !== kioskExperienceNames.readingRoom
+  ) {
     return { notFound: true };
   }
 


### PR DESCRIPTION
- For #13166

## What does this change?

I moved the logic inside the context and assigned a redirect URL based on what experience was active. It defaults to `undefined`, in which case the Modal shouldn't show at all.

I picked the T&R URLs based on the Slack chat.

Then I also blocked access to Stories kiosk outside of stories kiosk (or dev mode). 

## How to test

Run locally and try different modes, redirect should go where relevant.

## Have we considered potential risks?
N/A