### PR TITLE
Kiosk prev next browser

### DIFF
--- a/cardigan/stories/components/KioskNavigation/KioskNavigation.stories.tsx
+++ b/cardigan/stories/components/KioskNavigation/KioskNavigation.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { KioskProvider } from '@weco/common/contexts/KioskContext';
+import { HistoryProvider } from '@weco/common/hooks/useNavigationHistory';
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import { defaultServerData } from '@weco/common/server-data/types';
 import KioskNavigation from '@weco/content/views/components/KioskNavigation';
@@ -46,7 +47,9 @@ const meta: Meta<StoryArgs> = {
           cookieContent={context.args.kioskMode}
           readingRoomStories={{}}
         >
-          <Story />
+          <HistoryProvider>
+            <Story />
+          </HistoryProvider>
         </KioskProvider>
       </ServerDataContext.Provider>
     ),

--- a/common/hooks/useNavigationHistory.tsx
+++ b/common/hooks/useNavigationHistory.tsx
@@ -1,0 +1,87 @@
+import { useRouter } from 'next/router';
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+type HistoryContextType = {
+  back: () => void;
+  forward: () => void;
+  canGoBack: boolean;
+  canGoForward: boolean;
+};
+
+const HistoryContext = createContext<HistoryContextType | null>(null);
+
+export const HistoryProvider: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
+  const router = useRouter();
+  const [stack, setStack] = useState<string[]>([]);
+  const [index, setIndex] = useState(-1);
+  const isNavigatingRef = useRef(false);
+  const indexRef = useRef(-1);
+
+  // Keep indexRef in sync with index state
+  useEffect(() => {
+    indexRef.current = index;
+  }, [index]);
+
+  useEffect(() => {
+    const pathname = router.asPath;
+
+    // If we initiated this navigation via back/forward, don't modify the stack
+    if (isNavigatingRef.current) {
+      isNavigatingRef.current = false;
+      return;
+    }
+
+    setStack(prev => {
+      const newStack = prev.slice(0, indexRef.current + 1);
+      newStack.push(pathname);
+      return newStack;
+    });
+    setIndex(i => i + 1);
+  }, [router.asPath]);
+
+  const back = () => {
+    if (index > 0) {
+      isNavigatingRef.current = true;
+      setIndex(i => i - 1);
+      window.history.back();
+    }
+  };
+
+  const forward = () => {
+    if (index < stack.length - 1) {
+      isNavigatingRef.current = true;
+      setIndex(i => i + 1);
+      window.history.forward();
+    }
+  };
+
+  return (
+    <HistoryContext.Provider
+      value={{
+        back,
+        forward,
+        canGoBack: index > 0,
+        canGoForward: index < stack.length - 1,
+      }}
+    >
+      {children}
+    </HistoryContext.Provider>
+  );
+};
+
+export const useNavigationHistory = () => {
+  const ctx = useContext(HistoryContext);
+  if (!ctx)
+    throw new Error('useNavigationHistory must be used within HistoryProvider');
+  return ctx;
+};

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -12,7 +12,7 @@ import Modal from '@weco/common/views/components/Modal';
 
 import InactivityRedirectModal from './InactivityRedirect.Modal';
 
-const INACTIVITY_TIMEOUT = 3; // 60 seconds of inactivity before showing the warning modal
+const INACTIVITY_TIMEOUT = 60; // 60 seconds of inactivity before showing the warning modal
 const WARNING_COUNTDOWN = 30; // 30 seconds countdown before redirect
 
 const InactivityRedirect: FunctionComponent = () => {
@@ -195,6 +195,7 @@ const InactivityRedirect: FunctionComponent = () => {
       id="kiosk-inactivity-warning"
       openButtonRef={modalButtonRef}
       showOverlay={true}
+      removeCloseButton={true}
     >
       <InactivityRedirectModal
         countdown={countdown}

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -108,9 +108,7 @@ const Modal: FunctionComponent<Props> = ({
           <Overlay
             data-lock-scroll="true"
             onClick={() => {
-              if (!removeCloseButton) {
-                setIsActive(false);
-              }
+              setIsActive(false);
             }}
           />
         )}

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -11,6 +11,7 @@ import {
 } from '@weco/common/contexts/KioskContext';
 import { SearchContextProvider } from '@weco/common/contexts/SearchContext';
 import { UserContextProvider } from '@weco/common/contexts/UserContext';
+import { HistoryProvider } from '@weco/common/hooks/useNavigationHistory';
 import { useScrollTracking } from '@weco/common/hooks/useScrollTracking';
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import {
@@ -25,6 +26,7 @@ import useMaintainPageHeight from '@weco/common/services/app/useMaintainPageHeig
 import usePrismicPreview from '@weco/common/services/app/usePrismicPreview';
 import { deserialiseProps } from '@weco/common/utils/json';
 import CivicUK from '@weco/common/views/components/CivicUK';
+import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import GlobalSvgDefinitions from '@weco/common/views/components/GlobalSvgDefinitions';
 import InactivityRedirect from '@weco/common/views/components/InactivityRedirect';
 import InfoBanner from '@weco/common/views/components/InfoBanner';
@@ -171,37 +173,44 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                   cookieContent={kioskModeCookie}
                   readingRoomStories={serverData.prismic.readingRoomStories}
                 >
-                  <GlobalStyle
-                    $compositeTypography={
-                      !!serverData.toggles.featureFlags.compositeTypography
-                    }
-                  />
-
-                  <GlobalSvgDefinitions />
-                  <LoadingIndicator />
-
-                  {experienceName === 'Tenderness and Rage' && (
-                    <InfoBanner variant="kioskTRBanners" />
-                  )}
-
-                  {displayCookieBanner && (
-                    <CivicUK
-                      apiKey={civicUkApiKey}
-                      defer={serverData.consentStatus.cookieExists}
+                  <ConditionalWrapper
+                    condition={!!kioskModeCookie}
+                    wrapper={children => (
+                      <HistoryProvider>{children}</HistoryProvider>
+                    )}
+                  >
+                    <GlobalStyle
+                      $compositeTypography={
+                        !!serverData.toggles.featureFlags.compositeTypography
+                      }
                     />
-                  )}
-                  <HotjarLoader />
 
-                  {!pageProps.err &&
-                    getLayout(<Component {...componentProps} />)}
-                  {pageProps.err && (
-                    <ErrorPage
-                      statusCode={pageProps.err.statusCode}
-                      title={pageProps.err.message}
-                    />
-                  )}
+                    <GlobalSvgDefinitions />
+                    <LoadingIndicator />
 
-                  {!!kioskModeCookie && <InactivityRedirect />}
+                    {experienceName === 'Tenderness and Rage' && (
+                      <InfoBanner variant="kioskTRBanners" />
+                    )}
+
+                    {displayCookieBanner && (
+                      <CivicUK
+                        apiKey={civicUkApiKey}
+                        defer={serverData.consentStatus.cookieExists}
+                      />
+                    )}
+                    <HotjarLoader />
+
+                    {!pageProps.err &&
+                      getLayout(<Component {...componentProps} />)}
+                    {pageProps.err && (
+                      <ErrorPage
+                        statusCode={pageProps.err.statusCode}
+                        title={pageProps.err.message}
+                      />
+                    )}
+
+                    {!!kioskModeCookie && <InactivityRedirect />}
+                  </ConditionalWrapper>
                 </KioskProvider>
               </SearchContextProvider>
             </AppContextProvider>

--- a/content/webapp/views/components/KioskNavigation/index.tsx
+++ b/content/webapp/views/components/KioskNavigation/index.tsx
@@ -105,7 +105,6 @@ type NavigationContent = {
   totalCount: number;
   prevPageId?: string;
   nextPageId?: string;
-  listName?: string;
 };
 
 function findNavigationContent({
@@ -131,14 +130,12 @@ function findNavigationContent({
   // Search all arrays in the content object to find which one contains the pageId
   let items: string[] | undefined;
   let currentIndex = -1;
-  let listName: string | undefined;
 
-  for (const [key, value] of Object.entries(content)) {
+  for (const value of Object.values(content)) {
     if (Array.isArray(value)) {
       currentIndex = value.indexOf(pageId);
       if (currentIndex !== -1) {
         items = value;
-        listName = key;
         break;
       }
     }
@@ -157,7 +154,6 @@ function findNavigationContent({
     totalCount: items.length,
     prevPageId,
     nextPageId,
-    listName,
   };
 }
 
@@ -183,19 +179,9 @@ export const KioskNavigation: FunctionComponent<Props> = memo(
       [pageId, kioskMode, kiosksContent]
     );
 
-    // Determine URL path and label based on page type and list name
+    // Determine URL path and label based on page type
     const urlPath = pageType === 'work' ? 'works' : 'stories';
-
-    let label: string;
-    if (pageType === 'story') {
-      label = 'Related stories';
-    } else if (navigation?.listName === 'featuredWorks') {
-      label = 'Featured works';
-    } else if (navigation?.listName === 'includedWorks') {
-      label = 'Included works';
-    } else {
-      label = 'Related works';
-    }
+    const label = pageType === 'work' ? 'Related works' : 'Related stories';
 
     return (
       <KioskNavigationWrapper

--- a/content/webapp/views/components/KioskNavigation/index.tsx
+++ b/content/webapp/views/components/KioskNavigation/index.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components';
 
 import { useKiosk, useKiosksContent } from '@weco/common/contexts/KioskContext';
 import { KioskContent } from '@weco/common/contexts/KioskContext/kiosk';
-import { arrowSmall, home } from '@weco/common/icons';
+import { useNavigationHistory } from '@weco/common/hooks/useNavigationHistory';
+import { arrowSmall, chevron, home } from '@weco/common/icons';
 import { useModes } from '@weco/common/server-data/Context';
 import { font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
@@ -28,6 +29,33 @@ const KioskNavigationWrapper = styled(Space).attrs({
   justify-content: space-between;
 `;
 
+const LeftSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const HistoryNavigation = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+const HistoryButton = styled.button`
+  width: 24px;
+  height: 24px;
+  color: inherit;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &:hover:not(:disabled) {
+    opacity: 0.8;
+  }
+`;
+
 const HomeLink = styled(Link)`
   display: inline-flex;
   align-items: center;
@@ -40,7 +68,7 @@ const HomeLink = styled(Link)`
   }
 `;
 
-const NavigationLinks = styled.nav`
+const RightSection = styled.nav`
   display: flex;
   align-items: center;
   ${props => `gap: ${props.theme.gutter.medium};`}
@@ -139,6 +167,7 @@ export const KioskNavigation: FunctionComponent<Props> = memo(
     const { kioskMode } = useModes();
     const { isReadingRoomKiosk, kioskHomeUrl } = useKiosk();
     const kiosksContent = useKiosksContent();
+    const { back, forward, canGoBack, canGoForward } = useNavigationHistory();
 
     const navigation = useMemo(
       () =>
@@ -159,56 +188,72 @@ export const KioskNavigation: FunctionComponent<Props> = memo(
         data-component="kiosk-navigation"
         aria-label="Kiosk navigation"
       >
-        <HomeLink href={kioskHomeUrl} aria-label="Return to kiosk home page">
-          <Icon icon={home} aria-hidden="true" />
-          <span>Back to: Home</span>
-        </HomeLink>
-        <NavigationLinks aria-label="Content navigation">
-          {navigation && !isReadingRoomKiosk && (
-            <>
-              <span aria-label={`Viewing ${label.toLowerCase()}`}>{label}</span>
-              <span
-                aria-label={`Page ${navigation.currentIndex + 1} of ${navigation.totalCount}`}
+        <LeftSection>
+          <HistoryNavigation aria-label="Browser navigation">
+            <HistoryButton
+              onClick={back}
+              disabled={!canGoBack}
+              aria-label="Go back to previous page"
+            >
+              <Icon icon={chevron} rotate={90} aria-hidden="true" />
+            </HistoryButton>
+            <HistoryButton
+              onClick={forward}
+              disabled={!canGoForward}
+              aria-label="Go forward to next page"
+            >
+              <Icon icon={chevron} rotate={270} aria-hidden="true" />
+            </HistoryButton>
+          </HistoryNavigation>
+          <HomeLink href={kioskHomeUrl} aria-label="Return to kiosk home page">
+            <Icon icon={home} aria-hidden="true" />
+            <span>Back to: Home</span>
+          </HomeLink>
+        </LeftSection>
+        {navigation && !isReadingRoomKiosk && (
+          <RightSection aria-label="Content navigation">
+            <span aria-label={`Viewing ${label.toLowerCase()}`}>{label}</span>
+            <span
+              aria-label={`Page ${navigation.currentIndex + 1} of ${navigation.totalCount}`}
+            >
+              {navigation.currentIndex + 1} / {navigation.totalCount}
+            </span>
+            {navigation.prevPageId ? (
+              <NavLink
+                href={`/${urlPath}/${navigation.prevPageId}`}
+                aria-label="Go to previous page"
               >
-                {navigation.currentIndex + 1} / {navigation.totalCount}
-              </span>
-              {navigation.prevPageId ? (
-                <NavLink
-                  href={`/${urlPath}/${navigation.prevPageId}`}
-                  aria-label="Go to previous page"
-                >
-                  <Icon icon={arrowSmall} rotate={180} aria-hidden="true" />
-                  <span>Prev</span>
-                </NavLink>
-              ) : (
-                <DisabledNavLink
-                  aria-disabled="true"
-                  aria-label="Previous page unavailable"
-                >
-                  <Icon icon={arrowSmall} rotate={180} aria-hidden="true" />
-                  <span>Prev</span>
-                </DisabledNavLink>
-              )}
-              {navigation.nextPageId ? (
-                <NavLink
-                  href={`/${urlPath}/${navigation.nextPageId}`}
-                  aria-label="Go to next page"
-                >
-                  <Icon icon={arrowSmall} aria-hidden="true" />
-                  <span>Next</span>
-                </NavLink>
-              ) : (
-                <DisabledNavLink
-                  aria-disabled="true"
-                  aria-label="Next page unavailable"
-                >
-                  <Icon icon={arrowSmall} aria-hidden="true" />
-                  <span>Next</span>
-                </DisabledNavLink>
-              )}
-            </>
-          )}
-        </NavigationLinks>
+                <Icon icon={arrowSmall} rotate={180} aria-hidden="true" />
+                <span>Prev</span>
+              </NavLink>
+            ) : (
+              <DisabledNavLink
+                aria-disabled="true"
+                aria-label="Previous page unavailable"
+              >
+                <Icon icon={arrowSmall} rotate={180} aria-hidden="true" />
+                <span>Prev</span>
+              </DisabledNavLink>
+            )}
+            {navigation.nextPageId ? (
+              <NavLink
+                href={`/${urlPath}/${navigation.nextPageId}`}
+                aria-label="Go to next page"
+              >
+                <Icon icon={arrowSmall} aria-hidden="true" />
+                <span>Next</span>
+              </NavLink>
+            ) : (
+              <DisabledNavLink
+                aria-disabled="true"
+                aria-label="Next page unavailable"
+              >
+                <Icon icon={arrowSmall} aria-hidden="true" />
+                <span>Next</span>
+              </DisabledNavLink>
+            )}
+          </RightSection>
+        )}
       </KioskNavigationWrapper>
     );
   }

--- a/content/webapp/views/components/KioskNavigation/index.tsx
+++ b/content/webapp/views/components/KioskNavigation/index.tsx
@@ -15,6 +15,7 @@ const KioskNavigationWrapper = styled(Space).attrs({
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'md', properties: ['padding-left', 'padding-right'] },
   className: font('sans', -1),
+  as: 'nav',
 })`
   min-height: 88px;
   position: fixed;

--- a/content/webapp/views/components/KioskNavigation/index.tsx
+++ b/content/webapp/views/components/KioskNavigation/index.tsx
@@ -192,6 +192,7 @@ export const KioskNavigation: FunctionComponent<Props> = memo(
         <LeftSection>
           <HistoryNavigation aria-label="Browser navigation">
             <HistoryButton
+              type="button"
               onClick={back}
               disabled={!canGoBack}
               aria-label="Go back to previous page"
@@ -199,6 +200,7 @@ export const KioskNavigation: FunctionComponent<Props> = memo(
               <Icon icon={chevron} rotate={90} aria-hidden="true" />
             </HistoryButton>
             <HistoryButton
+              type="button"
               onClick={forward}
               disabled={!canGoForward}
               aria-label="Go forward to next page"


### PR DESCRIPTION
- For #13148

## What does this change?

- adds prev/next functionality to the KioskNav; see designs https://www.figma.com/design/eV1e7qHkYvob03Yvg8ptjv/Tenderness-and-rage?node-id=6515-6195&m=dev

This creates a history provider that tracks pages a user navigates through. We can't use the the History API because it doesn't expose whether history.forward() will work - we can't query the browser's position in the history stack.

## How to test

- [pick T&R mode](https://dash.wellcomecollection.org/toggles/#modes)
- visit [the 2nd story from T&R](https://www-dev.wellcomecollection.org/stories/telling-scotland-about-aids),
- use the prev/next controls on the right to create a navigation history
- use the back/forward controls on the left to navigate through the history

## Have we considered potential risks?

As copilot has noted if the user made use of browser forward and back this could get out of sync, but we can disable this for the iPads so I think this is ok
