### PR TITLE
dedupe the same download

### DIFF
--- a/content/webapp/utils/iiif/v3/index.test.ts
+++ b/content/webapp/utils/iiif/v3/index.test.ts
@@ -4,6 +4,7 @@ import type { ServiceWithMetadata } from '@weco/content/types/manifest';
 import type { TransformedCanvas } from '@weco/content/types/manifest';
 
 import {
+  deduplicateDownloadOptions,
   getManifestAccessRequirements,
   hasNonImagesOrOriginals,
   transformLabel,
@@ -312,5 +313,40 @@ describe('hasNonImagesOrOriginals', () => {
       }),
     ];
     expect(hasNonImagesOrOriginals(canvases)).toBe(true);
+  });
+});
+
+describe('deduplicateDownloadOptions', () => {
+  it('returns an empty array when given an empty array', () => {
+    expect(deduplicateDownloadOptions([])).toEqual([]);
+  });
+
+  it('returns the same options when there are no duplicates', () => {
+    const options = [
+      { id: 'a', label: 'File A', format: 'application/pdf' },
+      { id: 'b', label: 'File B', format: 'video/mp4' },
+    ];
+    expect(deduplicateDownloadOptions(options)).toEqual(options);
+  });
+
+  it('removes later duplicates and preserves the first occurrence', () => {
+    const first = { id: 'a', label: 'First', format: 'application/pdf' };
+    const duplicate = {
+      id: 'a',
+      label: 'Duplicate',
+      format: 'application/pdf',
+    };
+    const other = { id: 'b', label: 'Other', format: 'video/mp4' };
+    expect(deduplicateDownloadOptions([first, duplicate, other])).toEqual([
+      first,
+      other,
+    ]);
+  });
+
+  it('handles all duplicates', () => {
+    const option = { id: 'x', label: 'X', format: 'text/plain' };
+    expect(deduplicateDownloadOptions([option, option, option])).toEqual([
+      option,
+    ]);
   });
 });

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -150,9 +150,13 @@ type Rendering = {
 export function deduplicateDownloadOptions(
   options: DownloadOption[]
 ): DownloadOption[] {
-  return options.filter(
-    (option, index, self) => self.findIndex(o => o.id === option.id) === index
-  );
+  const seen = new Set<string>();
+
+  return options.filter(option => {
+    if (seen.has(option.id)) return false;
+    seen.add(option.id);
+    return true;
+  });
 }
 
 export function getDownloadOptionsFromManifestRendering(

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -147,6 +147,14 @@ type Rendering = {
   label?: string | InternationalString;
 };
 
+export function deduplicateDownloadOptions(
+  options: DownloadOption[]
+): DownloadOption[] {
+  return options.filter(
+    (option, index, self) => self.findIndex(o => o.id === option.id) === index
+  );
+}
+
 export function getDownloadOptionsFromManifestRendering(
   manifestRendering: Manifest['rendering']
 ): DownloadOption[] {

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.tsx
@@ -19,12 +19,13 @@ import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
 import useTransformedIIIFImage from '@weco/content/hooks/useTransformedIIIFImage';
-import { hasRestrictedItem } from '@weco/content/utils/iiif/v3';
 import {
+  deduplicateDownloadOptions,
   getDownloadOptionsFromCanvasRenderingAndSupplementing,
   getDownloadOptionsFromManifestRendering,
   getImageServiceFromItem,
   getVideoAudioDownloadOptions,
+  hasRestrictedItem,
   isChoiceBody,
 } from '@weco/content/utils/iiif/v3';
 import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
@@ -281,18 +282,14 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
 
   // We need multiple sources for downloads to cover the different
   // ways in which a download can be made available in a iiif manifest.
-  // However, sometimes the same download file can be available
-  // from multiple sources, so we deduplicate them here based on their id
-  // which is the url to the file to be downloaded.
-  const downloadOptions = [
+  // The same file can appear in multiple sources, so we deduplicate by id.
+  const downloadOptions = deduplicateDownloadOptions([
     ...iiifImageDownloadOptions,
     ...canvasImageDownloads,
     ...canvasDownloadOptions,
     ...manifestDownloadOptions,
     ...videoAudioDownloadOptions,
-  ].filter(
-    (option, index, self) => self.findIndex(o => o.id === option.id) === index
-  );
+  ]);
 
   return (
     <TopBar

--- a/content/webapp/views/pages/works/work/WorkDetails/index.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '@weco/content/services/wellcome/catalogue/types';
 import { TransformedManifest } from '@weco/content/types/manifest';
 import {
+  deduplicateDownloadOptions,
   getDownloadOptionsFromCanvasRenderingAndSupplementing,
   getDownloadOptionsFromManifestRendering,
   hasItemType,
@@ -95,6 +96,13 @@ const WorkDetails: FunctionComponent<Props> = ({
         getDownloadOptionsFromCanvasRenderingAndSupplementing(canvas)
       )
       .flat() || [];
+
+  // The same file can appear in multiple sources, so deduplicate by id
+  const downloadOptions = deduplicateDownloadOptions([
+    ...iiifImageDownloadOptions,
+    ...canvasDownloadOptions,
+    ...manifestDownloadOptions,
+  ]);
 
   // 'About this work' data
   const duration = work.duration && formatDuration(work.duration);
@@ -173,11 +181,7 @@ const WorkDetails: FunctionComponent<Props> = ({
       {showAvailableOnlineSection && (
         <WorkDetailsAvailableOnline
           work={work}
-          downloadOptions={[
-            ...manifestDownloadOptions,
-            ...iiifImageDownloadOptions,
-            ...canvasDownloadOptions,
-          ]}
+          downloadOptions={downloadOptions}
           itemUrl={toWorksItemLink({
             workId: work.id,
             props: {},


### PR DESCRIPTION
## What does this change?

We had [a report of duplicate downloads](https://wellcome.slack.com/archives/C8X9YKM5X/p1781618867860619?thread_ts=1781618088.695279&cid=C8X9YKM5X) showing on the work page for https://wellcomecollection.org/works/vug3vpep

This fixes that.

We look for downloads in several places in order to ensure we get anything that is available. Some things exist at the manifest level and others, for certain PDFs, on the canvas level. Sometimes these return the same thing which is why we have two.

We were already deduping these in the viewer topbar so have shared that logic with the work page.  

## How to test

- Visit https://wellcomecollection.org/works/vug3vpep
- Click on downloads and check there is only one PDF transcript link available (alongside the audio file)

## Have we considered potential risks?

None really, we only remove things we have more than one of