### PR TITLE
Hide library members login cta in kiosk mode

### DIFF
--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.WhereToFind.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.WhereToFind.tsx
@@ -1,3 +1,4 @@
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import Space from '@weco/common/views/components/styled/Space';
 import {
   Note,
@@ -21,15 +22,18 @@ type Props = {
 };
 
 const WhereToFindIt = ({ work, physicalItems, locationOfWork }: Props) => {
+  const { isKiosk } = useKiosk();
+
   return (
     <WorkDetailsSection headingText="Where to find it">
       {physicalItems.some(
         item => itemIsRequestable(item) || itemIsTemporarilyUnavailable(item)
-      ) && (
-        <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-          <LibraryMembersBar />
-        </Space>
-      )}
+      ) &&
+        !isKiosk && (
+          <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
+            <LibraryMembersBar />
+          </Space>
+        )}
       {locationOfWork && (
         <WorkDetailsText
           title={locationOfWork.noteType.label}


### PR DESCRIPTION
- For #13177 

## What does this change?

Hides the Library members login bar for kiosk modes


## How to test

- https://www-dev.wellcomecollection.org/works/a2239muq
- Test with and without ANY kiosk mode

## Have we considered potential risks?
N/A