### PR TITLE
Use difference cardSizeMap in kiosk/non-kiosk mode

### DIFF
--- a/content/webapp/views/pages/exhibitions/explore-more.tsx
+++ b/content/webapp/views/pages/exhibitions/explore-more.tsx
@@ -1,6 +1,7 @@
 import { SliceZone } from '@prismicio/react';
 import { NextPage } from 'next';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { font } from '@weco/common/utils/classnames';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import {
@@ -22,6 +23,8 @@ export type Props = {
 };
 
 const ExploreMorePage: NextPage<Props> = ({ exhibition, page, jsonLd }) => {
+  const { isKiosk } = useKiosk();
+
   return (
     <PageLayout
       title={page.title}
@@ -55,7 +58,9 @@ const ExploreMorePage: NextPage<Props> = ({ exhibition, page, jsonLd }) => {
           components={components}
           context={{
             itemsHaveTransparentBackground: false,
-            cardSizeMap: { s: [12], m: [6], l: [6], xl: [6] },
+            ...(isKiosk && {
+              cardSizeMap: { s: [12], m: [6], l: [6], xl: [6] },
+            }),
             isFirstCardFeatured: true,
           }}
         />


### PR DESCRIPTION
- For #13152

## What does this change?

We want the `/explore-more` page to display a certain way on the in-venue iPads, but we also want the page to be generally available, with a different card grid, on users' devices.

This checks for the `isKiosk` toggle and lays the page out with the 2-up card grid only if it's present.


## How to test

Because we are currently 404-ing the page unless you have the `isKiosk` mode turned on, it's not possible to test unless you also comment out [this piece of logic](https://github.com/wellcomecollection/wellcomecollection.org/blob/60515384e37dad84259e57a281a17c949c17ffe7/content/webapp/pages/exhibitions/%5BexhibitionId%5D/explore-more.tsx#L36-L38) when attempting to view the page without kiosk mode

## Have we considered potential risks?

n/a
