### PR TITLE
Codify bot blocking as higher priority

### DIFF
--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -223,82 +223,8 @@ resource "aws_wafv2_web_acl" "wc_org" {
   }
 
   rule {
-    name     = "block-azure-scraper-bot"
-    priority = 5
-
-    action {
-      count {}
-    }
-
-    statement {
-      and_statement {
-        statement {
-          regex_match_statement {
-            regex_string = "Chrome/\\d+\\.\\d+\\.0\\.0 "
-
-            field_to_match {
-              single_header {
-                name = "user-agent"
-              }
-            }
-
-            text_transformation {
-              priority = 0
-              type     = "NONE"
-            }
-          }
-        }
-        statement {
-          or_statement {
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "Mac OS X 10_15_7"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-            statement {
-              byte_match_statement {
-                positional_constraint = "CONTAINS"
-                search_string         = "Windows NT 10.0; Win64; x64"
-
-                field_to_match {
-                  single_header {
-                    name = "user-agent"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "block-azure-scraper-bot-${var.namespace}"
-    }
-  }
-
-  rule {
     name     = "managed-ip-blocking"
-    priority = 6
+    priority = 5
 
     override_action {
       none {}
@@ -321,7 +247,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-user-agent-manual"
-    priority = 7
+    priority = 6
 
     action {
       block {}
@@ -469,7 +395,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "apac-captcha-consent-block"
-    priority = 8
+    priority = 7
 
     action {
       captcha {}
@@ -519,7 +445,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "latam-captcha-consent-block"
-    priority = 9
+    priority = 8
 
     action {
       captcha {}
@@ -569,7 +495,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 10
+    priority = 9
 
     action {
       block {
@@ -604,7 +530,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 11
+    priority = 10
 
     action {
       block {
@@ -644,7 +570,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 12
+    priority = 11
 
     action {
       block {
@@ -681,7 +607,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 13
+    priority = 12
 
     action {
       block {}
@@ -703,7 +629,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 14
+    priority = 13
 
     action {
       block {}
@@ -741,7 +667,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 15
+    priority = 14
 
     override_action {
       none {}
@@ -764,7 +690,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 16
+    priority = 15
 
     override_action {
       none {}
@@ -787,7 +713,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 17
+    priority = 16
 
     override_action {
       none {}
@@ -809,7 +735,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 18
+    priority = 17
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -234,7 +234,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
       and_statement {
         statement {
           regex_match_statement {
-            regex_string = "Chrome/\\d+\\.0\\.0 "
+            regex_string = "Chrome/\\d+\\.\\d+\\.0\\.0 "
 
             field_to_match {
               single_header {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -227,7 +227,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 5
 
     action {
-      count {}
+      block {}
     }
 
     statement {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -227,7 +227,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     priority = 5
 
     action {
-      block {}
+      count {}
     }
 
     statement {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -222,11 +222,6 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
-  // This bot was identified on 2026-06-18 scraping /search/works and /works at high volume.
-  // It originates from Azure IP ranges and rotates through spoofed Chrome user-agents.
-  // The giveaway: real Chrome always has a 4-part build version (e.g. Chrome/133.0.6943.141);
-  // this bot uses round versions (e.g. Chrome/133.0.0.0) with only two exact OS strings.
-  // Rule is in COUNT mode for monitoring before enabling block.
   rule {
     name     = "block-azure-scraper-bot"
     priority = 5

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -222,9 +222,88 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // This bot was identified on 2026-06-18 scraping /search/works and /works at high volume.
+  // It originates from Azure IP ranges and rotates through spoofed Chrome user-agents.
+  // The giveaway: real Chrome always has a 4-part build version (e.g. Chrome/133.0.6943.141);
+  // this bot uses round versions (e.g. Chrome/133.0.0.0) with only two exact OS strings.
+  // Rule is in COUNT mode for monitoring before enabling block.
+  rule {
+    name     = "block-azure-scraper-bot"
+    priority = 5
+
+    action {
+      count {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          regex_match_statement {
+            regex_string = "Chrome/\\d+\\.0\\.0 "
+
+            field_to_match {
+              single_header {
+                name = "user-agent"
+              }
+            }
+
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          or_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "Mac OS X 10_15_7"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "CONTAINS"
+                search_string         = "Windows NT 10.0; Win64; x64"
+
+                field_to_match {
+                  single_header {
+                    name = "user-agent"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "block-azure-scraper-bot-${var.namespace}"
+    }
+  }
+
   rule {
     name     = "managed-ip-blocking"
-    priority = 5
+    priority = 6
 
     override_action {
       none {}
@@ -246,395 +325,8 @@ resource "aws_wafv2_web_acl" "wc_org" {
   }
 
   rule {
-    name     = "apac-captcha-consent-block"
-    priority = 6
-
-    action {
-      captcha {}
-    }
-
-    statement {
-      and_statement {
-        statement {
-          geo_match_statement {
-            country_codes = ["CN", "JP", "SG", "TW", "VN"]
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              size_constraint_statement {
-                comparison_operator = "GT"
-                size                = 0
-
-                field_to_match {
-                  cookies {
-                    match_pattern {
-                      included_cookies = ["CookieControl"]
-                    }
-                    match_scope       = "ALL"
-                    oversize_handling = "MATCH"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "apac-captcha-consent-block"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "latam-captcha-consent-block"
-    priority = 7
-
-    action {
-      captcha {}
-    }
-
-    statement {
-      and_statement {
-        statement {
-          geo_match_statement {
-            country_codes = ["BR"]
-          }
-        }
-        statement {
-          not_statement {
-            statement {
-              size_constraint_statement {
-                comparison_operator = "GT"
-                size                = 0
-
-                field_to_match {
-                  cookies {
-                    match_pattern {
-                      included_cookies = ["CookieControl"]
-                    }
-                    match_scope       = "ALL"
-                    oversize_handling = "MATCH"
-                  }
-                }
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "latam-captcha-consent-block"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "geo-rate-limit-USA"
-    priority = 8
-
-    action {
-      block {
-        custom_response {
-          response_code = 429
-        }
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        aggregate_key_type    = "CONSTANT"
-        evaluation_window_sec = 60
-        limit                 = 1750
-
-        scope_down_statement {
-          geo_match_statement {
-            country_codes = [
-              "US",
-            ]
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "geo-rate-limit-USA-${var.namespace}"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "geo-rate-limit-APAC"
-    priority = 9
-
-    action {
-      block {
-        custom_response {
-          response_code = 429
-        }
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        aggregate_key_type    = "CONSTANT"
-        evaluation_window_sec = 60
-        limit                 = 250
-
-        scope_down_statement {
-          geo_match_statement {
-            // We have seen significant bot traffic from these regions,
-            // so we rate limit to a lower threshold.
-            country_codes = [
-              "CN",
-              "SG",
-              "HK",
-              "VN",
-            ]
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "geo-rate-limit-apac-${var.namespace}"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "geo-rate-limit-LATAM"
-    priority = 10
-
-    action {
-      block {
-        custom_response {
-          response_code = 429
-        }
-      }
-    }
-
-    statement {
-      rate_based_statement {
-        aggregate_key_type    = "CONSTANT"
-        evaluation_window_sec = 60
-        limit                 = 200
-
-        scope_down_statement {
-          geo_match_statement {
-            // We have seen significant bot traffic from these regions,
-            // so we rate limit to a lower threshold.
-            country_codes = [
-              "BR",
-            ]
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "geo-rate-limit-latam-${var.namespace}"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "blanket-rate-limiting"
-    priority = 11
-
-    action {
-      block {}
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = local.blanket_rate_limit
-        aggregate_key_type = "IP"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-rate-limit-${var.namespace}"
-    }
-  }
-
-  rule {
-    name     = "restrictive-rate-limiting"
-    priority = 12
-
-    action {
-      block {}
-    }
-
-    statement {
-      rate_based_statement {
-        limit              = local.restrictive_rate_limit
-        aggregate_key_type = "IP"
-
-        scope_down_statement {
-          regex_pattern_set_reference_statement {
-            field_to_match {
-              uri_path {}
-            }
-
-            arn = aws_wafv2_regex_pattern_set.restricted_urls.arn
-
-            text_transformation {
-              priority = 1
-              type     = "URL_DECODE"
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-restrictive-rate-limit-${var.namespace}"
-    }
-  }
-
-  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
-  rule {
-    name     = "core-rule-group"
-    priority = 13
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesCommonRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-core-${var.namespace}"
-    }
-  }
-
-  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
-  rule {
-    name     = "sqli-rule-group"
-    priority = 14
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesSQLiRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-sqli-${var.namespace}"
-    }
-  }
-
-  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
-  rule {
-    name     = "known-bad-inputs-rule-group"
-    priority = 15
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesKnownBadInputsRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-known-bad-inputs-${var.namespace}"
-    }
-  }
-
-  rule {
-    name     = "bot-control-rule-group"
-    priority = 16
-
-    // Because the Bot Control rules are quite aggressive, they block some useful bots
-    // such as Updown. While we could add overrides for specific bots, we don"t want to have to
-    // keep coming back here as we use different monitoring services, scripts, etc.
-    //
-    // Instead, we"re starting by disabling most of the more high-risk rules and retaining only the
-    // ones like CategorySeo which we know cover the majority of our known-bad bot traffic.
-    // Rules can be found here:
-    // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesBotControlRuleSet"
-        vendor_name = "AWS"
-        version     = "Version_3.1"
-
-        managed_rule_group_configs {
-          aws_managed_rules_bot_control_rule_set {
-            inspection_level = "COMMON"
-          }
-        }
-
-        dynamic "rule_action_override" {
-          for_each = local.bot_control_rule_no_block_list
-          content {
-            name = rule_action_override.value
-            action_to_use {
-              count {}
-            }
-          }
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      sampled_requests_enabled   = true
-      metric_name                = "weco-cloudfront-acl-bot-control-${var.namespace}"
-    }
-  }
-
-  rule {
     name     = "bot-user-agent-manual"
-    priority = 17
+    priority = 7
 
     action {
       block {}
@@ -779,6 +471,394 @@ resource "aws_wafv2_web_acl" "wc_org" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    name     = "apac-captcha-consent-block"
+    priority = 8
+
+    action {
+      captcha {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          geo_match_statement {
+            country_codes = ["CN", "JP", "SG", "TW", "VN"]
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              size_constraint_statement {
+                comparison_operator = "GT"
+                size                = 0
+
+                field_to_match {
+                  cookies {
+                    match_pattern {
+                      included_cookies = ["CookieControl"]
+                    }
+                    match_scope       = "ALL"
+                    oversize_handling = "MATCH"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "apac-captcha-consent-block"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "latam-captcha-consent-block"
+    priority = 9
+
+    action {
+      captcha {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          geo_match_statement {
+            country_codes = ["BR"]
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              size_constraint_statement {
+                comparison_operator = "GT"
+                size                = 0
+
+                field_to_match {
+                  cookies {
+                    match_pattern {
+                      included_cookies = ["CookieControl"]
+                    }
+                    match_scope       = "ALL"
+                    oversize_handling = "MATCH"
+                  }
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "latam-captcha-consent-block"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "geo-rate-limit-USA"
+    priority = 10
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type    = "CONSTANT"
+        evaluation_window_sec = 60
+        limit                 = 1750
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = [
+              "US",
+            ]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "geo-rate-limit-USA-${var.namespace}"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "geo-rate-limit-APAC"
+    priority = 11
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type    = "CONSTANT"
+        evaluation_window_sec = 60
+        limit                 = 250
+
+        scope_down_statement {
+          geo_match_statement {
+            // We have seen significant bot traffic from these regions,
+            // so we rate limit to a lower threshold.
+            country_codes = [
+              "CN",
+              "SG",
+              "HK",
+              "VN",
+            ]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "geo-rate-limit-apac-${var.namespace}"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "geo-rate-limit-LATAM"
+    priority = 12
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type    = "CONSTANT"
+        evaluation_window_sec = 60
+        limit                 = 200
+
+        scope_down_statement {
+          geo_match_statement {
+            // We have seen significant bot traffic from these regions,
+            // so we rate limit to a lower threshold.
+            country_codes = [
+              "BR",
+            ]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "geo-rate-limit-latam-${var.namespace}"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "blanket-rate-limiting"
+    priority = 13
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = local.blanket_rate_limit
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-rate-limit-${var.namespace}"
+    }
+  }
+
+  rule {
+    name     = "restrictive-rate-limiting"
+    priority = 14
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = local.restrictive_rate_limit
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            field_to_match {
+              uri_path {}
+            }
+
+            arn = aws_wafv2_regex_pattern_set.restricted_urls.arn
+
+            text_transformation {
+              priority = 1
+              type     = "URL_DECODE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-restrictive-rate-limit-${var.namespace}"
+    }
+  }
+
+  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
+  rule {
+    name     = "core-rule-group"
+    priority = 15
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-core-${var.namespace}"
+    }
+  }
+
+  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
+  rule {
+    name     = "sqli-rule-group"
+    priority = 16
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-sqli-${var.namespace}"
+    }
+  }
+
+  // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
+  rule {
+    name     = "known-bad-inputs-rule-group"
+    priority = 17
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-known-bad-inputs-${var.namespace}"
+    }
+  }
+
+  rule {
+    name     = "bot-control-rule-group"
+    priority = 18
+
+    // Because the Bot Control rules are quite aggressive, they block some useful bots
+    // such as Updown. While we could add overrides for specific bots, we don"t want to have to
+    // keep coming back here as we use different monitoring services, scripts, etc.
+    //
+    // Instead, we"re starting by disabling most of the more high-risk rules and retaining only the
+    // ones like CategorySeo which we know cover the majority of our known-bad bot traffic.
+    // Rules can be found here:
+    // https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS"
+        version     = "Version_3.1"
+
+        managed_rule_group_configs {
+          aws_managed_rules_bot_control_rule_set {
+            inspection_level = "COMMON"
+          }
+        }
+
+        dynamic "rule_action_override" {
+          for_each = local.bot_control_rule_no_block_list
+          content {
+            name = rule_action_override.value
+            action_to_use {
+              count {}
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-bot-control-${var.namespace}"
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     sampled_requests_enabled   = true


### PR DESCRIPTION
- For #13144 and https://wellcome.slack.com/archives/CUA669WHH/p1781772188773619

## What does this change?

- The bot traffic rule priority was manually changed already so I codified it.
- Added a rule to count a suspicious bot (see Slack convo for detail) but then removed it (again, please see Slack chats for details, but we learned that User agents for Chrome now were all `0.0.0` so it's not an indicator of bots)

## How to test

I've applied it a while ago, this just codified it.

## Have we considered potential risks?

N/A