### PR TITLE
Use typography instead of font for compositeTypography

### DIFF
--- a/cardigan/config/decorators.tsx
+++ b/cardigan/config/decorators.tsx
@@ -10,7 +10,7 @@ export const ContextDecorator: FunctionComponent<PropsWithChildren> = ({
 }) => {
   return (
     <ThemeProvider theme={theme}>
-      <GlobalStyle $compositeTypography={true} />
+      <GlobalStyle />
       <AppContextProvider>
         <div className="enhanced">{children}</div>
       </AppContextProvider>

--- a/cardigan/stories/components/Buttons/Button/Button.stories.tsx
+++ b/cardigan/stories/components/Buttons/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { eye } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button, { ButtonProps } from '@weco/common/views/components/Buttons';
 import theme from '@weco/common/views/themes/default';
 
@@ -113,7 +113,7 @@ export const DropdownButton: Story = {
   },
   render: args => (
     <div
-      className={font('sans', -2)}
+      className={typography('body', 'sm', 'regular')}
       style={{
         padding: '20px',
         backgroundColor: args.isOnDark ? theme.color('black') : undefined,

--- a/cardigan/stories/components/Cards/FeaturedCard/FeaturedCard.stories.tsx
+++ b/cardigan/stories/components/Cards/FeaturedCard/FeaturedCard.stories.tsx
@@ -4,7 +4,7 @@ import { ReadmeDecorator } from '@weco/cardigan/config/decorators';
 import { exhibitionBasic } from '@weco/cardigan/stories/data/content';
 import { contentAPIArticle } from '@weco/cardigan/stories/data/contentAPI.content';
 import { image } from '@weco/cardigan/stories/data/images';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import FeaturedCard from '@weco/content/views/components/FeaturedCard';
 import Readme from '@weco/content/views/components/FeaturedCard/README.mdx';
 
@@ -70,10 +70,10 @@ export const Basic: Story = {
         }}
         Readme={Readme}
       >
-        <h2 className={font('brand-bold', 2)}>
+        <h2 className={typography('heading', 'xl', 'strong', 'brand')}>
           Remote diagnosis from wee to the Web
         </h2>
-        <p className={font('sans', -1)}>
+        <p className={typography('body', 'md', 'regular')}>
           Medical practice might have moved on from when patients posted flasks
           of their urine for doctors to taste, but telehealth today keeps up the
           tradition of remote diagnosis – to our possible detriment.

--- a/cardigan/stories/components/Icon/Icon.stories.tsx
+++ b/cardigan/stories/components/Icon/Icon.stories.tsx
@@ -3,7 +3,7 @@ import { themeColors } from '@weco/cardigan/.storybook/preview';
 import { ComponentProps, useEffect, useState } from 'react';
 
 import * as Icons from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 type StoryProps = Omit<ComponentProps<typeof Icon>, 'icon'> & {
@@ -48,7 +48,7 @@ const Template = args => {
   return (
     <>
       {args.matchText ? (
-        <span className={font('sans', 1)}>
+        <span className={typography('body', 'xl', 'regular')}>
           <Icon {...args} icon={Icons[currentIcon]} />
           <span style={{ marginLeft: '5px' }}>Some text</span>
         </span>

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -12,7 +12,7 @@ import {
   headerBackgroundLs,
   landingHeaderBackgroundLs,
 } from '@weco/common/utils/backgrounds';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground';
 import Layout, { gridSize8 } from '@weco/common/views/components/Layout';
 import PageHeader from '@weco/common/views/components/PageHeader';
@@ -89,15 +89,17 @@ const ContentTypeInfo = (
     />
     <div style={{ display: 'flex', alignItems: 'baseline' }}>
       <Space
-        className={font('sans', -2)}
+        className={typography('body', 'sm', 'regular')}
         $h={{ size: 'xs', properties: ['margin-right'] }}
         $v={{ size: 'xs', properties: ['margin-top'] }}
       >
         <p style={{ marginBottom: 0 }}>
           <span>By </span>
-          <span className={font('sans-bold', -2)}>Naomi Paxton</span>{' '}
+          <span className={typography('body', 'sm', 'strong')}>
+            Naomi Paxton
+          </span>{' '}
           <span
-            className={font('sans', -2)}
+            className={typography('body', 'sm', 'regular')}
             style={{ color: theme.color('neutral.600') }}
           >
             17 April 2019
@@ -268,7 +270,7 @@ export const Event: Meta<typeof PageHeader> = {
         </Space>
         <div style={{ display: 'flex' }}>
           <TextWithDot
-            className={font('sans-bold', -1)}
+            className={typography('body', 'md', 'strong')}
             dotColor="neutral.500"
             text="Past"
           />
@@ -317,7 +319,7 @@ export const Exhibition: Meta<typeof PageHeader> = {
     ContentTypeInfo: (
       <div style={{ display: 'flex' }}>
         <TextWithDot
-          className={font('sans-bold', -1)}
+          className={typography('body', 'md', 'strong')}
           dotColor="neutral.500"
           text="Closed"
         />
@@ -419,7 +421,10 @@ export const Book: Meta<typeof PageHeader> = {
     variant: 'basic',
     title: 'Together',
     ContentTypeInfo: (
-      <p className={font('sans-bold', 1)} style={{ marginBottom: 0 }}>
+      <p
+        className={typography('body', 'xl', 'strong')}
+        style={{ marginBottom: 0 }}
+      >
         Loneliness, Health & What Happens When We Find Connection
       </p>
     ),

--- a/cardigan/stories/components/ScrollContainer/ScrollContainer.stories.tsx
+++ b/cardigan/stories/components/ScrollContainer/ScrollContainer.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { ComponentProps } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -93,11 +93,11 @@ const Template = args => {
           hasCopy ? (
             <>
               <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
-                <h2 className={font('sans-bold', 2)}>
+                <h2 className={typography('heading', 'xl', 'strong', 'sans')}>
                   Title for this component
                 </h2>
               </Space>
-              <DetailsCopy className={font('sans', -2)}>
+              <DetailsCopy className={typography('body', 'sm', 'regular')}>
                 Scroll container details (x results)
               </DetailsCopy>
             </>

--- a/cardigan/stories/global/icons/icons.tsx
+++ b/cardigan/stories/global/icons/icons.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import * as icons from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 const IconWrapper = styled.div`
@@ -16,7 +16,7 @@ const IconWrapper = styled.div`
 `;
 
 const IconId = styled.p.attrs({
-  className: font('mono', -1),
+  className: typography('caption', 'md', 'regular'),
 })`
   hyphens: auto;
 `;

--- a/cardigan/stories/global/palette/palette.tsx
+++ b/cardigan/stories/global/palette/palette.tsx
@@ -1,6 +1,6 @@
 import styled, { useTheme } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider';
 import {
   hexToRgb,
@@ -34,11 +34,15 @@ const SectionWrapper = styled.div`
   margin: 1rem 0;
 `;
 
-const SectionTitle = styled.h2.attrs({ className: font('brand-bold', 1) })`
+const SectionTitle = styled.h2.attrs({
+  className: typography('heading', 'lg', 'strong', 'brand'),
+})`
   padding: 2rem 0 0;
 `;
 
-const SectionDescription = styled.p.attrs({ className: font('sans', -2) })``;
+const SectionDescription = styled.p.attrs({
+  className: typography('body', 'sm', 'regular'),
+})``;
 
 const PaletteBlock = styled.div`
   flex-basis: 25%;
@@ -46,7 +50,7 @@ const PaletteBlock = styled.div`
 `;
 
 const PaletteName = styled.h3.attrs({
-  className: font('mono', -2),
+  className: typography('caption', 'md', 'regular'),
 })``;
 
 const PaletteColor = styled.div<{ $hasBorder: boolean }>`
@@ -69,11 +73,11 @@ const PaletteColor = styled.div<{ $hasBorder: boolean }>`
 `;
 
 const PaletteHex = styled.div.attrs({
-  className: font('mono', -2),
+  className: typography('caption', 'md', 'regular'),
 })``;
 
 const PaletteCode = styled.code.attrs({
-  className: font('mono', -2),
+  className: typography('caption', 'md', 'regular'),
 })``;
 
 const buildPaletteColors = (

--- a/common/utils/classnames.ts
+++ b/common/utils/classnames.ts
@@ -3,7 +3,7 @@ import {
   TypographySizeKey,
 } from '@wellcometrust/wellcome-design-system/theme';
 
-const validCompositeTypographyClasses: Set<string> = (() => {
+const validTypographyClasses: Set<string> = (() => {
   const t = designSystemTheme.typography;
   const sizes: TypographySizeKey[] = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'];
   const valid = new Set<string>();
@@ -35,56 +35,7 @@ const validCompositeTypographyClasses: Set<string> = (() => {
   return valid;
 })();
 
-// int(r|m|sb|b) = Inter(regular|medium|semi-bold|bold); wb = Wellcome Bold; lr = Lettera Regular
-type FontFamily = 'sans' | 'sans-bold' | 'brand' | 'brand-bold' | 'mono';
-type FontSize = -2 | -1 | 0 | 1 | 2 | 4 | 5;
-
-// Parallel composite type class for each font(family, size) combination.
-// Where there is no direct equivalent in the composite type scale, we map to the
-// closest available style (e.g. font('sans', 2) and font('mono', -1)).
-// Ambiguous cases (body vs label, body vs heading) default to body.
-const fontCompositeMap: Partial<Record<string, string>> = {
-  'sans:-2': 'type-body-sm-regular',
-  'sans:-1': 'type-body-md-regular',
-  'sans:0': 'type-body-lg-regular',
-  'sans:1': 'type-body-xl-regular',
-  'sans:2': 'type-body-xl-regular', // font('sans', 2) didn't have an exact match. This is the closest available
-  'sans-bold:-2': 'type-body-sm-strong',
-  'sans-bold:-1': 'type-body-md-strong',
-  'sans-bold:0': 'type-body-lg-strong',
-  'sans-bold:1': 'type-body-xl-strong',
-  'sans-bold:2': 'type-heading-xl-strong-sans',
-  'brand:0': 'type-heading-md-regular-brand',
-  'brand:1': 'type-heading-lg-regular-brand',
-  'brand-bold:-2': 'type-heading-xs-strong-brand',
-  'brand-bold:-1': 'type-heading-sm-strong-brand',
-  'brand-bold:0': 'type-heading-md-strong-brand',
-  'brand-bold:1': 'type-heading-lg-strong-brand',
-  'brand-bold:2': 'type-heading-xl-strong-brand',
-  'brand-bold:4': 'type-heading-xxl-strong-brand',
-  'brand-bold:5': 'type-display-md-strong',
-  'mono:-2': 'type-caption-md-regular',
-  'mono:-1': 'type-caption-md-regular', // font('mono', -1) didn't have an exact match. This is the closest available
-};
-
-function fontFamily(family: FontFamily): string {
-  return `font-${family}`;
-}
-
-export function fontSize(size: FontSize): string {
-  return `font-size-f${size}`;
-}
-
-// Interim measure to allow this function to output _both_ of the possible
-// typography class names. After we've QA-ed behind a toggle, I think we can
-// replace calls to `font` with equivalent calls to `compositeTypography`
-export function font(family: FontFamily, size: FontSize): string {
-  const base = `${fontFamily(family)} ${fontSize(size)}`;
-  const composite = fontCompositeMap[`${family}:${size}`];
-  return composite ? `${base} ${composite}` : base;
-}
-
-export function compositeTypography(
+export function typography(
   category: 'body' | 'caption' | 'display' | 'label' | 'heading',
   size: TypographySizeKey,
   weight: 'regular' | 'strong',
@@ -98,9 +49,9 @@ export function compositeTypography(
   if (
     // Warn if there isn't a class for the given arguments
     process.env.NODE_ENV !== 'production' &&
-    !validCompositeTypographyClasses.has(className)
+    !validTypographyClasses.has(className)
   ) {
-    console.warn(`compositeTypography: no class generated for "${className}"`);
+    console.warn(`typography: no class generated for "${className}"`);
   }
 
   return className;

--- a/common/views/components/AccessibilityProvision/index.tsx
+++ b/common/views/components/AccessibilityProvision/index.tsx
@@ -8,7 +8,7 @@ import {
   bslSquare,
   closedCaptioningSquare,
 } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -60,7 +60,9 @@ const AccessibilityProvision: FunctionComponent<Props> = ({
         <Icon icon={closedCaptioningSquare} />
       </IconsContainer>
       <Text
-        className={!showText ? `visually-hidden` : font('sans', -1)}
+        className={
+          !showText ? `visually-hidden` : typography('body', 'md', 'regular')
+        }
         id="accessibility-provision"
       >
         {accessibilityProvisionText}

--- a/common/views/components/ApiToolbar/index.tsx
+++ b/common/views/components/ApiToolbar/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { cross } from '@weco/common/icons';
 import { Contributor, License } from '@weco/common/model/catalogue';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 export type ApiToolbarLink = {
@@ -24,7 +24,7 @@ const ToolbarContainer = styled.div`
 `;
 
 const LinkList = styled.ul.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: flex;
   list-style: none;
@@ -142,7 +142,10 @@ const ApiToolbar: FunctionComponent<Props> = ({ links = [] }) => {
           flexGrow: 1,
         }}
       >
-        <span className={font('brand-bold', 0)} style={{ marginLeft: '10px' }}>
+        <span
+          className={typography('heading', 'md', 'strong', 'brand')}
+          style={{ marginLeft: '10px' }}
+        >
           API toolbar
         </span>
         <LinkList>

--- a/common/views/components/BorderlessClickable/index.tsx
+++ b/common/views/components/BorderlessClickable/index.tsx
@@ -8,7 +8,7 @@ import {
 import styled from 'styled-components';
 
 import { IconSvg } from '@weco/common/icons';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import {
   BaseButtonInner,
   BasicButton,
@@ -75,7 +75,7 @@ const Button: ForwardRefRenderFunction<
               {/* This is all a little hacky and will need some tidy up */}
               {/* We currently only use this in the header sign in button */}
               <span
-                className={font('sans', 0)}
+                className={typography('body', 'lg', 'regular')}
                 style={{ transform: 'translateY(0.01em)' }}
               >
                 <Icon icon={iconLeft} matchText={true} />

--- a/common/views/components/Breadcrumb/index.tsx
+++ b/common/views/components/Breadcrumb/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { BreadcrumbItems, Breadcrumbs } from '@weco/common/model/breadcrumbs';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import { breadcrumbsLd } from '@weco/common/utils/json-ld';
 import { links } from '@weco/common/views/components/Header';
 import Space from '@weco/common/views/components/styled/Space';
@@ -63,7 +63,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
           <Space
             key={prefix ? `${prefix}-${text}` : text}
             as={prefix ? 'b' : 'span'}
-            className={font('sans', -2)}
+            className={typography('body', 'sm', 'regular')}
           >
             {i > 0 && (
               <Space
@@ -80,7 +80,7 @@ const Breadcrumb: FunctionComponent<BreadcrumbItems> = ({
             {prefix}{' '}
             <LinkOrSpanTag
               className={classNames({
-                [font('sans-bold', -2)]: Boolean(prefix),
+                [typography('body', 'sm', 'strong')]: Boolean(prefix),
               })}
               href={url}
               data-gtm-trigger={url ? 'breadcrumb_link' : undefined}

--- a/common/views/components/Buttons/Buttons.styles.tsx
+++ b/common/views/components/Buttons/Buttons.styles.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 import { ButtonSize, SolidButtonStyledProps } from './Buttons.types';
@@ -11,14 +11,22 @@ export const BaseButtonInner = styled.span.attrs<{
   $isNewSearchBar?: boolean;
 }>(props => ({
   className: !props.$isInline
-    ? font('sans-bold', props.$isPill ? -2 : props.$isNewSearchBar ? 0 : -1)
-    : font('sans', props.$isPill ? -2 : props.$isNewSearchBar ? 0 : -1),
+    ? props.$isPill
+      ? typography('body', 'sm', 'strong')
+      : props.$isNewSearchBar
+        ? typography('body', 'lg', 'strong')
+        : typography('body', 'md', 'strong')
+    : props.$isPill
+      ? typography('body', 'sm', 'regular')
+      : props.$isNewSearchBar
+        ? typography('body', 'lg', 'regular')
+        : typography('body', 'md', 'regular'),
 }))`
   display: flex;
   align-items: center;
   height: 1em;
 
-  /* We need to do .{class}.{class} to override any line-height set by the font utility */
+  /* We need to do .{class}.{class} to override any line-height set by the typography utility */
   && {
     line-height: 1;
   }

--- a/common/views/components/Caption/index.tsx
+++ b/common/views/components/Caption/index.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -27,7 +27,7 @@ const Wrapper = styled(Space).attrs({
     size: 'sm',
     properties: ['margin-top'],
   },
-  className: `${font('mono', -2)} caption`,
+  className: `${typography('caption', 'md', 'regular')} caption`,
 })<{ $width?: number }>`
   ${props => (props.$width ? `width: ${props.$width}px;` : '')}
 

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components';
 
 import cookies from '@weco/common/data/cookies';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 
 const headingStyles =
   'style="font-weight: 500; font-family: Inter, sans-serif;"';
@@ -54,7 +54,7 @@ const CivicUK = ({ apiKey, defer }: { apiKey: string; defer?: boolean }) => {
   const theme = useTheme();
 
   const notifyTitleStyles = `
-  class="${font('sans-bold', 1)}"
+  class="${typography('body', 'xl', 'strong')}"
   style="display: block; margin: ${theme.spacingUnits['150']} 0;"
 `;
 
@@ -75,7 +75,7 @@ const CivicUK = ({ apiKey, defer }: { apiKey: string; defer?: boolean }) => {
   };
 
   const text = {
-    title: `<h1 class="${font('sans-bold', 2)}">Manage cookies</h1>`,
+    title: `<h1 class="${typography('heading', 'xl', 'strong', 'sans')}">Manage cookies</h1>`,
     intro:
       "We use cookies to make our website work. To help us make our marketing and website better, we'd like your consent to use cookies on behalf of third parties too.",
     necessaryTitle: `<h2 ${headingStyles}>Essential cookies</h2>`,

--- a/common/views/components/CollapsibleContent/index.tsx
+++ b/common/views/components/CollapsibleContent/index.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { plus } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -24,7 +24,7 @@ const IconContainer = styled.div<{ $darkTheme?: boolean }>`
 `;
 
 const Control = styled.button.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   color: inherit;
   display: flex;

--- a/common/views/components/DownloadLink/index.tsx
+++ b/common/views/components/DownloadLink/index.tsx
@@ -2,13 +2,15 @@ import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { download } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
 const DownloadLinkStyle = styled.a.attrs<{ $isDark?: boolean }>(props => ({
-  className: props.$isDark ? font('sans', -1) : font('sans-bold', -1),
+  className: props.$isDark
+    ? typography('body', 'md', 'regular')
+    : typography('body', 'md', 'strong'),
 }))<{ $isDark?: boolean }>`
   display: inline-block;
   white-space: nowrap;
@@ -33,7 +35,9 @@ const DownloadLinkUnStyled = styled.a<{ $isDark?: boolean }>`
 `;
 
 const Format = styled(Space).attrs<{ $isDark?: boolean }>(props => ({
-  className: props.$isDark ? font('sans', -1) : font('sans-bold', -1),
+  className: props.$isDark
+    ? typography('body', 'md', 'regular')
+    : typography('body', 'md', 'strong'),
   $h: { size: 'sm', properties: ['margin-left'] },
 }))<{ $isDark?: boolean }>`
   color: ${props =>

--- a/common/views/components/Footer/Footer.Nav.tsx
+++ b/common/views/components/Footer/Footer.Nav.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react';
 import styled from 'styled-components';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { links, NavLink } from '@weco/common/views/components/Header';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -34,7 +34,7 @@ const NavList = styled.ul<{
 `;
 
 const NavLinkElement = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: {
     size: 'xs',
     properties: ['padding-top', 'padding-bottom'],

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { Venue } from '@weco/common/model/opening-hours';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Divider from '@weco/common/views/components/Divider';
 import FindUs from '@weco/common/views/components/FindUs';
@@ -24,7 +24,7 @@ type Props = {
 // Styles
 const Wrapper = styled(Space).attrs({
   as: 'footer',
-  className: `${font('sans', -1)} is-hidden-print`,
+  className: `${typography('body', 'md', 'regular')} is-hidden-print`,
   $v: { size: 'xl', properties: ['padding-top'] },
 })`
   position: relative;
@@ -162,7 +162,9 @@ const FooterBottom = styled(Space).attrs({
   justify-content: space-between;
 `;
 
-const FooterLicense = styled.p.attrs({ className: font('sans', -2) })`
+const FooterLicense = styled.p.attrs({
+  className: typography('body', 'sm', 'regular'),
+})`
   display: inline;
   margin: 0 1rem 1rem 0;
 `;
@@ -214,7 +216,7 @@ const Footer: FunctionComponent<Props> = ({
             openingtimes link */}
               {hasVenuesInfo && (
                 <>
-                  <h4 className={font('sans-bold', -1)}>
+                  <h4 className={typography('body', 'md', 'strong')}>
                     Today&rsquo;s opening times
                   </h4>
                   <OpeningTimes venues={venues} />

--- a/common/views/components/Header/Header.SignIn.Desktop.tsx
+++ b/common/views/components/Header/Header.SignIn.Desktop.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { user as userIcon } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { BorderlessLink } from '@weco/common/views/components/BorderlessClickable';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
@@ -23,7 +23,10 @@ const AccountA = styled(Space).attrs<AccountAProps>(props => ({
 `;
 
 const SignedOutWrapper = styled.span.attrs({
-  className: 'display-none headerMedium-display-block' + ' ' + font('sans', -2),
+  className:
+    'display-none headerMedium-display-block' +
+    ' ' +
+    typography('body', 'sm', 'regular'),
 })`
   /* Hack to minimise the margins between both icons when signed out */
   button span span:first-child {
@@ -69,7 +72,7 @@ const DesktopSignIn: FunctionComponent = () => {
           <Button
             variant="DropdownButton"
             label={
-              <span className={font('sans', -2)}>
+              <span className={typography('body', 'sm', 'regular')}>
                 {user.firstName.charAt(0).toLocaleUpperCase()}
                 {user.lastName.charAt(0).toLocaleUpperCase()}
               </span>
@@ -78,7 +81,7 @@ const DesktopSignIn: FunctionComponent = () => {
             id="signedin-dropdown"
             buttonType="borderless"
           >
-            <span className={font('sans', -2)}>
+            <span className={typography('body', 'sm', 'regular')}>
               <AccountA as="a" href="/account">
                 Library account
               </AccountA>

--- a/common/views/components/Header/Header.SignIn.Mobile.tsx
+++ b/common/views/components/Header/Header.SignIn.Mobile.tsx
@@ -3,12 +3,12 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { user as userIcon } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
 const StyledComponent = styled.div.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   ${props => props.theme.media('headerMedium')`
     display: none;
@@ -49,7 +49,7 @@ const MobileSignIn: FunctionComponent = () => {
     <StyledComponent>
       <Space
         $h={{ size: 'xs', properties: ['margin-right'] }}
-        className={font('sans', 0)}
+        className={typography('body', 'lg', 'regular')}
       >
         <Icon icon={userIcon} matchText={true} />
       </Space>

--- a/common/views/components/Header/index.tsx
+++ b/common/views/components/Header/index.tsx
@@ -9,7 +9,7 @@ import { searchLabelText } from '@weco/common/data/microcopy';
 import { cross, search } from '@weco/common/icons';
 import WellcomeCollectionBlack from '@weco/common/icons/wellcome_collection_black';
 import { SiteSection } from '@weco/common/model/site-section';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 import HeaderSearch from './Header.Search';
@@ -147,7 +147,9 @@ const Header: FunctionComponent<Props> = ({
                   $burgerMenuisActive={burgerMenuIsActive}
                   $hasColorBackground={hasColorBackground}
                 >
-                  <HeaderList className={font('brand-bold', -1)}>
+                  <HeaderList
+                    className={typography('heading', 'sm', 'strong', 'brand')}
+                  >
                     {(customNavLinks || links).map((link, i) => (
                       <HeaderItem key={i}>
                         <HeaderLink

--- a/common/views/components/InactivityRedirect/InactivityRedirect.Modal.tsx
+++ b/common/views/components/InactivityRedirect/InactivityRedirect.Modal.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
@@ -13,7 +13,7 @@ const RedirectModalContent = styled(Space).attrs({
 `;
 
 const RedirectModalTitle = styled.h2.attrs({
-  className: font('brand-bold', 1),
+  className: typography('heading', 'lg', 'strong', 'brand'),
 })`
   margin-bottom: ${props => props.theme.getSpaceValue('md', 'zero')};
 `;
@@ -63,7 +63,7 @@ const InactivityRedirectModal: FunctionComponent<Props> = ({
       <span
         data-chromatic="ignore"
         aria-hidden="true"
-        className={font('brand-bold', 5)}
+        className={typography('display', 'md', 'strong')}
       >
         {countdown}
       </span>

--- a/common/views/components/InfoBanner/InfoBanners.styles.ts
+++ b/common/views/components/InfoBanner/InfoBanners.styles.ts
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
 export const BannerContainer = styled(Space).attrs({
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<{ $backgroundColor?: PaletteColor }>`
   background-color: ${props =>
     props.theme.color(props.$backgroundColor || 'yellow')};

--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -10,14 +10,14 @@ import {
 import { KiosksContentType } from '@weco/common/contexts/KioskContext/kiosks-content';
 import { arrowSmall, home } from '@weco/common/icons';
 import { useModes } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
 const KioskNavigationWrapper = styled(Space).attrs({
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'md', properties: ['padding-left', 'padding-right'] },
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   height: ${props => props.theme.kioskNavigationHeight}px;
   position: fixed;

--- a/common/views/components/LabelsList/LabelsList.Label.tsx
+++ b/common/views/components/LabelsList/LabelsList.Label.tsx
@@ -2,7 +2,7 @@ import { CSSProperties, FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { LabelColor, Label as LabelType } from '@weco/common/model/labels';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
@@ -12,7 +12,7 @@ type LabelContainerProps = {
 };
 
 const LabelContainer = styled(Space).attrs({
-  className: font('sans-bold', -2),
+  className: typography('body', 'sm', 'strong'),
 })<LabelContainerProps>`
   white-space: nowrap;
 

--- a/common/views/components/NewsletterPromo/index.tsx
+++ b/common/views/components/NewsletterPromo/index.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { newsletterAddressBook } from '@weco/common/data/dotdigital';
 import useValidation from '@weco/common/hooks/useValidation';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio';
 import {
@@ -31,7 +31,7 @@ const NewsletterForm = styled.form.attrs({
 `;
 
 const PrivacyNotice = () => (
-  <p className={font('sans', -2)}>
+  <p className={typography('body', 'sm', 'regular')}>
     By clicking subscribe, you agree to receive this newsletter. You can
     unsubscribe any time. For information about how we handle your data,{' '}
     <a
@@ -108,12 +108,18 @@ const NewsletterPromo: FunctionComponent = () => {
     >
       <Container>
         <ContaineredLayout gridSizes={gridSize8()}>
-          <h2 className={font('brand-bold', 1)} style={{ textAlign: 'center' }}>
+          <h2
+            className={typography('heading', 'lg', 'strong', 'brand')}
+            style={{ textAlign: 'center' }}
+          >
             {isSuccess ? 'Thank you for signing up!' : 'Stay in the know'}
           </h2>
           {!isSuccess && (
             <>
-              <p className={font('sans', -1)} style={{ marginBottom: '1rem' }}>
+              <p
+                className={typography('body', 'md', 'regular')}
+                style={{ marginBottom: '1rem' }}
+              >
                 Sign up to our newsletter to find out what’s on, read our latest
                 stories and get involved.
               </p>
@@ -142,7 +148,7 @@ const NewsletterPromo: FunctionComponent = () => {
                 />
 
                 <p
-                  className={font('sans', -2)}
+                  className={typography('body', 'sm', 'regular')}
                   style={{ marginBottom: 0, marginTop: '1rem' }}
                 >
                   <a href="/newsletter">All our newsletters</a>
@@ -158,7 +164,7 @@ const NewsletterPromo: FunctionComponent = () => {
                       setHasCheckedMarketing(currentValue => !currentValue);
                     }}
                     text={
-                      <p className={font('sans', -2)}>
+                      <p className={typography('body', 'sm', 'regular')}>
                         Tick this box if you’re happy to receive other emails
                         about Wellcome Collection, upcoming events and
                         exhibitions and/or other relevant opportunities.
@@ -182,7 +188,9 @@ const NewsletterPromo: FunctionComponent = () => {
           )}
 
           {isSuccess && (
-            <div className={`${font('sans', -1)} spaced-text`}>
+            <div
+              className={`${typography('body', 'md', 'regular')} spaced-text`}
+            >
               <p>
                 If this is the first time you have subscribed to one of our
                 newsletters, you will receive an email asking you to confirm

--- a/common/views/components/PageHeader/PageHeader.Landing.tsx
+++ b/common/views/components/PageHeader/PageHeader.Landing.tsx
@@ -4,7 +4,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
 import {
   ContaineredLayout,
@@ -20,7 +20,7 @@ import { TitleWrapper, Wrapper } from './PageHeader.styles';
 
 const ContentWrapper = styled(Space).attrs({
   $v: { size: 'xs', properties: ['margin-top'] },
-  className: font('sans', 2),
+  className: typography('body', 'xl', 'regular'),
 })`
   p:last-child {
     margin-bottom: 0;

--- a/common/views/components/PageHeader/PageHeader.styles.tsx
+++ b/common/views/components/PageHeader/PageHeader.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
@@ -24,7 +24,9 @@ export const Wrapper = styled(Space)`
 export const TitleWrapper = styled.h1.attrs<{
   $isOfficialLandingPage?: boolean;
 }>(props => ({
-  className: font('brand-bold', props.$isOfficialLandingPage ? 5 : 4),
+  className: props.$isOfficialLandingPage
+    ? typography('display', 'md', 'strong')
+    : typography('heading', 'xxl', 'strong', 'brand'),
 }))`
   display: inline-block;
   margin: 0 !important;

--- a/common/views/components/PageHeader/PagerHeader.Basic.tsx
+++ b/common/views/components/PageHeader/PagerHeader.Basic.tsx
@@ -7,7 +7,7 @@ import {
 import styled from 'styled-components';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import AccessibilityProvision from '@weco/common/views/components/AccessibilityProvision';
 import Breadcrumb from '@weco/common/views/components/Breadcrumb';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
@@ -42,7 +42,7 @@ const Heading = styled(Space)`
 
 const HighlightedHeading: FunctionComponent<{ text: string }> = ({ text }) => {
   return (
-    <h1 className={font('brand-bold', 2)}>
+    <h1 className={typography('heading', 'xl', 'strong', 'brand')}>
       <Heading
         $v={{ size: 'xs', properties: ['padding-top', 'padding-bottom'] }}
         $h={{ size: 'sm', properties: ['padding-left', 'padding-right'] }}
@@ -151,7 +151,7 @@ const BasicPageHeader: FunctionComponent<Props> = ({
             {isContentTypeInfoBeforeMedia && ContentTypeInfo && (
               <Space
                 $v={{ size: 'sm', properties: ['margin-bottom'] }}
-                className={font('sans', 0)}
+                className={typography('body', 'lg', 'regular')}
               >
                 {ContentTypeInfo}
               </Space>
@@ -198,7 +198,7 @@ const BasicPageHeader: FunctionComponent<Props> = ({
         <ContaineredLayout gridSizes={pageGridLayout}>
           <Space
             $v={{ size: 'md', properties: ['margin-top'] }}
-            className={font('sans-bold', 0)}
+            className={typography('body', 'lg', 'strong')}
           >
             {ContentTypeInfo}
           </Space>

--- a/common/views/components/PopupDialog/PopupDialog.styles.tsx
+++ b/common/views/components/PopupDialog/PopupDialog.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 type PopupDialogOpenProps = {
@@ -22,7 +22,7 @@ export const PopupDialogOpen = styled(Space).attrs<PopupDialogOpenProps>(
       properties: ['padding-left', 'padding-right'],
       overrides: { zero: '200', sm: '200', md: '200' },
     },
-    className: font('sans-bold', -1),
+    className: typography('body', 'md', 'strong'),
   })
 )<PopupDialogOpenProps>`
   line-height: 1;
@@ -118,7 +118,7 @@ export const PopupDialogCTA = styled(Space).attrs({
     properties: ['padding-left', 'padding-right'],
     overrides: { zero: '200', sm: '200', md: '200' },
   },
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: inline-block;
   background-color: ${props => props.theme.color('accent.purple')};

--- a/common/views/components/PopupDialog/index.tsx
+++ b/common/views/components/PopupDialog/index.tsx
@@ -12,7 +12,7 @@ import { chat, clear } from '@weco/common/icons';
 import { PopupDialogDocument as RawPopupDialogDocument } from '@weco/common/prismicio-types';
 import { transformLink } from '@weco/common/services/prismic/transformers';
 import { InferDataInterface } from '@weco/common/services/prismic/types';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import getFocusableElements from '@weco/common/utils/get-focusable-elements';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
@@ -185,8 +185,10 @@ const PopupDialog: FunctionComponent<Props> = ({ document }: Props) => {
             overrides: { zero: '150', sm: '150', md: '150' },
           }}
         >
-          <h2 className={font('brand-bold', -2)}>{title}</h2>
-          <div className={font('sans', -1)}>
+          <h2 className={typography('heading', 'xs', 'strong', 'brand')}>
+            {title}
+          </h2>
+          <div className={typography('body', 'md', 'regular')}>
             <PrismicHtmlBlock html={text} />
           </div>
         </Space>

--- a/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
+++ b/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const DialogControls = styled.span`
@@ -33,7 +33,7 @@ export const DialogButton = styled.button`
 
 export const TranscriptButton = styled.button.attrs({
   type: 'button',
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   display: flex;
   align-items: center;
@@ -84,7 +84,7 @@ export const VideoIframe = styled.iframe`
 export const TranscriptOverlay = styled(Space).attrs({
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<{ $hidden: boolean }>`
   position: absolute;
   inset: 0;

--- a/common/views/components/PortraitVideoEmbed/index.tsx
+++ b/common/views/components/PortraitVideoEmbed/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { play } from '@weco/common/icons';
 import { ImageType } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
@@ -73,7 +73,7 @@ const PlayCircle = styled.span`
 `;
 
 const DurationText = styled.span.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   color: ${props => props.theme.color('white')};
 `;
@@ -81,7 +81,7 @@ const DurationText = styled.span.attrs({
 const CardTitle = styled(Space).attrs({
   $v: { size: 'xs', properties: ['margin-top'] },
   as: 'span',
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: block;
   line-height: 1.6;

--- a/common/views/components/SearchBar/SearchBar.New.tsx
+++ b/common/views/components/SearchBar/SearchBar.New.tsx
@@ -11,7 +11,7 @@ import styled, { useTheme } from 'styled-components';
 import Typed from 'typed.js';
 
 import { search } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import TextInput from '@weco/common/views/components/TextInput';
 import { visuallyHiddenStyles } from '@weco/common/views/themes/utility-classes';
@@ -22,7 +22,7 @@ const Container = styled.div`
 `;
 
 const Typewriter = styled.div.attrs({
-  className: font('sans', 1),
+  className: typography('body', 'xl', 'regular'),
   'aria-hidden': 'true',
 })`
   position: absolute;

--- a/common/views/components/StackingTable/index.tsx
+++ b/common/views/components/StackingTable/index.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, ReactElement, ReactNode } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { bodyStrongFontWeight } from '@weco/common/views/themes/typography';
 
@@ -11,7 +11,7 @@ type TableProps = {
 };
 
 const StyledTable = styled.table.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<TableProps>`
   table-layout: ${props => (props.$useFixedWidth ? 'fixed' : 'auto')};
   width: 100%;
@@ -66,7 +66,7 @@ const StyledTh = styled(Space).attrs<ThProps>(props => ({
     size: 'sm',
     properties: props.$plain ? [] : ['padding-left', 'padding-right'],
   },
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 }))<ThProps>`
   background: ${props =>
     props.$plain ? 'transparent' : props.theme.color('warmNeutral.400')};

--- a/common/views/components/Tasl/Tasl.styles.tsx
+++ b/common/views/components/Tasl/Tasl.styles.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const StyledTasl = styled.div.attrs({
-  className: `${font('mono', -2)} plain-text tasl`, // Need the tasl class as it's used with ImageGallery styled components
+  className: `${typography('caption', 'md', 'regular')} plain-text tasl`, // Need the tasl class as it's used with ImageGallery styled components
 })<{ $positionAtTop: boolean; $isEnhanced: boolean }>`
   text-align: right;
   top: ${props => (props.$positionAtTop ? 0 : 'auto')};

--- a/common/views/components/TextInput/index.tsx
+++ b/common/views/components/TextInput/index.tsx
@@ -11,14 +11,14 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { exclamation, tickCircle } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import ClearInput from '@weco/common/views/components/TextInput/TextInput.Clear';
 import { focusStyle } from '@weco/common/views/themes/base/wellcome-normalize';
 
 export const TextInputLabel = styled.label.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: block;
   line-height: 1.2;
@@ -30,7 +30,9 @@ type TextInputWrapProps = {
   $isNewSearchBar?: boolean;
 };
 export const TextInputWrap = styled(Space).attrs<TextInputWrapProps>(props => ({
-  className: font('sans', props.$isNewSearchBar ? 1 : 0),
+  className: props.$isNewSearchBar
+    ? typography('body', 'xl', 'regular')
+    : typography('body', 'lg', 'regular'),
   $v: { size: 'xs', properties: ['margin-top'] },
 }))<TextInputWrapProps>`
   display: flex;
@@ -78,7 +80,7 @@ export const TextInputWrap = styled(Space).attrs<TextInputWrapProps>(props => ({
 `;
 
 const HintCopy = styled.span.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: block;
   color: ${props => props.theme.color('neutral.700')};
@@ -105,7 +107,7 @@ export const TextInputInput = styled.input.attrs<{ $type?: string }>(props => ({
 `;
 
 const StatusMessage = styled(Space).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
   $v: { size: 'xs', properties: ['margin-top'] },
 })`
   display: flex;

--- a/common/views/components/ThemeCard/index.tsx
+++ b/common/views/components/ThemeCard/index.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent, useState } from 'react';
 import styled from 'styled-components';
 
 import { LinkProps } from '@weco/common/model/link-props';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Space from '@weco/common/views/components/styled/Space';
 import { ConceptImagesArray } from '@weco/content/hooks/useConceptImageUrls';
 
 const Title = styled(Space).attrs({
-  className: font('brand', 1),
+  className: typography('heading', 'lg', 'regular', 'brand'),
   as: 'h3',
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
@@ -98,7 +98,7 @@ const TextContent = styled(Space).attrs({
 `;
 
 const Description = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   margin-bottom: 0;
 `;

--- a/common/views/components/styled/PaginationWrapper.tsx
+++ b/common/views/components/styled/PaginationWrapper.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 
 import Space from './Space';
 
 const PaginationWrapper = styled(Space).attrs<{
   $verticalSpacing?: 'md' | 'sm';
 }>(props => ({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   ...(props.$verticalSpacing && {
     $v: {
       size: props.$verticalSpacing,

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -175,11 +175,7 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                   cookieContent={kioskModeCookie}
                   readingRoomStories={serverData.prismic.readingRoomStories}
                 >
-                  <GlobalStyle
-                    $compositeTypography={
-                      !!serverData.toggles.featureFlags.compositeTypography
-                    }
-                  />
+                  <GlobalStyle />
 
                   <GlobalSvgDefinitions />
                   <LoadingIndicator />

--- a/common/views/slices/ArchiveCardList/index.tsx
+++ b/common/views/slices/ArchiveCardList/index.tsx
@@ -2,7 +2,7 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { ArchiveCardListSlice as RawArchiveCardListSlice } from '@weco/common/prismicio-types';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { Container } from '@weco/common/views/components/styled/Container';
 import {
@@ -58,7 +58,9 @@ const ArchiveCardListSlice: FunctionComponent<ArchiveCardListSliceProps> = ({
       <Container>
         {title && (
           <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-            <h2 className={font('sans-bold', 2)}>{title}</h2>
+            <h2 className={typography('heading', 'xl', 'strong', 'sans')}>
+              {title}
+            </h2>
           </Space>
         )}
         <Grid>

--- a/common/views/slices/CardListing/index.tsx
+++ b/common/views/slices/CardListing/index.tsx
@@ -7,7 +7,7 @@ import {
   SeriesDocument as RawSeriesDocument,
 } from '@weco/common/prismicio-types';
 import { isFilledLinkToDocumentWithData } from '@weco/common/services/prismic/types';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import { gridSize12 } from '@weco/common/views/components/Layout';
@@ -119,18 +119,20 @@ const CardListingSlice: FunctionComponent<CardListingSliceProps> = ({
                   background="black"
                   textColor="white"
                 >
-                  <h3 className={font('brand-bold', 2)}>
+                  <h3
+                    className={typography('heading', 'xl', 'strong', 'brand')}
+                  >
                     {featuredItem.data.title}
                   </h3>
                   {featuredItem.type === 'series' &&
                     featuredItem.data.description && (
-                      <p className={font('sans', -1)}>
+                      <p className={typography('body', 'md', 'regular')}>
                         {featuredItem.data.description}
                       </p>
                     )}
                   {featuredItem.type === 'article' &&
                     featuredItem.data.promo?.caption && (
-                      <p className={font('sans', -1)}>
+                      <p className={typography('body', 'md', 'regular')}>
                         {featuredItem.data.promo.caption}
                       </p>
                     )}

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -6,11 +6,7 @@ import { normalize } from './base/normalize';
 import { row } from './base/row';
 import { wellcomeNormalize } from './base/wellcome-normalize';
 import { Size, themeValues } from './config';
-import {
-  makeCompositeTypographyClasses,
-  makeFontSizeClasses,
-  typography,
-} from './typography';
+import { makeTypographyClasses, typography } from './typography';
 import { utilityClasses } from './utility-classes';
 
 type Classes = typeof classes;
@@ -47,7 +43,7 @@ const cls = {
   ...sizesClasses,
 } as unknown as Classes & SizedClasses;
 
-const GlobalStyle = createGlobalStyle<{ $compositeTypography: boolean }>`
+const GlobalStyle = createGlobalStyle`
   ${css`
     .${cls.displayBlock} {
       display: block;
@@ -78,9 +74,8 @@ const GlobalStyle = createGlobalStyle<{ $compositeTypography: boolean }>`
   ${layout}
   ${row}
   ${fonts}
-  ${({ $compositeTypography }) => !$compositeTypography && makeFontSizeClasses()}
   ${typography}
-  ${({ $compositeTypography }) => $compositeTypography && makeCompositeTypographyClasses()}
+  ${makeTypographyClasses()}
 `;
 
 // Static theme instance for backward compatibility

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -17,7 +17,7 @@ import { css } from 'styled-components';
 export const bodyStrongFontWeight =
   designSystemTheme.typography.body.strong?.lg?.fontWeight ?? 'bold';
 
-export const compositeTypographyMixin = (
+export const typographyMixin = (
   category: 'body' | 'caption' | 'display' | 'label' | 'heading',
   size: TypographySizeKey,
   weight: 'regular' | 'strong',
@@ -53,7 +53,7 @@ export const typography = css`
   }
 
   body {
-    ${compositeTypographyMixin('body', 'lg', 'regular')}
+    ${typographyMixin('body', 'lg', 'regular')}
     color: ${props => props.theme.color('black')};
     font-variant-ligatures: no-common-ligatures;
     -webkit-font-smoothing: antialiased;
@@ -149,15 +149,15 @@ export const typography = css`
 
   .body-text {
     h1 {
-      ${compositeTypographyMixin('heading', 'xxl', 'strong', 'brand')}
+      ${typographyMixin('heading', 'xxl', 'strong', 'brand')}
     }
 
     h2 {
-      ${compositeTypographyMixin('heading', 'xl', 'strong', 'brand')}
+      ${typographyMixin('heading', 'xl', 'strong', 'brand')}
     }
 
     h3 {
-      ${compositeTypographyMixin('body', 'xl', 'strong')}
+      ${typographyMixin('body', 'xl', 'strong')}
     }
 
     *::selection {
@@ -206,7 +206,7 @@ export const typography = css`
   }
 
   .drop-cap {
-    ${compositeTypographyMixin('heading', 'xl', 'strong', 'brand')}
+    ${typographyMixin('heading', 'xl', 'strong', 'brand')}
     font-size: 3em;
     color: ${props => props.theme.color('black')};
     float: left;
@@ -238,7 +238,7 @@ export const typography = css`
     position: relative;
 
     &::before {
-      ${compositeTypographyMixin('heading', 'xl', 'strong', 'brand')}
+      ${typographyMixin('heading', 'xl', 'strong', 'brand')}
       position: absolute;
       content: '“';
       color: ${props => props.theme.color('accent.blue')};
@@ -254,15 +254,7 @@ export const typography = css`
   }
 `;
 
-export const makeFontSizeClasses = () => css`
-  ${Object.entries(designSystemTheme.font.size)
-    .map(([key, value]) => {
-      return `.font-size-${key} {font-size: ${value}}`;
-    })
-    .join(' ')}
-`;
-
-export const makeCompositeTypographyClasses = () => {
+export const makeTypographyClasses = () => {
   const t = designSystemTheme.typography;
   const sizes: TypographySizeKey[] = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'];
 

--- a/content/webapp/views/components/Accordion/index.tsx
+++ b/content/webapp/views/components/Accordion/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
 import { chevron } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -29,7 +29,7 @@ const SummaryInner = styled.div`
 const Summary = styled(Space).attrs({
   as: 'summary',
   $v: { size: 'md', properties: ['padding-top', 'padding-bottom'] },
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
 })`
   border-top: 1px solid ${props => props.theme.color('neutral.300')};
   cursor: pointer;
@@ -55,7 +55,7 @@ const Summary = styled(Space).attrs({
 
 const ShowHide = styled(Space).attrs({
   $h: { size: 'xs', properties: ['margin-right'] },
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   position: relative;
 
@@ -86,7 +86,7 @@ const ShowHide = styled(Space).attrs({
 `;
 
 const Details = styled.details.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   @media (prefers-reduced-motion: no-preference) {
     /* stylelint-disable-next-line property-no-unknown */

--- a/content/webapp/views/components/ArchiveCard/index.tsx
+++ b/content/webapp/views/components/ArchiveCard/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { organisation, user } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -16,7 +16,7 @@ const Wrapper = styled(NextLink)`
 `;
 
 const Root = styled(Space).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
 })`
@@ -37,7 +37,7 @@ const Label = styled(Space).attrs({
 const Title = styled(Space).attrs({
   as: 'h2',
   $v: { size: 'xs', properties: ['margin-bottom'] },
-  className: font('brand', 0),
+  className: typography('heading', 'md', 'regular', 'brand'),
 })`
   ${Root}:hover & {
     text-decoration: underline;

--- a/content/webapp/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { check } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 const PlayRateContainer = styled.div`
@@ -13,7 +13,7 @@ const PlayRateContainer = styled.div`
 `;
 
 const TogglePlayRateButton = styled.button.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })<{ $isDark: boolean }>`
   anchor-name: --play-rate-button;
   color: ${props =>
@@ -34,7 +34,7 @@ const TogglePlayRateButton = styled.button.attrs({
 
 const PlayRateButton = styled.div.attrs({
   as: 'button',
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<{
   $isDark: boolean;
 }>`
@@ -166,7 +166,9 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
           aria-expanded={isPlayRateActive}
         >
           Speed
-          <span className={font('sans-bold', 0)}>{audioPlaybackRate}x</span>
+          <span className={typography('body', 'lg', 'strong')}>
+            {audioPlaybackRate}x
+          </span>
         </TogglePlayRateButton>
         <PlayRateList popover="auto" ref={popoverRef} id={id} $isDark={isDark}>
           <ul>

--- a/content/webapp/views/components/AudioPlayer/AudioPlayer.styles.tsx
+++ b/content/webapp/views/components/AudioPlayer/AudioPlayer.styles.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const AudioPlayerWrapper = styled(Space).attrs({
@@ -23,7 +23,7 @@ export const PlayPauseButton = styled.button.attrs<PlayPauseButtonProps>(
 `;
 
 export const TimeWrapper = styled.div.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })<{ $isDark: boolean }>`
   display: flex;
   justify-content: space-between;

--- a/content/webapp/views/components/AudioPlayer/index.tsx
+++ b/content/webapp/views/components/AudioPlayer/index.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, useEffect, useId, useRef, useState } from 'react';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
@@ -180,7 +180,10 @@ export const AudioPlayer: FunctionComponent<AudioPlayerProps> = ({
       <AudioPlayerWrapper $isDark={!!isDark}>
         {title && (
           <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-            <figcaption className={font('sans-bold', -1)} {...titleProps}>
+            <figcaption
+              className={typography('body', 'md', 'strong')}
+              {...titleProps}
+            >
               <TitleWrapper $isDark={!!isDark}>{title}</TitleWrapper>
             </figcaption>
           </Space>

--- a/content/webapp/views/components/BetaMessage/index.tsx
+++ b/content/webapp/views/components/BetaMessage/index.tsx
@@ -2,12 +2,12 @@ import { FunctionComponent, ReactElement, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { underConstruction } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
 const StyledBetaMessage = styled.div.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: flex;
   align-items: center;

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { officialLandingPagesUid } from '@weco/common/data/hardcoded-ids';
 import { ContentListSlice as RawContentListSlice } from '@weco/common/prismicio-types';
 import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
 import {
@@ -215,12 +215,18 @@ const Body: FunctionComponent<Props> = ({
               isReversed={false}
               priority={isFirst}
             >
-              <h3 className={font('brand-bold', 2)}>{firstItem.title}</h3>
+              <h3 className={typography('heading', 'xl', 'strong', 'brand')}>
+                {firstItem.title}
+              </h3>
               {isCardType && firstItem.description && (
-                <p className={font('sans', -1)}>{firstItem.description}</p>
+                <p className={typography('body', 'md', 'regular')}>
+                  {firstItem.description}
+                </p>
               )}
               {'promo' in firstItem && firstItem.promo && (
-                <p className={font('sans', -1)}>{firstItem.promo.caption}</p>
+                <p className={typography('body', 'md', 'regular')}>
+                  {firstItem.promo.caption}
+                </p>
               )}
             </FeaturedCard>
           ) : null;

--- a/content/webapp/views/components/BslLeafletVideo/index.tsx
+++ b/content/webapp/views/components/BslLeafletVideo/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { bslSquare } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import {
   ContaineredLayout,
@@ -15,7 +15,7 @@ import VideoEmbed, {
 } from '@weco/common/views/components/VideoEmbed';
 
 const BslLeaftletButtonText = styled(Space).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
   $h: { size: 'xs', properties: ['margin-left'] },
 })``;
 
@@ -68,7 +68,10 @@ const BslLeafletVideo: FunctionComponent<Props> = ({
           $v={{ size: 'sm', properties: ['padding-top', 'padding-bottom'] }}
         >
           <Space $h={{ size: 'xl', properties: ['padding-right'] }}>
-            <h3 className={font('sans-bold', -1)} style={{ marginBottom: 0 }}>
+            <h3
+              className={typography('body', 'md', 'strong')}
+              style={{ marginBottom: 0 }}
+            >
               {video.title}
             </h3>
           </Space>

--- a/content/webapp/views/components/Card/index.tsx
+++ b/content/webapp/views/components/Card/index.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 
 import { getCrop } from '@weco/common/model/image';
 import { Label as LabelType } from '@weco/common/model/labels';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -158,7 +158,7 @@ export const CardLabels: FunctionComponent<{ labels: LabelType[] }> = ({
 );
 
 const Description = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   padding: 0;
   margin: 0;
@@ -166,7 +166,7 @@ const Description = styled.p.attrs({
 
 export const CardTitle = styled(Space).attrs({
   as: 'h3',
-  className: font('brand-bold', 1),
+  className: typography('heading', 'lg', 'strong', 'brand'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
   transition: color 400ms ease;

--- a/content/webapp/views/components/CardGrid/CardGrid.BookCard.tsx
+++ b/content/webapp/views/components/CardGrid/CardGrid.BookCard.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import { BookBasic } from '@weco/content/types/books';
@@ -35,20 +35,20 @@ const LinkSpace = styled(Space).attrs<LinkSpaceAttrs>(props => ({
 `;
 
 const Title = styled.h3.attrs({
-  className: font('brand-bold', 0),
+  className: typography('heading', 'md', 'strong', 'brand'),
 })`
   margin: 0;
 `;
 
 const Subtitle = styled(Space).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $v: { size: 'xs', properties: ['margin-top'] },
 })`
   margin: 0;
 `;
 
 const Caption = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   margin: 0;
 `;

--- a/content/webapp/views/components/CardGrid/CardGrid.ExhibitionCard.tsx
+++ b/content/webapp/views/components/CardGrid/CardGrid.ExhibitionCard.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -18,7 +18,7 @@ import DateRange from '@weco/content/views/components/DateRange';
 import StatusIndicator from '@weco/content/views/components/StatusIndicator';
 
 const DateWrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'sm', properties: ['margin-bottom'] },
 })`
   padding: 0;

--- a/content/webapp/views/components/CardGrid/CardGrid.ExhibitionGuideCard.tsx
+++ b/content/webapp/views/components/CardGrid/CardGrid.ExhibitionGuideCard.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
 import {
@@ -62,7 +62,10 @@ const ExhibitionGuideCard: FunctionComponent<Props> = ({ exhibitionGuide }) => {
           <CardTitle>{exhibitionGuide.title}</CardTitle>
           {exhibitionGuide.promo?.caption && (
             <Space $v={{ size: 'xs', properties: ['margin-top'] }}>
-              <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+              <p
+                className={typography('body', 'md', 'regular')}
+                style={{ marginBottom: 0 }}
+              >
                 {exhibitionGuide.promo.caption}
               </p>
             </Space>

--- a/content/webapp/views/components/CardGrid/CardGrid.ExhibitionGuideLinksCard.tsx
+++ b/content/webapp/views/components/CardGrid/CardGrid.ExhibitionGuideLinksCard.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -77,13 +77,13 @@ const ExhibitionGuideLinksCard: FunctionComponent<Props> = ({
         <Space
           $v={{ size: 'sm', properties: ['margin-top', 'margin-bottom'] }}
           as="h3"
-          className={font('brand-bold', 1)}
+          className={typography('heading', 'lg', 'strong', 'brand')}
         >
           {exhibitionGuide.title}
         </Space>
       </ExhibitionTitleLink>
       <Space $v={{ size: 'xs', properties: ['margin-top'] }}>
-        <PlainList className={font('sans', -1)}>
+        <PlainList className={typography('body', 'md', 'regular')}>
           {links.map((link, i) => (
             <Type key={i}>
               <a href={link.url}>{link.text}</a>

--- a/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.tsx
+++ b/content/webapp/views/components/CatalogueImageGallery/CatalogueImageGallery.Scrollable.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { Image } from '@weco/content/services/wellcome/catalogue/types';
 import { useExpandedImage } from '@weco/content/views/components/ImageModal';
@@ -18,7 +18,7 @@ export type Props = {
 };
 
 const DetailsCopy = styled.span.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   color: ${props => props.theme.color('neutral.400')};
 `;

--- a/content/webapp/views/components/CollaboratorCards/CollaboratorsCards.Card.tsx
+++ b/content/webapp/views/components/CollaboratorCards/CollaboratorsCards.Card.tsx
@@ -3,12 +3,12 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { IconSvg } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 
 const StyledLink = styled(NextLink).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   background-color: ${props => props.theme.color('warmNeutral.300')};
   padding: ${props => props.theme.spacingUnits['100']};

--- a/content/webapp/views/components/CompactCard/CompactCard.test.tsx
+++ b/content/webapp/views/components/CompactCard/CompactCard.test.tsx
@@ -7,15 +7,19 @@ import {
   mockDataWithPrismicText,
 } from '@weco/common/test/fixtures/components/compact-card';
 import { renderWithTheme } from '@weco/common/test/fixtures/test-helpers';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import { GridCell, SizeMap } from '@weco/common/views/components/styled/Grid';
 
 import CompactCard, { HasImageProps } from '.';
 
-const getBaseTitleClass = number => {
-  return font('brand-bold', number);
+const getBaseTitleClass = (number: 0 | 1) => {
+  const map = {
+    0: typography('heading', 'md', 'strong', 'brand'),
+    1: typography('heading', 'lg', 'strong', 'brand'),
+  } as const;
+  return map[number];
 };
 
 const mockOnClick = jest.fn();
@@ -62,7 +66,7 @@ const TextWrapper = styled(GridCell).attrs<HasImageProps>(props => {
 })<HasImageProps>``;
 
 const TitleWrapper = styled.div.attrs({
-  className: font('brand-bold', 0),
+  className: typography('heading', 'md', 'strong', 'brand'),
 })``;
 
 const extraClass = 'my_extra_extra_class';

--- a/content/webapp/views/components/CompactCard/index.tsx
+++ b/content/webapp/views/components/CompactCard/index.tsx
@@ -7,7 +7,7 @@ import {
 import styled from 'styled-components';
 
 import { Label } from '@weco/common/model/labels';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import ImageType from '@weco/common/views/components/PrismicImage';
@@ -52,7 +52,7 @@ type CompactArticleProps = ArticleCardProps & {
 export type Props = CompactCardProps | CompactArticleProps;
 
 const BaseTitleWrapper = styled.h3.attrs({
-  className: font('brand-bold', 1),
+  className: typography('heading', 'lg', 'strong', 'brand'),
 })`
   margin: 0;
 `;
@@ -177,7 +177,9 @@ const CompactCard: FunctionComponent<Props> = (
           {ExtraInfo}
 
           {description && (
-            <div className={`spaced-text ${font('sans', -1)}`}>
+            <div
+              className={`spaced-text ${typography('body', 'md', 'regular')}`}
+            >
               {descriptionIsString ? <p>{description}</p> : description}
             </div>
           )}

--- a/content/webapp/views/components/Contact/index.tsx
+++ b/content/webapp/views/components/Contact/index.tsx
@@ -7,7 +7,7 @@ import {
   link as linkIcon,
   phone as phoneIcon,
 } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -25,15 +25,19 @@ const TitleWrapper = styled(Space).attrs({
   display: block;
 `;
 
-const Title = styled.span.attrs({ className: font('sans-bold', 0) })``;
+const Title = styled.span.attrs({
+  className: typography('body', 'lg', 'strong'),
+})``;
 
 const Subtitle = styled(Space).attrs({
   as: 'span',
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
   $h: { size: 'xs', properties: ['margin-left'] },
 })``;
 
-const PhoneNumber = styled.span.attrs({ className: font('sans', 0) })`
+const PhoneNumber = styled.span.attrs({
+  className: typography('body', 'lg', 'regular'),
+})`
   display: block;
 `;
 
@@ -94,7 +98,7 @@ const Contact: FunctionComponent<Props> = ({
           <NextLink
             href={{ pathname: link.url }}
             style={{ display: 'block' }}
-            className={font('sans', 0)}
+            className={typography('body', 'lg', 'regular')}
           >
             {link.text}
           </NextLink>
@@ -118,7 +122,7 @@ const Contact: FunctionComponent<Props> = ({
           <Icon icon={emailIcon} />
           <a
             style={{ display: 'block' }}
-            className={font('sans', 0)}
+            className={typography('body', 'lg', 'regular')}
             href={`mailto:${email}`}
           >
             {email}

--- a/content/webapp/views/components/ContentPage/ContentPage.BannerCard.tsx
+++ b/content/webapp/views/components/ContentPage/ContentPage.BannerCard.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components';
 import { arrowSmall } from '@weco/common/icons';
 import { getCrop } from '@weco/common/model/image';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import Button from '@weco/common/views/components/Buttons';
 import LabelsList from '@weco/common/views/components/LabelsList';
@@ -62,7 +62,7 @@ const ImageWrapper = styled.div<ImageWrapperProps>`
 `;
 
 const DateRangeWrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-top', 'margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.400')};
@@ -133,7 +133,7 @@ const BannerCard: FunctionComponent<Props> = ({
         )}
         <Space
           as="h2"
-          className={font('brand-bold', 2)}
+          className={typography('heading', 'xl', 'strong', 'brand')}
           $v={{ size: 'sm', properties: ['margin-top', 'margin-bottom'] }}
         >
           {title}
@@ -143,7 +143,7 @@ const BannerCard: FunctionComponent<Props> = ({
             <DateRange start={start} end={end} />
           </DateRangeWrapper>
         )}
-        <p className={font('sans', -1)}>{description}</p>
+        <p className={typography('body', 'md', 'regular')}>{description}</p>
         <Button
           variant="ButtonSolid"
           colors={theme.buttonColors.whiteTransparentWhite}

--- a/content/webapp/views/components/ContentPage/ContentPage.LinkedWorks.tsx
+++ b/content/webapp/views/components/ContentPage/ContentPage.LinkedWorks.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useEffect } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { ContaineredLayout } from '@weco/common/views/components/Layout';
 import { SizeMap } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
@@ -35,7 +35,7 @@ const ListItem = styled.li`
 `;
 
 const DetailsCopy = styled.span.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   color: ${props => props.theme.color('black')};
 `;
@@ -71,7 +71,9 @@ const LinkedWorks: FunctionComponent<LinkedWorkProps> = ({
   return (
     <FullWidthRow>
       <ContaineredLayout gridSizes={gridSizes as SizeMap}>
-        <h2 className={font('brand-bold', 1)}>Featured in this article</h2>
+        <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+          Featured in this article
+        </h2>
       </ContaineredLayout>
 
       <ScrollContainer

--- a/content/webapp/views/components/ContentSearchResult/index.tsx
+++ b/content/webapp/views/components/ContentSearchResult/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
 import Space from '@weco/common/views/components/styled/Space';
 import { Addressable } from '@weco/content/services/wellcome/content/types/api';
@@ -22,13 +22,13 @@ const Link = styled(NextLink)`
 
 const Type = styled(Space).attrs({
   $v: { size: 'xs', properties: ['margin-bottom'] },
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })``;
 
 const Title = styled(Space).attrs({
   as: 'h2',
   $v: { size: 'xs', properties: ['margin-bottom'] },
-  className: font('sans-bold', 0),
+  className: typography('body', 'lg', 'strong'),
 })`
   ${Link}:hover & {
     text-decoration: underline;
@@ -41,7 +41,7 @@ const Description = styled(Space).attrs({
 
 const DatesContributors = styled(Space).attrs({
   $v: { size: 'xs', properties: ['margin-bottom'] },
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   color: ${props => props.theme.color('neutral.600')};
 `;

--- a/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
+++ b/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { getCrop } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
@@ -44,21 +44,21 @@ const OrganisationImage = styled.div`
   width: 72px;
 `;
 
-const Name = styled.h3.attrs({ className: font('sans-bold', 0) })`
+const Name = styled.h3.attrs({ className: typography('body', 'lg', 'strong') })`
   margin: 0;
 `;
 
 const Pronouns = styled(ContributorInfoWrapper).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $h: { size: 'xs', properties: ['margin-left'] },
 })``;
 
 const Role = styled(ContributorInfoWrapper).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })``;
 
 const Description = styled(Space).attrs({
-  className: `${font('sans', -1)} spaced-text`,
+  className: `${typography('body', 'md', 'regular')} spaced-text`,
   $v: { size: 'xs', properties: ['margin-top'] },
 })``;
 

--- a/content/webapp/views/components/Contributors/index.tsx
+++ b/content/webapp/views/components/Contributors/index.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Space from '@weco/common/views/components/styled/Space';
 import { Contributor as ContributorType } from '@weco/content/types/contributors';
@@ -74,7 +74,7 @@ const Contributors: FunctionComponent<Props> = ({
 
   return (
     <div data-component="contributors">
-      <h2 className={font('brand-bold', 1)}>
+      <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
         {isNotUndefined(titleOverride)
           ? titleOverride
           : getContributorsTitle(roles, titlePrefix)}

--- a/content/webapp/views/components/Download/index.tsx
+++ b/content/webapp/views/components/Download/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useRef } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import DownloadLink from '@weco/common/views/components/DownloadLink';
 import PlainList from '@weco/common/views/components/styled/PlainList';
@@ -10,7 +10,7 @@ import SpacingComponent from '@weco/common/views/components/styled/SpacingCompon
 import { DownloadOption } from '@weco/content/types/manifest';
 
 export const DownloadOptions = styled.div.attrs({
-  className: font('sans-bold', 0),
+  className: typography('body', 'lg', 'strong'),
 })`
   white-space: normal;
   color: ${props => props.theme.color('black')};
@@ -21,7 +21,7 @@ export const DownloadOptions = styled.div.attrs({
 `;
 
 const Wrapper = styled.div.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<{ $isEnhanced: boolean }>`
   position: relative;
   ${props => (props.$isEnhanced ? 'display: inline-block;' : '')}
@@ -56,7 +56,7 @@ const Download: FunctionComponent<Props> = ({
         isOnDark={useDarkControl}
         id={ariaControlsId}
       >
-        <DownloadOptions className={font('sans-bold', -1)}>
+        <DownloadOptions className={typography('body', 'md', 'strong')}>
           <SpacingComponent>
             <PlainList>
               {downloadOptions.map(option => (

--- a/content/webapp/views/components/EventCard/index.tsx
+++ b/content/webapp/views/components/EventCard/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { inOurBuilding } from '@weco/common/data/microcopy';
 import { location } from '@weco/common/icons';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Divider from '@weco/common/views/components/Divider';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
@@ -72,14 +72,14 @@ export function getLocationText(
 }
 
 const DateInfo = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   padding: 0;
   margin: 0;
 `;
 
 const LocationWrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-top', 'margin-bottom'] },
 })`
   display: flex;
@@ -177,19 +177,21 @@ const EventCard: FunctionComponent<Props> = ({
           {upcomingDatesFullyBooked(event.times) && (
             <Space $v={{ size: 'sm', properties: ['margin-top'] }}>
               <TextWithDot
-                className={font('sans', -1)}
+                className={typography('body', 'md', 'regular')}
                 dotColor="validation.red"
                 text="Fully booked"
               />
             </Space>
           )}
           {!isPast && event.times.length > 1 && (
-            <p className={font('sans-bold', -2)}>See all dates/times</p>
+            <p className={typography('body', 'sm', 'strong')}>
+              See all dates/times
+            </p>
           )}
           {isPast && !event.availableOnline && !isInPastListing && (
             <div>
               <TextWithDot
-                className={font('sans', -1)}
+                className={typography('body', 'md', 'regular')}
                 dotColor="neutral.500"
                 text="Past"
               />
@@ -202,10 +204,13 @@ const EventCard: FunctionComponent<Props> = ({
           {event.series.map(series => (
             <p
               key={series.title}
-              className={font('sans-bold', -2)}
+              className={typography('body', 'sm', 'strong')}
               style={{ marginBottom: 0 }}
             >
-              <span className={font('sans', -2)}>Part of</span> {series.title}
+              <span className={typography('body', 'sm', 'regular')}>
+                Part of
+              </span>{' '}
+              {series.title}
             </p>
           ))}
         </CardPostBody>

--- a/content/webapp/views/components/EventbriteButtons/index.tsx
+++ b/content/webapp/views/components/EventbriteButtons/index.tsx
@@ -2,19 +2,19 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { ticket } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { Event } from '@weco/content/types/events';
 
 const Location = styled(Space).attrs({
   as: 'p',
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })``;
 
 const Copy = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   color: ${props => props.theme.color('neutral.700')};
   margin: 0;

--- a/content/webapp/views/components/EventsSearchResults/index.tsx
+++ b/content/webapp/views/components/EventsSearchResults/index.tsx
@@ -6,7 +6,7 @@ import { getCrop } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isPast as checkIfIsPast } from '@weco/common/utils/dates';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Divider from '@weco/common/views/components/Divider';
@@ -48,14 +48,14 @@ const EventsContainer = styled.div`
 `;
 
 const DateInfo = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   padding: 0;
   margin: 0;
 `;
 
 const LocationWrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-top', 'margin-bottom'] },
 })`
   display: flex;
@@ -169,7 +169,7 @@ const EventsSearchResults: FunctionComponent<Props> = ({
                 {upcomingDatesFullyBooked(times) && (
                   <Space $v={{ size: 'sm', properties: ['margin-top'] }}>
                     <TextWithDot
-                      className={font('sans', -1)}
+                      className={typography('body', 'md', 'regular')}
                       dotColor="validation.red"
                       text="Fully booked"
                     />
@@ -177,7 +177,9 @@ const EventsSearchResults: FunctionComponent<Props> = ({
                 )}
 
                 {!isPast && times.length > 1 && (
-                  <p className={font('sans-bold', -2)}>See all dates/times</p>
+                  <p className={typography('body', 'sm', 'strong')}>
+                    See all dates/times
+                  </p>
                 )}
 
                 {firstStartTime &&
@@ -199,10 +201,12 @@ const EventsSearchResults: FunctionComponent<Props> = ({
                 {event.series.map(series => (
                   <p
                     key={series.title}
-                    className={font('sans-bold', -2)}
+                    className={typography('body', 'sm', 'strong')}
                     style={{ marginBottom: 0 }}
                   >
-                    <span className={font('sans', -2)}>Part of</span>{' '}
+                    <span className={typography('body', 'sm', 'regular')}>
+                      Part of
+                    </span>{' '}
                     {series.title}
                   </p>
                 ))}

--- a/content/webapp/views/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
+++ b/content/webapp/views/components/ExhibitionCaptions/ExhibitionCaptions.Stop.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { KnownTarget } from 'styled-components/dist/types';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dasherizeShorten } from '@weco/common/utils/grammar';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
@@ -19,7 +19,7 @@ import ZoomedPrismicImage from '@weco/content/views/components/ZoomedPrismicImag
 
 export const StandaloneTitle = styled(Space).attrs({
   as: 'h2',
-  className: `${font('brand-bold', 2)}`,
+  className: `${typography('heading', 'xl', 'strong', 'brand')}`,
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
 })`
@@ -34,13 +34,13 @@ type LevelProps = { $level: number };
 
 export const ContextTitle = styled(Space).attrs<LevelProps>(props => ({
   as: `h${props.$level}` as KnownTarget,
-  className: font('brand-bold', 1),
+  className: typography('heading', 'lg', 'strong', 'brand'),
   $v: { size: 'sm', properties: ['margin-bottom'] },
 }))<LevelProps>``;
 
 const TranscriptTitle = styled(Space).attrs<LevelProps>(props => ({
   as: `h${props.$level}` as KnownTarget,
-  className: font('brand-bold', 0),
+  className: typography('heading', 'md', 'strong', 'brand'),
   $v: { size: 'sm', properties: ['margin-bottom'] },
 }))<LevelProps>``;
 
@@ -61,12 +61,12 @@ export const ContextContainer = styled(Space).attrs<ContextContainerProps>(
 
 export const TombstoneTitle = styled(Space).attrs<LevelProps>(props => ({
   as: `h${props.$level}` as KnownTarget,
-  className: font('brand-bold', 1),
+  className: typography('heading', 'lg', 'strong', 'brand'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 }))<LevelProps>``;
 
 export const Tombstone = styled(Space).attrs({
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
   $h: { size: 'md', properties: ['padding-right'] },
 })`
   flex-basis: 100%;
@@ -100,7 +100,7 @@ export const CaptionTranscription = styled.div`
 `;
 
 export const Caption = styled(Space).attrs({
-  className: `spaced-text ${font('sans', -1)}`,
+  className: `spaced-text ${typography('body', 'md', 'regular')}`,
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
 })`
   border-left: 20px solid ${props => props.theme.color('lightYellow')};
@@ -112,7 +112,7 @@ const PrismicImageWrapper = styled.div`
 `;
 
 const Transcription = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
   $v: {
     size: 'sm',
@@ -209,7 +209,7 @@ const Stop: FunctionComponent<{
                 </TombstoneTitle>
               )}
               {tombstone && (
-                <div className={font('sans', 0)}>
+                <div className={typography('body', 'lg', 'regular')}>
                   <PrismicHtmlBlock html={tombstone} />
                 </div>
               )}

--- a/content/webapp/views/components/ExpandableList/index.tsx
+++ b/content/webapp/views/components/ExpandableList/index.tsx
@@ -7,11 +7,11 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
 const ShowHideButton = styled.button.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   margin: 0 !important;
   padding: 0;
@@ -58,7 +58,7 @@ const ExpandableList: FunctionComponent<Props> = ({
             item,
             index // TODO way of getting better key?
           ) => (
-            <li className={font('sans', -1)} key={index}>
+            <li className={typography('body', 'md', 'regular')} key={index}>
               {item}
             </li>
           )
@@ -66,7 +66,7 @@ const ExpandableList: FunctionComponent<Props> = ({
         {isShowingRemainingListItems && (
           <>
             {remainingListItems.map((item, index) => (
-              <li className={font('sans', -1)} key={index}>
+              <li className={typography('body', 'md', 'regular')} key={index}>
                 {/* if item is a link then add href and index 0 */}
                 {item}
               </li>

--- a/content/webapp/views/components/FeaturedCard/FeaturedCard.styles.ts
+++ b/content/webapp/views/components/FeaturedCard/FeaturedCard.styles.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
 export const DateWrapper = styled(Space).attrs({
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
   padding: 0;
@@ -51,7 +51,7 @@ export const FeaturedCardLeft = styled(GridCell)<HasIsReversed>`
 `;
 
 export const FeaturedCardRight = styled.div.attrs({
-  className: font('sans-bold', -2), // required for em value in label height calc below
+  className: typography('body', 'sm', 'strong'), // required for em value in label height calc below
 })<HasIsReversed>`
   display: flex;
   flex-direction: column;

--- a/content/webapp/views/components/FeaturedCard/index.tsx
+++ b/content/webapp/views/components/FeaturedCard/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -143,12 +143,19 @@ const FeaturedCardArticle: FunctionComponent<FeaturedCardArticleProps> = ({
       background={background}
       textColor={textColor}
     >
-      <h2 className={font('brand-bold', 2)}>{article.title}</h2>
-      {article.caption && <p className={font('sans', -1)}>{article.caption}</p>}
+      <h2 className={typography('heading', 'xl', 'strong', 'brand')}>
+        {article.title}
+      </h2>
+      {article.caption && (
+        <p className={typography('body', 'md', 'regular')}>{article.caption}</p>
+      )}
       {article.seriesTitle && (
         <Space $v={{ size: 'md', properties: ['margin-top'] }}>
-          <p className={font('sans-bold', -2)} style={{ marginBottom: 0 }}>
-            <span className={font('sans', -2)}>Part of</span>{' '}
+          <p
+            className={typography('body', 'sm', 'strong')}
+            style={{ marginBottom: 0 }}
+          >
+            <span className={typography('body', 'sm', 'regular')}>Part of</span>{' '}
             {article.seriesTitle}
           </p>
         </Space>
@@ -170,7 +177,9 @@ const FeaturedCardExhibition: FunctionComponent<
       textColor={textColor}
     >
       <div>
-        <h3 className={font('brand-bold', 2)}>{exhibition.title}</h3>
+        <h3 className={typography('heading', 'xl', 'strong', 'brand')}>
+          {exhibition.title}
+        </h3>
         {!exhibition.statusOverride && exhibition.start && exhibition.end && (
           <DateWrapper as="p">
             <DateRange start={exhibition.start} end={exhibition.end} />
@@ -182,7 +191,10 @@ const FeaturedCardExhibition: FunctionComponent<
           statusOverride={exhibition.statusOverride}
         />
         {exhibition.promo?.caption && (
-          <p className={font('sans', -1)} style={{ marginTop: '1rem' }}>
+          <p
+            className={typography('body', 'md', 'regular')}
+            style={{ marginTop: '1rem' }}
+          >
             {exhibition.promo.caption}
           </p>
         )}

--- a/content/webapp/views/components/FeaturedText/index.tsx
+++ b/content/webapp/views/components/FeaturedText/index.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef, FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 
 type Props = ComponentPropsWithoutRef<typeof PrismicHtmlBlock>;
@@ -8,7 +8,7 @@ type Props = ComponentPropsWithoutRef<typeof PrismicHtmlBlock>;
 const FeaturedText: FunctionComponent<Props> = props => (
   <div
     data-component="featured-text"
-    className={`body-text ${font('sans', 0)}`}
+    className={`body-text ${typography('body', 'lg', 'regular')}`}
   >
     <PrismicHtmlBlock {...props} />
   </div>

--- a/content/webapp/views/components/FullWidthBanner/index.tsx
+++ b/content/webapp/views/components/FullWidthBanner/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { arrowSmall, web } from '@weco/common/icons';
 import { ImageType } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import {
   ContaineredLayout,
@@ -59,7 +59,7 @@ const ImageSection = styled.div`
 `;
 
 const SupportText = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'md', properties: ['margin-top'] },
 })`
   display: flex;

--- a/content/webapp/views/components/GifVideo/index.tsx
+++ b/content/webapp/views/components/GifVideo/index.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { Tasl as TaslType } from '@weco/common/model/tasl';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Caption from '@weco/common/views/components/Caption';
 import FeaturedWorkLink, {
@@ -32,7 +32,7 @@ const PlayPause = styled.button.attrs({
 `;
 
 const Text = styled.span.attrs({
-  className: font('mono', -1),
+  className: typography('caption', 'md', 'regular'),
 })<{ $isPlaying: boolean }>`
   display: block;
   background: ${props => props.theme.color('neutral.700')};
@@ -205,7 +205,7 @@ const GifVideo: FunctionComponent<Props> = ({
 
       {tasl && hasLinkedWork(tasl.sourceLink) && (
         <Space
-          className={font('sans-bold', -1)}
+          className={typography('body', 'md', 'strong')}
           style={{ display: 'block' }}
           $v={{ size: 'sm', properties: ['margin-top'] }}
         >

--- a/content/webapp/views/components/GuideStopCard/index.tsx
+++ b/content/webapp/views/components/GuideStopCard/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { duration as durationIcon, map } from '@weco/common/icons';
 import { getCrop, ImageType } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import { GridCell } from '@weco/common/views/components/styled/Grid';
@@ -20,7 +20,7 @@ import ImagePlaceholder, {
 } from '@weco/content/views/components/ImagePlaceholder';
 
 const AlignIconFirstLineCenter = styled.div.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: flex;
   align-items: start;
@@ -112,7 +112,7 @@ const GuideStopCard: FunctionComponent<Props> = ({
               >
                 <Icon icon={durationIcon} sizeOverride="width: 16px;" />
               </Space>
-              <span className={font('sans', -1)}>
+              <span className={typography('body', 'md', 'regular')}>
                 {duration} minutes {type === 'audio' ? 'listen' : 'watch'} time
               </span>
             </AlignIconFirstLineCenter>

--- a/content/webapp/views/components/GuideTextItem/index.tsx
+++ b/content/webapp/views/components/GuideTextItem/index.tsx
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { camelize } from '@weco/common/utils/grammar';
 import CollapsibleContent from '@weco/common/views/components/CollapsibleContent';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
@@ -33,7 +33,7 @@ const GuideTextItem: FunctionComponent<{
         <Tombstone>
           {title && <TombstoneTitle $level={3}>{title}</TombstoneTitle>}
           {tombstone && (
-            <div className={font('sans', 0)}>
+            <div className={typography('body', 'lg', 'regular')}>
               <PrismicHtmlBlock html={tombstone} />
             </div>
           )}

--- a/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
+++ b/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { chevron } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { ArticleBasic } from '@weco/content/types/articles';
@@ -72,12 +72,12 @@ const TextWrap = styled.div<{ $isNext: boolean }>`
 `;
 
 const InSeries = styled(Space).attrs({
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })``;
 
 const Title = styled.div.attrs({
-  className: font('sans-bold', 1),
+  className: typography('body', 'xl', 'strong'),
 })`
   white-space: nowrap;
   overflow: hidden;
@@ -85,7 +85,7 @@ const Title = styled.div.attrs({
 `;
 
 const Chevron = styled(Space).attrs({
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
   $v: { size: 'sm', properties: ['padding-top'] },
 })<{ $isNext: boolean }>`
   transform: translateX(${props => (props.$isNext ? '-6px' : '6px')});

--- a/content/webapp/views/components/ImageGallery/index.tsx
+++ b/content/webapp/views/components/ImageGallery/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { cross, gallery } from '@weco/common/icons';
 import { CaptionedImage as CaptionedImageProps } from '@weco/common/model/captioned-image';
 import { repeatingLsBlack } from '@weco/common/utils/backgrounds';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dasherize, pluralize } from '@weco/common/utils/grammar';
 import Button from '@weco/common/views/components/Buttons';
 import Control from '@weco/common/views/components/Control';
@@ -138,7 +138,7 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
             </Space>
             <h2
               id={title ? dasherize(title) : `gallery-${id}`}
-              className={font('brand-bold', 1)}
+              className={typography('heading', 'lg', 'strong', 'brand')}
               ref={headingRef}
             >
               {title || 'In pictures'}
@@ -249,7 +249,7 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
                       items.length > 1 ? (
                         <Space
                           $v={{ size: 'sm', properties: ['margin-bottom'] }}
-                          className={font('sans-bold', -1)}
+                          className={typography('body', 'md', 'strong')}
                         >
                           {i + 1} of {items.length}
                         </Space>

--- a/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
+++ b/content/webapp/views/components/ImageModal/ImageModal.VisuallySimilarImages.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import LL from '@weco/common/views/components/styled/LL';
 import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -84,7 +84,9 @@ const VisuallySimilarImages: FunctionComponent<Props> = ({
 
   return similarImages.length === 0 ? null : (
     <>
-      <h3 className={font('brand-bold', -1)}>Visually similar images</h3>
+      <h3 className={typography('heading', 'sm', 'strong', 'brand')}>
+        Visually similar images
+      </h3>
 
       <Wrapper>
         {similarImages.map(related => (
@@ -122,7 +124,10 @@ const VisuallySimilarImages: FunctionComponent<Props> = ({
           </li>
         ))}
       </Wrapper>
-      <p className={font('sans', -2)} style={{ marginBottom: 0 }}>
+      <p
+        className={typography('body', 'sm', 'regular')}
+        style={{ marginBottom: 0 }}
+      >
         We use machine learning to find images in our collection with similar
         shapes and features.
         <br />

--- a/content/webapp/views/components/ImageModal/ImageModal.styles.tsx
+++ b/content/webapp/views/components/ImageModal/ImageModal.styles.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const Container = styled.div`
@@ -15,7 +15,7 @@ export const ImageInfoWrapper = styled.div`
 `;
 
 export const MetadataWrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-top', 'margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.600')};
@@ -29,7 +29,7 @@ export const Metadata = styled.span`
 `;
 
 export const ModalTitle = styled.h2.attrs({
-  className: font('sans-bold', 1),
+  className: typography('body', 'xl', 'strong'),
 })`
   margin-bottom: 0;
 `;

--- a/content/webapp/views/components/ImageWithTasl/index.tsx
+++ b/content/webapp/views/components/ImageWithTasl/index.tsx
@@ -2,7 +2,7 @@ import { ComponentProps, FunctionComponent, ReactElement } from 'react';
 
 import { getCrop } from '@weco/common/model/image';
 import { EditorialImageSlice as RawEditorialImageSlice } from '@weco/common/prismicio-types';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import FeaturedWorkLink, {
   hasLinkedWork,
 } from '@weco/common/views/components/FeaturedWorkLink';
@@ -33,7 +33,7 @@ const ImageWithTasl: FunctionComponent<ImageWithTaslProps> = ({
 
       {displayWorkLink && tasl && hasLinkedWork(tasl.sourceLink) && (
         <Space
-          className={font('sans-bold', -1)}
+          className={typography('body', 'md', 'strong')}
           style={{ display: 'block' }}
           $v={{ size: 'sm', properties: ['margin-top'] }}
         >

--- a/content/webapp/views/components/InPageNavigation/InPageNavigation.styles.tsx
+++ b/content/webapp/views/components/InPageNavigation/InPageNavigation.styles.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { compositeTypography, font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import AnimatedUnderlineCSS, {
   AnimatedUnderlineProps,
 } from '@weco/common/views/components/styled/AnimatedUnderline';
@@ -131,7 +131,7 @@ const AnimatedLink = styled(NextLink)<AnimatedUnderlineProps>`
 `;
 
 export const Anchor = styled.a.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   color: ${props => props.theme.color('black')};
 `;
@@ -145,11 +145,7 @@ type InPageNavAnimatedLinkProps = {
 export const InPageNavAnimatedLink = styled(
   AnimatedLink
 ).attrs<InPageNavAnimatedLinkProps>(props => ({
-  className: compositeTypography(
-    'body',
-    'md',
-    props.$isActive ? 'strong' : 'regular'
-  ),
+  className: typography('body', 'md', props.$isActive ? 'strong' : 'regular'),
 }))<InPageNavAnimatedLinkProps>`
   color: ${props =>
     props.theme.color(
@@ -244,7 +240,7 @@ export const Root = styled(Space).attrs<{
 `;
 
 export const MobileNavButton = styled.button.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })<{ $hasStuck: boolean; $isListActive: boolean; $isOnWhite: boolean }>`
   --mobile-nav-border-color: ${props =>
     props.$hasStuck

--- a/content/webapp/views/components/InPageNavigation/index.tsx
+++ b/content/webapp/views/components/InPageNavigation/index.tsx
@@ -6,7 +6,7 @@ import { CSSTransition, SwitchTransition } from 'react-transition-group';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { useActiveAnchor } from '@weco/common/hooks/useActiveAnchor';
 import { cross } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import { SizeMap } from '@weco/common/views/components/styled/Grid';
@@ -221,7 +221,9 @@ const InPageNavigation: FunctionComponent<Props> = ({
         }}
       >
         <Root $hasStuck={hasStuck} data-in-page-navigation="true">
-          <h2 className={`${font('sans-bold', -1)} is-hidden-s is-hidden-m`}>
+          <h2
+            className={`${typography('body', 'md', 'strong')} is-hidden-s is-hidden-m`}
+          >
             {titleText}
           </h2>
 

--- a/content/webapp/views/components/InfoBlock/index.tsx
+++ b/content/webapp/views/components/InfoBlock/index.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dasherize } from '@weco/common/utils/grammar';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
@@ -24,7 +24,10 @@ const InfoBlock: FunctionComponent<Props> = ({
 }: Props): ReactElement<Props> => {
   return (
     <Wrapper data-component="info-block">
-      <h2 id={dasherize(title)} className={font('brand-bold', 1)}>
+      <h2
+        id={dasherize(title)}
+        className={typography('heading', 'lg', 'strong', 'brand')}
+      >
         {title}
       </h2>
       <div className="spaced-text body-text">

--- a/content/webapp/views/components/InfoBox/index.tsx
+++ b/content/webapp/views/components/InfoBox/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import { IconSvg } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
@@ -26,7 +26,7 @@ const InfoContainer = styled(Space).attrs({
 `;
 
 export const InfoIconWrapper = styled(Space).attrs({
-  className: font('sans-bold', 0),
+  className: typography('body', 'lg', 'strong'),
   $h: { size: 'xs', properties: ['margin-right'] },
 })`
   float: left;
@@ -40,7 +40,15 @@ const InfoBox: FunctionComponent<Props> = ({
 }) => {
   return (
     <div data-component="info-box">
-      <h2 className={font('brand-bold', hasBiggerHeading ? 2 : 1)}>{title}</h2>
+      <h2
+        className={
+          hasBiggerHeading
+            ? typography('heading', 'xl', 'strong', 'brand')
+            : typography('heading', 'lg', 'strong', 'brand')
+        }
+      >
+        {title}
+      </h2>
 
       <InfoContainer>
         {items.map(({ title, description, icon }, i) => (
@@ -50,11 +58,13 @@ const InfoBox: FunctionComponent<Props> = ({
                 <Icon icon={icon} />
               </InfoIconWrapper>
             )}
-            {title && <h3 className={font('sans-bold', -1)}>{title}</h3>}
+            {title && (
+              <h3 className={typography('body', 'md', 'strong')}>{title}</h3>
+            )}
             {description && (
               <Space
                 $v={{ size: 'sm', properties: ['margin-bottom'] }}
-                className={font('sans', -1)}
+                className={typography('body', 'md', 'regular')}
               >
                 <PrismicHtmlBlock html={description} />
               </Space>

--- a/content/webapp/views/components/LinkLabels/index.tsx
+++ b/content/webapp/views/components/LinkLabels/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { IconSvg } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space, {
@@ -28,7 +28,7 @@ type LinkOrSpanSpaceAttrs = {
 const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
   as: props.$url ? 'a' : 'span',
   href: props.$url,
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $h: {
     size: 'xs',
     properties: ['margin-right', props.$addBorder ? 'padding-left' : ''].filter(
@@ -44,14 +44,14 @@ const ItemText = styled(Space).attrs<LinkOrSpanSpaceAttrs>(props => ({
 `;
 
 const PlainItemList = styled(PlainList).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: flex;
   flex-wrap: wrap;
 `;
 
 const ListWithHeading = styled.dl.attrs({
-  className: `${font('sans', -1)}`,
+  className: `${typography('body', 'md', 'regular')}`,
 })`
   display: flex;
   flex-wrap: wrap;

--- a/content/webapp/views/components/Message/index.tsx
+++ b/content/webapp/views/components/Message/index.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 const Wrapper = styled(Space).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
 })`

--- a/content/webapp/views/components/Number/index.tsx
+++ b/content/webapp/views/components/Number/index.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
@@ -43,7 +43,7 @@ const Number: FunctionComponent<Props> = ({
   <Wrapper
     data-component="number"
     as="span"
-    className={font('brand-bold', -1)}
+    className={typography('heading', 'sm', 'strong', 'brand')}
     $h={{ size: 'xs', properties: ['margin-left'] }}
     $backgroundColor={backgroundColor}
   >

--- a/content/webapp/views/components/Pagination/index.tsx
+++ b/content/webapp/views/components/Pagination/index.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { chevron } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatNumber } from '@weco/common/utils/grammar';
 import Icon from '@weco/common/views/components/Icon';
 
@@ -16,7 +16,7 @@ export type Props = {
 };
 
 const Container = styled.nav.attrs({
-  className: `${font('sans', -2)} is-hidden-print`,
+  className: `${typography('body', 'sm', 'regular')} is-hidden-print`,
 })<{ $isHiddenMobile?: boolean }>`
   display: flex;
   align-items: center;

--- a/content/webapp/views/components/PaletteColorPicker/index.tsx
+++ b/content/webapp/views/components/PaletteColorPicker/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { hexToHsv, hsvToHex } from '@weco/content/utils/convert-colors';
 
 import HueSlider from './PaletteColorPicker.HueSlider';
@@ -82,7 +82,7 @@ const Swatch = styled.button.attrs<{
   $hexColor: string;
 }>((props: SwatchProps) => ({
   type: 'button',
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   'aria-pressed': !!props.$ariaPressed,
 }))<SwatchProps>`
   position: relative;

--- a/content/webapp/views/components/PartNumberIndicator/index.tsx
+++ b/content/webapp/views/components/PartNumberIndicator/index.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef, FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Number from '@weco/content/views/components/Number';
 
 type NumberProps = ComponentPropsWithoutRef<typeof Number>;
@@ -15,7 +15,7 @@ const PartNumberIndicator: FunctionComponent<Props> = ({
 }) => (
   <div
     data-component="part-number-indicator"
-    className={font('brand-bold', -1)}
+    className={typography('heading', 'sm', 'strong', 'brand')}
   >
     {description}
     <Number {...numberProps} />

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import useVideoEmbed, { VideoProvider } from '@weco/common/hooks/useVideoEmbed';
 import { chevron, cross } from '@weco/common/icons';
 import { ImageType } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import PortraitVideoEmbed from '@weco/common/views/components/PortraitVideoEmbed';
@@ -122,7 +122,11 @@ const PortraitVideoList: FunctionComponent<Props> = ({
         gridSizes={gridSizes}
         useShim={useShim}
         CopyContent={
-          title ? <h2 className={font('brand-bold', 1)}>{title}</h2> : undefined
+          title ? (
+            <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+              {title}
+            </h2>
+          ) : undefined
         }
       >
         {items.map((item, i) => (

--- a/content/webapp/views/components/PrototypeSearchSelects/index.tsx
+++ b/content/webapp/views/components/PrototypeSearchSelects/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import { useEffect, useState } from 'react';
 
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { SEARCH_PAGES_FORM_ID } from '@weco/common/utils/search';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Space from '@weco/common/views/components/styled/Space';
@@ -68,7 +68,9 @@ const PrototypeSearchSelects: FunctionComponent<Props> = ({
             data-component="prototype-search-selects"
           >
             <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-              <h1 className={font('sans-bold', -1)}>Search the catalogue</h1>
+              <h1 className={typography('body', 'md', 'strong')}>
+                Search the catalogue
+              </h1>
             </Space>
             <div style={{ display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
               {semanticSearchPrototype && (

--- a/content/webapp/views/components/Quote/index.tsx
+++ b/content/webapp/views/components/Quote/index.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -16,7 +16,7 @@ const Blockquote = styled.blockquote.attrs<{ $isPullOrReview: boolean }>(
   props => ({
     className: classNames({
       'quote--pull': props.$isPullOrReview,
-      [font('sans', 2)]: props.$isPullOrReview,
+      [typography('body', 'xl', 'regular')]: props.$isPullOrReview,
       'body-text': true,
       quote: true,
     }),
@@ -26,7 +26,7 @@ const Blockquote = styled.blockquote.attrs<{ $isPullOrReview: boolean }>(
 `;
 
 const Cite = styled.cite.attrs({
-  className: `quote__cite ${font('sans', -1)}`,
+  className: `quote__cite ${typography('body', 'md', 'regular')}`,
 })`
   color: ${props => props.theme.color('neutral.600')};
   display: flex;

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 
 export const Card = styled.a<{ $isHover?: boolean }>`
   display: flex;
@@ -66,7 +66,9 @@ export const TextWrapper = styled.div`
 `;
 
 export const Title = styled.h2.attrs<{ $isHover?: boolean }>(props => ({
-  className: !props.$isHover ? font('sans-bold', -1) : font('sans', -1),
+  className: !props.$isHover
+    ? typography('body', 'md', 'strong')
+    : typography('body', 'md', 'regular'),
 }))<{ $linesToClamp: number }>`
   ${props => props.theme.clampLines(props.$linesToClamp)};
   color: ${props => props.theme.color('black')};
@@ -144,7 +146,7 @@ export const ImageWrapper = styled.div<{ $isHover?: boolean }>`
 `;
 
 export const MetaContainer = styled.div.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   color: ${props => props.theme.color('neutral.600')};
 `;

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.Navigation.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, RefObject, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { arrowSmall } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import useSwipeable, { SwipeDirection } from '@weco/content/hooks/useSwipeable';
@@ -21,7 +21,7 @@ const ScrollButtonsContainer = styled(Space)<{
 `;
 
 const ScrollButton = styled('button').attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   line-height: 1;
   color: var(--button-color);

--- a/content/webapp/views/components/SearchFilters/ResetActiveFilters.tsx
+++ b/content/webapp/views/components/SearchFilters/ResetActiveFilters.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import { cross } from '@weco/common/icons';
 import { LinkProps } from '@weco/common/model/link-props';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import {
@@ -162,7 +162,7 @@ export const ResetActiveFilters: FunctionComponent<ResetActiveFilters> = ({
     ) : null;
 
   return (
-    <div className={font('sans-bold', -1)}>
+    <div className={typography('body', 'md', 'strong')}>
       <h2 style={{ display: 'inline' }}>
         <Space as="span" $h={{ size: 'sm', properties: ['margin-right'] }}>
           Active filters:

--- a/content/webapp/views/components/SearchFilters/SearchFilters.Desktop.DateRangeFilter.tsx
+++ b/content/webapp/views/components/SearchFilters/SearchFilters.Desktop.DateRangeFilter.tsx
@@ -1,4 +1,4 @@
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -17,7 +17,7 @@ const DesktopDateRangeFilter = ({
   hasNoOptions,
 }: DesktopDateRangeFilterProps) => {
   return (
-    <Space className={font('sans', -1)}>
+    <Space className={typography('body', 'md', 'regular')}>
       <Button
         variant="DropdownButton"
         isPill

--- a/content/webapp/views/components/SearchFilters/SearchFilters.Desktop.Modal.tsx
+++ b/content/webapp/views/components/SearchFilters/SearchFilters.Desktop.Modal.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { LinkProps } from '@weco/common/model/link-props';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatNumber } from '@weco/common/utils/grammar';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio';
@@ -192,7 +192,9 @@ export const getFilterLabel = (type: Filter['type'], label: string) => {
   }
 
   return filterTitle ? (
-    <h3 className={font('brand-bold', 0)}>{filterTitle}</h3>
+    <h3 className={typography('heading', 'md', 'strong', 'brand')}>
+      {filterTitle}
+    </h3>
   ) : null;
 };
 
@@ -306,7 +308,9 @@ const ModalMoreFilters: FunctionComponent<ModalMoreFiltersProps> = ({
           modalStyle="filters"
         >
           <FiltersHeader>
-            <h3 className={font('brand-bold', 0)}>All filters</h3>
+            <h3 className={typography('heading', 'md', 'strong', 'brand')}>
+              All filters
+            </h3>
           </FiltersHeader>
           {/* The Modal element needs to be pre-rendered even if inactive for its CSSTransition effect
             But there's a bit of rerending withing MoreFilters that is causing issues with the Desktop behaviour,

--- a/content/webapp/views/components/SearchFilters/SearchFilters.Desktop.tsx
+++ b/content/webapp/views/components/SearchFilters/SearchFilters.Desktop.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { partition } from '@weco/common/utils/arrays';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { BooleanFilter as BooleanFilterType } from '@weco/content/services/wellcome/common/filters';
 
@@ -14,7 +14,7 @@ import DynamicFilterArray from './SearchFilters.Desktop.DynamicFilters';
 import ModalMoreFilters from './SearchFilters.Desktop.Modal';
 
 const Wrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: flex;
   align-items: flex-end;

--- a/content/webapp/views/components/SearchFilters/SearchFilters.Mobile.tsx
+++ b/content/webapp/views/components/SearchFilters/SearchFilters.Mobile.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, ReactElement, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { filter } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import getFocusableElements from '@weco/common/utils/get-focusable-elements';
 import Button, {
   ButtonTypes,
@@ -249,7 +249,9 @@ const SearchFiltersMobile: FunctionComponent<SearchFiltersSharedProps> = ({
       >
         <FiltersScrollable>
           <FiltersHeader>
-            <h2 className={font('brand-bold', 1)}>Filters</h2>
+            <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+              Filters
+            </h2>
           </FiltersHeader>
 
           <FiltersBody>

--- a/content/webapp/views/components/SearchResults/SearchResults.Async.tsx
+++ b/content/webapp/views/components/SearchResults/SearchResults.Async.tsx
@@ -1,6 +1,6 @@
 import { Component, ReactElement } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { fetchMultiContentClientSide } from '@weco/content/services/prismic/fetch/multi-content';
 import { MultiContent } from '@weco/content/types/multi-content';
@@ -35,7 +35,10 @@ class AsyncSearchResults extends Component<Props, State> {
       <>
         {this.props.title && (
           <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
-            <h2 className={font('brand-bold', 1)} style={{ marginBottom: 0 }}>
+            <h2
+              className={typography('heading', 'lg', 'strong', 'brand')}
+              style={{ marginBottom: 0 }}
+            >
               {this.props.title}
             </h2>
           </Space>

--- a/content/webapp/views/components/SearchResults/SearchResults.Default.tsx
+++ b/content/webapp/views/components/SearchResults/SearchResults.Default.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { getCrop } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -40,7 +40,7 @@ const SearchResults: FunctionComponent<Props> = ({
           !summary ? { size: 'sm', properties: ['margin-bottom'] } : undefined
         }
       >
-        <h2 id={id} className={font('brand-bold', 1)}>
+        <h2 id={id} className={typography('heading', 'lg', 'strong', 'brand')}>
           {title}
         </h2>
       </Space>

--- a/content/webapp/views/components/SearchResults/SearchResults.EventCard.tsx
+++ b/content/webapp/views/components/SearchResults/SearchResults.EventCard.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 
 import { getCrop } from '@weco/common/model/image';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
 import { EventBasic } from '@weco/content/types/events';
@@ -65,7 +65,10 @@ const EventCard: FunctionComponent<Props> = ({ event, xOfY }) => {
         </Space>
       </>
     ) : !event.isPast && event.times.length > 1 ? (
-      <p className={font('sans-bold', 0)} style={{ marginBottom: 0 }}>
+      <p
+        className={typography('body', 'lg', 'strong')}
+        style={{ marginBottom: 0 }}
+      >
         See all dates/times
       </p>
     ) : undefined;

--- a/content/webapp/views/components/SectionHeader/index.tsx
+++ b/content/webapp/views/components/SectionHeader/index.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import {
   ContaineredLayout,
@@ -42,7 +42,10 @@ type Props = {
 
 const SectionHeader: FunctionComponent<Props> = ({ title, gridSize }) => {
   return (
-    <div data-component="section-header" className={font('brand-bold', 2)}>
+    <div
+      data-component="section-header"
+      className={typography('heading', 'xl', 'strong', 'brand')}
+    >
       <ConditionalWrapper
         condition={!!gridSize}
         wrapper={children => (

--- a/content/webapp/views/components/Select/Select.Container.tsx
+++ b/content/webapp/views/components/Select/Select.Container.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
 import { chevron } from '@weco/common/icons';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -12,7 +12,7 @@ type StyledSelectProps = {
 };
 
 const StyledSelect = styled.div.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })<StyledSelectProps>`
   position: relative;
   ${({ $isPill }) => $isPill && 'display: inline-block;'}
@@ -67,7 +67,7 @@ const SelectLabel = styled.label`
 const LabelContent = styled(Space).attrs<{ $hideLabel?: boolean }>(props => ({
   as: 'span',
   className: classNames({
-    [font('sans-bold', -1)]: true,
+    [typography('body', 'md', 'strong')]: true,
     'visually-hidden': !!props.$hideLabel,
   }),
   $h: { size: 'xs', properties: ['margin-right'] },

--- a/content/webapp/views/components/SelectableTags/index.tsx
+++ b/content/webapp/views/components/SelectableTags/index.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useState } from 'react';
 import styled, { css } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { toHtmlId } from '@weco/common/utils/grammar';
 import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -23,7 +23,7 @@ type SelectableTagsProps = {
 };
 
 export const SelectableTagsWrapper = styled.div.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: flex;
   flex-wrap: wrap;

--- a/content/webapp/views/components/SourcedDescription/index.tsx
+++ b/content/webapp/views/components/SourcedDescription/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import styled, { css } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Space from '@weco/common/views/components/styled/Space';
 import { SourceOntology } from '@weco/content/services/wellcome/catalogue/types';
@@ -44,7 +44,7 @@ const showSourceBox = css`
 `;
 
 const SourcePill = styled.div.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   position: relative;
   display: inline-flex;
@@ -75,7 +75,7 @@ const underlineParagraph = css`
 `;
 
 const Paragraph = styled.p.attrs({
-  className: font('sans', 1),
+  className: typography('body', 'xl', 'regular'),
 })`
   display: inline;
   padding-right: ${props => props.theme.spacingUnits['100']};
@@ -197,7 +197,9 @@ const SourcedDescription: FunctionComponent<{
 
           <SourceBoxContainer $marginLeft={sourceBoxMarginLeft}>
             <SourceBox {...dataGtmPropsToAttributes({ trigger: 'source_box' })}>
-              <span className={font('sans-bold', -2)}>Source:</span>
+              <span className={typography('body', 'sm', 'strong')}>
+                Source:
+              </span>
               <SourceLink>
                 {source === 'wikidata' && <WikidataLogo width={16} />}
                 {source === 'nlm-mesh' && (

--- a/content/webapp/views/components/StatusIndicator/index.tsx
+++ b/content/webapp/views/components/StatusIndicator/index.tsx
@@ -1,7 +1,7 @@
 // eslint-data-component: intentionally omitted
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import {
   addDays,
   isFuture,
@@ -55,7 +55,11 @@ const StatusIndicator: FunctionComponent<Props> = ({
 
   return (
     <TextWithDot
-      className={isLarge ? font('sans', 0) : font('sans', -1)}
+      className={
+        isLarge
+          ? typography('body', 'lg', 'regular')
+          : typography('body', 'md', 'regular')
+      }
       dotColor={color}
       text={text}
     />

--- a/content/webapp/views/components/StoriesGrid/index.tsx
+++ b/content/webapp/views/components/StoriesGrid/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { getCrop } from '@weco/common/model/image';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import PrismicImage, {
@@ -58,7 +58,7 @@ const MobileLabel = styled.div`
 `;
 
 const StoryInformation = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: '2xs', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.600')};
@@ -152,7 +152,9 @@ const StoriesGrid: FunctionComponent<Props> = ({
                   <LabelsList labels={[{ text: article.format.label }]} />
                 </DesktopLabel>
 
-                <h3 className={font('brand-bold', 0)}>{article.title}</h3>
+                <h3 className={typography('heading', 'md', 'strong', 'brand')}>
+                  {article.title}
+                </h3>
 
                 {!isCompact &&
                   (article.publicationDate ||
@@ -185,7 +187,10 @@ const StoriesGrid: FunctionComponent<Props> = ({
                   )}
 
                 {article.caption && (
-                  <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+                  <p
+                    className={typography('body', 'md', 'regular')}
+                    style={{ marginBottom: 0 }}
+                  >
                     {article.caption}
                   </p>
                 )}

--- a/content/webapp/views/components/StoryCard/StoryCard.ContentApi.tsx
+++ b/content/webapp/views/components/StoryCard/StoryCard.ContentApi.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import { Article } from '@weco/content/services/wellcome/content/types/api';
@@ -17,14 +17,14 @@ import {
 } from '@weco/content/views/components/Card';
 
 const Caption = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: inline-block;
   margin: 0;
 `;
 
 const PartOf = styled.div.attrs({
-  className: font('sans-bold', -2),
+  className: typography('body', 'sm', 'strong'),
 })`
   margin: 0;
 `;
@@ -79,7 +79,8 @@ const StoryCardContentApi: FunctionComponent<Props> = ({
       {seriesTitle && (
         <CardPostBody>
           <PartOf>
-            <span className={font('sans', -2)}>Part of</span> {seriesTitle}
+            <span className={typography('body', 'sm', 'regular')}>Part of</span>{' '}
+            {seriesTitle}
           </PartOf>
         </CardPostBody>
       )}

--- a/content/webapp/views/components/StoryCard/StoryCard.Prismic.tsx
+++ b/content/webapp/views/components/StoryCard/StoryCard.Prismic.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import {
@@ -21,14 +21,14 @@ import {
 import PartNumberIndicator from '@weco/content/views/components/PartNumberIndicator';
 
 const Caption = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   display: inline-block;
   margin: 0;
 `;
 
 const PartOf = styled.div.attrs({
-  className: font('sans-bold', -2),
+  className: typography('body', 'sm', 'strong'),
 })`
   margin: 0;
 `;
@@ -102,7 +102,10 @@ const StoryCard: FunctionComponent<Props> = ({
         <CardPostBody>
           {article.series.map(series => (
             <PartOf key={series.id}>
-              <span className={font('sans', -2)}>Part of</span> {series.title}
+              <span className={typography('body', 'sm', 'regular')}>
+                Part of
+              </span>{' '}
+              {series.title}
             </PartOf>
           ))}
         </CardPostBody>

--- a/content/webapp/views/components/Table/Table.styles.tsx
+++ b/content/webapp/views/components/Table/Table.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 
 export const ControlsWrap = styled.div`
   position: relative;
@@ -88,7 +88,9 @@ export const TableWrap = styled.div`
 
 export const TableTable = styled.table.attrs<{ $hasSmallerCopy?: boolean }>(
   props => ({
-    className: font('sans', props.$hasSmallerCopy ? -2 : -1),
+    className: props.$hasSmallerCopy
+      ? typography('body', 'sm', 'regular')
+      : typography('body', 'md', 'regular'),
   })
 )`
   width: 100%;

--- a/content/webapp/views/components/Table/index.tsx
+++ b/content/webapp/views/components/Table/index.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 
 import { arrow } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Control from '@weco/common/views/components/Control';
 import Rotator from '@weco/common/views/components/styled/Rotator';
 
@@ -188,7 +188,10 @@ const Table: FunctionComponent<Props> = ({
   return (
     <div data-component="table">
       {caption && (
-        <h2 className={font('brand-bold', 1)} aria-hidden="true">
+        <h2
+          className={typography('heading', 'lg', 'strong', 'brand')}
+          aria-hidden="true"
+        >
           {caption}
         </h2>
       )}

--- a/content/webapp/views/components/Tabs/Tabs.styles.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { focusStyle } from '@weco/common/views/themes/base/wellcome-normalize';
 
@@ -50,7 +50,9 @@ type NavItemProps = {
 };
 
 export const Tab = styled.div.attrs<NavItemProps>(props => ({
-  className: props.$selected ? font('sans-bold', -1) : font('sans', -1),
+  className: props.$selected
+    ? typography('body', 'md', 'strong')
+    : typography('body', 'md', 'regular'),
 }))<NavItemProps>`
   padding: 0;
   margin: 0;

--- a/content/webapp/views/components/Tags/index.tsx
+++ b/content/webapp/views/components/Tags/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { LinkProps } from '@weco/common/model/link-props';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import {
   SolidButtonStyledProps,
   StyledButtonCSS,
@@ -31,7 +31,7 @@ type PartWithSeparatorProps = {
 const nbsp = '\\00a0';
 
 const PartWithSeparator = styled.span.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<PartWithSeparatorProps>`
   &::after {
     display: ${props => (props.$isLast ? 'none' : 'inline')};
@@ -91,8 +91,8 @@ const Tags: FunctionComponent<Props> = ({
                       <span
                         className={
                           i === 0 && isFirstPartBold
-                            ? font('sans-bold', -1)
-                            : font('sans', -1)
+                            ? typography('body', 'md', 'strong')
+                            : typography('body', 'md', 'regular')
                         }
                       >
                         {part}

--- a/content/webapp/views/components/TagsGroup/index.tsx
+++ b/content/webapp/views/components/TagsGroup/index.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import Tags, { TagType } from '@weco/content/views/components/Tags';
 
@@ -15,7 +15,7 @@ const TagsGroup: FunctionComponent<Props> = ({ tags, title }: Props) => {
       {title && (
         <Space
           as="h2"
-          className={font('brand-bold', -1)}
+          className={typography('heading', 'sm', 'strong', 'brand')}
           $v={{ size: 'sm', properties: ['margin-bottom'] }}
         >
           {title}

--- a/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
+++ b/content/webapp/views/components/ThemeCardsList/ThemeCardsList.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 
 export { ListItem } from '@weco/content/views/components/ScrollContainer/ScrollContainer.styles';
 
@@ -8,7 +8,14 @@ export const Title = styled.h2.attrs<{
   $headingLevel: 2 | 3;
   $fontFamily: 'brand-bold' | 'sans-bold';
 }>(props => ({
-  className: font(props.$fontFamily, props.$headingLevel === 2 ? 2 : 1),
+  className:
+    props.$fontFamily === 'brand-bold'
+      ? props.$headingLevel === 2
+        ? typography('heading', 'xl', 'strong', 'brand')
+        : typography('heading', 'lg', 'strong', 'brand')
+      : props.$headingLevel === 2
+        ? typography('heading', 'xl', 'strong', 'sans')
+        : typography('body', 'xl', 'strong'),
   as: props.$headingLevel === 2 ? 'h2' : 'h3',
 }))<{ $hasDescriptionSibling: boolean }>`
   ${props =>

--- a/content/webapp/views/components/TitledTextList/index.tsx
+++ b/content/webapp/views/components/TitledTextList/index.tsx
@@ -2,14 +2,14 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import PrismicHtmlBlock from '@weco/common/views/components/PrismicHtmlBlock';
 import Space from '@weco/common/views/components/styled/Space';
 import { LabelField } from '@weco/content/model/label-field';
 
 const HeadingLink = styled.a.attrs({
-  className: font('sans-bold', 0),
+  className: typography('body', 'lg', 'strong'),
 })`
   text-decoration: underline;
   color: ${props => props.theme.color('accent.green')};

--- a/content/webapp/views/components/VenueHours/VenueHours.JauntyBox.tsx
+++ b/content/webapp/views/components/VenueHours/VenueHours.JauntyBox.tsx
@@ -3,7 +3,7 @@ import {
   ExceptionalOpeningHoursDay,
   Venue,
 } from '@weco/common/model/opening-hours';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatDayName } from '@weco/common/utils/format-date';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -40,7 +40,7 @@ const VenueHoursJauntyBox = ({
       $bottomRight={randomPx()}
       $bottomLeft={randomPx()}
     >
-      <h3 className={font('sans-bold', -1)}>
+      <h3 className={typography('body', 'md', 'strong')}>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <Space as="span" $h={{ size: 'xs', properties: ['margin-right'] }}>
             <Icon icon={clock} />

--- a/content/webapp/views/components/VenueHours/VenueHours.styles.tsx
+++ b/content/webapp/views/components/VenueHours/VenueHours.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -71,7 +71,7 @@ export const OverrideDay = styled.div`
 `;
 
 export const OpeningHours = styled(PlainList).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })``;
 
 export const DifferentToRegularTime = styled.span`

--- a/content/webapp/views/components/VenueHours/index.tsx
+++ b/content/webapp/views/components/VenueHours/index.tsx
@@ -12,7 +12,7 @@ import {
   groupOverrideDates,
 } from '@weco/common/services/prismic/opening-times';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -90,7 +90,7 @@ const VenueHours: FunctionComponent<Props> = ({ venue }) => {
       <VenueHoursTimes $v={{ size: 'sm', properties: ['margin-bottom'] }}>
         <Space
           as="h2"
-          className={font('brand-bold', 1)}
+          className={typography('heading', 'lg', 'strong', 'brand')}
           $h={{ size: 'sm', properties: ['padding-right'] }}
         >
           {isFeatured ? venue.name : 'Opening hours'}

--- a/content/webapp/views/components/WatchLabel/index.tsx
+++ b/content/webapp/views/components/WatchLabel/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
 import { play } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -21,14 +21,14 @@ const WatchIconWrapper = styled.div`
 `;
 
 const WatchText = styled(Space).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
   $h: { size: 'xs', properties: ['margin-left'] },
 })`
   color: ${props => props.theme.color('neutral.700')};
 `;
 
 const Wrapper = styled.div.attrs({
-  className: font('sans', 0),
+  className: typography('body', 'lg', 'regular'),
 })`
   display: flex;
   align-items: center;

--- a/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
+++ b/content/webapp/views/components/WorkCards/WorkCards.Card.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -74,7 +74,7 @@ const LinkSpace = styled(Space).attrs<LinkSpaceAttrs>(props => ({
 `;
 
 const Title = styled.h3.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   margin: 0;
   display: -webkit-box;
@@ -85,14 +85,14 @@ const Title = styled.h3.attrs({
 `;
 
 const Meta = styled.p.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   color: ${props => props.theme.color('neutral.600')};
   margin: 0;
 `;
 
 const NotAvailable = styled.span.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   transform: rotate(2deg);
 `;

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.styles.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const Container = styled.div`
@@ -58,7 +58,7 @@ export const Details = styled.div`
 `;
 
 export const WorkInformation = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: '2xs', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.600')};
@@ -77,7 +77,7 @@ export const WorkInformationItemSeparator = styled.span`
 `;
 
 export const WorkTitleHeading = styled.h3.attrs({
-  className: font('sans-bold', 0),
+  className: typography('body', 'lg', 'strong'),
 })`
   margin-bottom: 0.5rem;
 `;

--- a/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Header.tsx
+++ b/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.Header.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import styled from 'styled-components';
 
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Breadcrumb, {
   getBreadcrumbItems,
 } from '@weco/common/views/components/Breadcrumb';
@@ -63,12 +63,16 @@ const ThematicBrowsingHeader = ({
           </Space>
 
           <Layout gridSizes={gridSize10(false)}>
-            <h1 className={font('brand-bold', 4)}>{title}</h1>
+            <h1 className={typography('heading', 'xxl', 'strong', 'brand')}>
+              {title}
+            </h1>
           </Layout>
 
           {introText && (
             <Layout gridSizes={gridSize8(false)}>
-              <div className={`${font('sans', 1)} body-text`}>
+              <div
+                className={`${typography('body', 'xl', 'regular')} body-text`}
+              >
                 {typeof introText !== 'string' ? (
                   <PrismicHtmlBlock html={introText} />
                 ) : (

--- a/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.SubjectsMenu.tsx
+++ b/content/webapp/views/layouts/ThematicBrowsingLayout/ThematicBrowsing.SubjectsMenu.tsx
@@ -2,7 +2,7 @@ import NextLink from 'next/link';
 import styled from 'styled-components';
 
 import { subjectCategories } from '@weco/common/data/hardcoded-ids';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 
@@ -119,7 +119,7 @@ const SubCategoryListItem = ({
             alt=""
           />
         </ImageContainer>
-        <span className={font('sans-bold', -1)}>{title}</span>
+        <span className={typography('body', 'md', 'strong')}>{title}</span>
       </CardLink>
     </CardListItem>
   );

--- a/content/webapp/views/pages/books/book/index.tsx
+++ b/content/webapp/views/pages/books/book/index.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 import styled from 'styled-components';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import Button from '@weco/common/views/components/Buttons';
 import {
@@ -24,7 +24,7 @@ const MetadataWrapper = styled.div`
 `;
 
 const Subtitle = styled.p.attrs({
-  className: font('sans-bold', 1),
+  className: typography('body', 'xl', 'strong'),
 })`
   margin: 0;
 `;

--- a/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
+++ b/content/webapp/views/pages/collections/collections.WorkTypesList.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { WorkTypeStats } from '@weco/content/services/wellcome/catalogue/workTypeAggregations';
 import { toSearchImagesLink } from '@weco/content/views/components/SearchPagesLink/Images';
@@ -301,7 +301,7 @@ const WorkTypeItem: FunctionComponent<WorkTypeItemProps> = ({
           <div>
             <CountDisplayContainer
               aria-hidden="true"
-              className={font('brand-bold', 1)}
+              className={typography('heading', 'lg', 'strong', 'brand')}
               ref={el => {
                 countContainerRef.current = el as HTMLDivElement | null;
                 if (registerNumberRef)
@@ -313,9 +313,11 @@ const WorkTypeItem: FunctionComponent<WorkTypeItemProps> = ({
             {/* Screen reader only text with stable count */}
             <span className="visually-hidden">{accessibleCountText}</span>
           </div>
-          <div className={font('sans', 1)}>{stats.label}</div>
+          <div className={typography('body', 'xl', 'regular')}>
+            {stats.label}
+          </div>
           {description && (
-            <DescriptionText className={font('sans', 0)}>
+            <DescriptionText className={typography('body', 'lg', 'regular')}>
               {description}
             </DescriptionText>
           )}

--- a/content/webapp/views/pages/collections/subjects/sub-theme/index.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/index.tsx
@@ -88,7 +88,9 @@ const WellcomeSubThemePage: NextPage<Props> & {
       slice.slice_type === 'cardListing'
   );
   const hasNewOnlineWorks = newOnlineWorks.length > 0;
-  const hasRelatedStories = cardListingSlices.some(slice => slice.items.length > 0);
+  const hasRelatedStories = cardListingSlices.some(
+    slice => slice.items.length > 0
+  );
   const hasWorksAbout =
     !!worksAndImagesAbout.works && worksAndImagesAbout.works.totalResults > 0;
   const hasImagesAbout = !!(

--- a/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.RelatedTopics.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.RelatedTopics.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { themeValues } from '@weco/common/views/themes/config';
 import { RelatedConcept } from '@weco/content/services/wellcome/catalogue/types';
 
 const RelatedConceptsContainer = styled.div.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: flex;
   flex-wrap: wrap;
@@ -15,7 +15,7 @@ const RelatedConceptsContainer = styled.div.attrs({
   gap: ${props => props.theme.spacingUnits['100']};
 `;
 const RelatedConceptItem = styled.div.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   display: flex;
   align-items: center;
@@ -32,7 +32,7 @@ const SubThemeRelatedTopics = ({
       <RelatedConceptsContainer>
         {relatedTopics.map((item, index) => (
           <RelatedConceptItem key={item.id}>
-            <Space className={font('sans', -1)}>
+            <Space className={typography('body', 'md', 'regular')}>
               <Button
                 variant="ButtonSolidLink"
                 colors={themeValues.buttonColors.slateTransparentBlack}

--- a/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.styles.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/sub-theme.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
@@ -11,7 +11,7 @@ export const PageGrid = styled(Grid)`
 `;
 
 export const Title = styled(Space).attrs({
-  className: font('sans-bold', 2),
+  className: typography('heading', 'xl', 'strong', 'sans'),
   as: 'h2',
   $v: { size: 'md', properties: ['margin-bottom'] },
 })``;

--- a/content/webapp/views/pages/collections/types-and-techniques/index.tsx
+++ b/content/webapp/views/pages/collections/types-and-techniques/index.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from 'next';
 import { ReactElement } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import {
   ContaineredLayout,
@@ -25,7 +25,7 @@ const CollectionsTypesPage: NextPage<Props> & {
       <ContaineredLayout gridSizes={gridSize12()}>
         <Space $v={{ size: 'xl', properties: ['margin-bottom'] }}>
           <Space $v={{ size: 'lg', properties: ['margin-bottom'] }}>
-            <h2 className={font('sans-bold', 2)}>
+            <h2 className={typography('heading', 'xl', 'strong', 'sans')}>
               Types of materials in the collections
             </h2>
           </Space>

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { thematicBrowsingPaths } from '@weco/common/data/hardcoded-ids';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import Breadcrumb, {
@@ -30,7 +30,7 @@ const ConceptHero = styled(Space).attrs({
 `;
 
 const AlternativeLabels = styled(Space).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
   $v: { size: 'sm', properties: ['margin-bottom'] },
 })`
   display: flex;
@@ -40,7 +40,7 @@ const AlternativeLabels = styled(Space).attrs({
 `;
 
 const AlternativeLabel = styled.span.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   border-right: 1px solid ${props => props.theme.color('neutral.700')};
   padding-right: ${props => props.theme.spacingUnits['100']};
@@ -128,7 +128,9 @@ const ThemeHeader: FunctionComponent<{
           </Space>
 
           <Layout gridSizes={gridSize10(false)}>
-            <h1 className={font('brand-bold', 4)}>{concept.displayLabel}</h1>
+            <h1 className={typography('heading', 'xxl', 'strong', 'brand')}>
+              {concept.displayLabel}
+            </h1>
             {themePagesAllFields && (
               <ThemeAlternativeLabels
                 alternativeLabels={concept.alternativeLabels}
@@ -141,7 +143,7 @@ const ThemeHeader: FunctionComponent<{
               concept.description.sourceLabel === 'weco-authority') && (
               <Layout gridSizes={gridSize8(false)}>
                 <Space
-                  className={`${font('sans', 1)} body-text`}
+                  className={`${typography('body', 'xl', 'regular')} body-text`}
                   $v={{ size: 'sm', properties: ['margin-bottom'] }}
                 >
                   <SourcedDescription

--- a/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.ImagesResults.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useMemo } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { capitalize, pluralize } from '@weco/common/utils/grammar';
 import { ReturnedResults } from '@weco/common/utils/search';
 import Space from '@weco/common/views/components/styled/Space';
@@ -32,7 +32,7 @@ const ThemeImagesWrapper = styled(Space).attrs({
 
 const SectionHeading = styled(Space).attrs({
   as: 'h3',
-  className: font('sans-bold', 1),
+  className: typography('body', 'xl', 'strong'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('white')};

--- a/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.RelatedConceptsGroup.tsx
@@ -1,14 +1,14 @@
 import { FunctionComponent } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dasherize } from '@weco/common/utils/grammar';
 import Button, { ButtonColors } from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { RelatedConcept } from '@weco/content/services/wellcome/catalogue/types';
 
 const RelatedConceptsContainer = styled.div.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: flex;
   flex-wrap: wrap;
@@ -17,7 +17,7 @@ const RelatedConceptsContainer = styled.div.attrs({
 `;
 
 const RelatedConceptItem = styled.div.attrs<{ $isFullWidth: boolean }>({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   display: flex;
   align-items: center;
@@ -26,7 +26,7 @@ const RelatedConceptItem = styled.div.attrs<{ $isFullWidth: boolean }>({
 `;
 
 const SectionHeading = styled.h2.attrs({
-  className: font('brand-bold', 2),
+  className: typography('heading', 'xl', 'strong', 'brand'),
 })``;
 
 const InlineLabel = styled.div`
@@ -72,7 +72,7 @@ const RelatedConceptsGroup: FunctionComponent<Props> = ({
               !!item.relationshipType && item.relationshipType?.length > 0
             }
           >
-            <Space className={font('sans', -1)}>
+            <Space className={typography('body', 'md', 'regular')}>
               <Button
                 {...(dataGtmTriggerName && {
                   dataGtmProps: {

--- a/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { capitalize, pluralize } from '@weco/common/utils/grammar';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
 import Space from '@weco/common/views/components/styled/Space';
@@ -24,7 +24,7 @@ import { FromCollectionsHeading } from './concept.styles';
 
 const WorksCount = styled(Space).attrs({
   as: 'p',
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
   $v: { size: 'xs', properties: ['padding-top'] },
 })`
   color: ${props => props.theme.color('neutral.600')};

--- a/content/webapp/views/pages/concepts/concept/concept.styles.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
@@ -14,7 +14,7 @@ export const MobileNavBackground = styled(Space).attrs({
 `;
 
 export const FromCollectionsHeading = styled.h2.attrs({
-  className: font('brand-bold', 2),
+  className: typography('heading', 'xl', 'strong', 'brand'),
 })<{ $color: PaletteColor }>`
   color: ${props => props.theme.color(props.$color)};
   margin-bottom: 0;

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'styled-components';
 
 import { pageDescriptionConcepts } from '@weco/common/data/microcopy';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
@@ -167,7 +167,12 @@ const ConceptPage: NextPage<Props> = ({
                   >
                     <section>
                       <h2
-                        className={font('brand-bold', 2)}
+                        className={typography(
+                          'heading',
+                          'xl',
+                          'strong',
+                          'brand'
+                        )}
                         id="frequent-collaborators"
                       >
                         {config.collaborators.label || 'Frequent collaborators'}

--- a/content/webapp/views/pages/event-series/index.tsx
+++ b/content/webapp/views/pages/event-series/index.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { PaginatedResults } from '@weco/common/services/prismic/types';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import HeaderBackground from '@weco/common/views/components/HeaderBackground';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
@@ -96,7 +96,9 @@ const EventSeriesPage: NextPage<Props> = ({
                 title="Coming up"
               />
             ) : (
-              <h2 className={font('brand-bold', 1)}>No upcoming events</h2>
+              <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+                No upcoming events
+              </h2>
             )}
           </>
         )}

--- a/content/webapp/views/pages/events/event/EventSchedule/EventSchedule.BookingButton.tsx
+++ b/content/webapp/views/pages/events/event/EventSchedule/EventSchedule.BookingButton.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { email, ticketAvailable } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import { Event } from '@weco/content/types/events';
@@ -58,7 +58,7 @@ type EventBookingButtonProps = {
 
 const EventBookingButtonLink = styled(Space).attrs<EventBookingButtonProps>(
   props => ({
-    className: font('sans', 0),
+    className: typography('body', 'lg', 'regular'),
     href: `mailto:${props.email}?subject=${props.title}`,
     $v: { size: 'xs', properties: ['margin-top'] },
   })

--- a/content/webapp/views/pages/events/event/EventSchedule/EventSchedule.Item.tsx
+++ b/content/webapp/views/pages/events/event/EventSchedule/EventSchedule.Item.tsx
@@ -2,7 +2,7 @@ import { Fragment, FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { eventPolicyIds } from '@weco/common/data/hardcoded-ids';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { formatDayDate, formatTime } from '@weco/common/utils/format-date';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
@@ -59,7 +59,7 @@ const EventContainer = styled(Space).attrs({
     size: 'sm',
     properties: ['padding-left', 'padding-right'],
   },
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: inline-block;
   background-color: ${props => props.theme.color('yellow')};
@@ -72,7 +72,7 @@ const eventLocations = (locations: Place[], isHybridEvent: boolean) => {
   return (
     <Space
       $v={{ size: 'xs', properties: ['margin-bottom'] }}
-      className={font('sans', -1)}
+      className={typography('body', 'md', 'regular')}
       style={{ display: 'flex', alignItems: 'center' }}
     >
       {locations.map((l, i) => {
@@ -170,7 +170,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
               <h4
                 style={{ marginBottom: 0 }}
                 key={`${event.title} ${startTimeString}`}
-                className={font('sans-bold', -1)}
+                className={typography('body', 'md', 'strong')}
               >
                 <HTMLDateAndTime variant="time" date={t.range.startDateTime} />
                 {' – '}
@@ -197,7 +197,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
             <Space
               $v={{ size: 'xs', properties: ['margin-bottom'] }}
               as="h5"
-              className={font('brand-bold', 1)}
+              className={typography('heading', 'lg', 'strong', 'brand')}
             >
               {event.title}
             </Space>
@@ -207,7 +207,7 @@ const EventScheduleItem: FunctionComponent<Props> = ({
             {event.promo?.caption && (
               <Space
                 $v={{ size: 'sm', properties: ['margin-bottom'] }}
-                className={font('sans', -1)}
+                className={typography('body', 'md', 'regular')}
                 dangerouslySetInnerHTML={{ __html: event.promo?.caption }}
               />
             )}
@@ -219,7 +219,10 @@ const EventScheduleItem: FunctionComponent<Props> = ({
                   properties: ['margin-top', 'margin-bottom'],
                 }}
               >
-                <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+                <p
+                  className={typography('body', 'md', 'regular')}
+                  style={{ marginBottom: 0 }}
+                >
                   <a href={`/events/${event.id}`}>
                     Full event details
                     <span className="visually-hidden">

--- a/content/webapp/views/pages/events/event/EventSchedule/index.tsx
+++ b/content/webapp/views/pages/events/event/EventSchedule/index.tsx
@@ -1,6 +1,6 @@
 import { Fragment, FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import Space from '@weco/common/views/components/styled/Space';
 import {
@@ -27,7 +27,7 @@ const EventScheduleList: FunctionComponent<{
               <Space
                 $v={{ size: 'sm', properties: ['margin-bottom'] }}
                 as="h3"
-                className={font('brand-bold', 0)}
+                className={typography('heading', 'md', 'strong', 'brand')}
               >
                 {eventsGroup.label}
               </Space>
@@ -78,7 +78,9 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
     <div data-component="event-schedule">
       {futureEvents.length > 0 && (
         <>
-          <h2 className={font('brand-bold', 1)}>Events</h2>
+          <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+            Events
+          </h2>
           <EventScheduleList
             groupedEvents={futureEvents}
             isNotLinkedIds={isNotLinkedIds}
@@ -87,7 +89,9 @@ const EventSchedule: FunctionComponent<Props> = ({ schedule }) => {
       )}
       {pastEvents.length > 0 && (
         <>
-          <h2 className={font('brand-bold', 1)}>Past events</h2>
+          <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+            Past events
+          </h2>
           <EventScheduleList
             groupedEvents={pastEvents}
             isNotLinkedIds={isNotLinkedIds}

--- a/content/webapp/views/pages/events/event/event.EventDatesLink.tsx
+++ b/content/webapp/views/pages/events/event/event.EventDatesLink.tsx
@@ -2,11 +2,11 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { arrowSmall } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 const Wrapper = styled.a.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: inline-flex;
   align-items: center;

--- a/content/webapp/views/pages/events/event/event.EventStatus.tsx
+++ b/content/webapp/views/pages/events/event/event.EventStatus.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { PaletteColor } from '@weco/common/views/themes/config';
 import TextWithDot from '@weco/content/views/components/TextWithDot';
 
@@ -13,7 +13,7 @@ const EventStatus: FunctionComponent<EventStatusProps> = ({ text, color }) => {
   return (
     <div style={{ display: 'flex' }}>
       <TextWithDot
-        className={font('sans-bold', -1)}
+        className={typography('body', 'md', 'strong')}
         dotColor={color}
         text={text}
       />

--- a/content/webapp/views/pages/events/event/index.tsx
+++ b/content/webapp/views/pages/events/event/index.tsx
@@ -14,7 +14,7 @@ import { arrow, email, ticket } from '@weco/common/icons';
 import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { headerBackgroundLs } from '@weco/common/utils/backgrounds';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatDayDate, formatTime } from '@weco/common/utils/format-date';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
@@ -66,14 +66,14 @@ const DateWrapper = styled.div.attrs({
 `;
 
 const ThirdParty = styled.span.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   color: ${props => props.theme.color('neutral.700')};
   margin: 0;
 `;
 
 const EmailTeamCopy = styled(Space).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $v: { size: 'xs', properties: ['margin-top'] },
 })`
   display: block;
@@ -343,7 +343,9 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
 
         {accessResourceLinks && accessResourceLinks.length > 0 && (
           <>
-            <h2 className={font('brand-bold', 1)}>Event access content</h2>
+            <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+              Event access content
+            </h2>
             <Space $v={{ size: 'md', properties: ['padding-bottom'] }}>
               <ResourcesList>
                 {accessResourceLinks.map((link, i) => {
@@ -355,9 +357,13 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
                         $borderColor="accent.turquoise"
                       >
                         {link.type === 'visual-story' && (
-                          <h3 className={font('sans-bold', 0)}>Visual story</h3>
+                          <h3 className={typography('body', 'lg', 'strong')}>
+                            Visual story
+                          </h3>
                         )}
-                        <span className={font('sans', -2)}>{link.text}</span>
+                        <span className={typography('body', 'sm', 'regular')}>
+                          {link.text}
+                        </span>
                         <ResourceLinkIconWrapper>
                           <Icon icon={arrow} />
                         </ResourceLinkIconWrapper>
@@ -416,13 +422,21 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
           {isNotUndefined(
             event.policies.find(p => p.id === eventPolicyIds.schoolBooking)
           ) ? (
-            <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+            <p
+              className={typography('body', 'md', 'regular')}
+              style={{ marginBottom: 0 }}
+            >
               {a11y.defaultEventMessage}
             </p>
           ) : (
             <>
-              <p className={font('sans', -1)}>{a11y.defaultEventMessage}</p>
-              <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+              <p className={typography('body', 'md', 'regular')}>
+                {a11y.defaultEventMessage}
+              </p>
+              <p
+                className={typography('body', 'md', 'regular')}
+                style={{ marginBottom: 0 }}
+              >
                 <a
                   href={`https://wellcomecollection.org/visit-us/${prismicPageIds.bookingAndAttendingOurEvents}`}
                 >

--- a/content/webapp/views/pages/events/events.NoEvents.tsx
+++ b/content/webapp/views/pages/events/events.NoEvents.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Buttons from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -35,7 +35,7 @@ const NoEvents: FunctionComponent<Props> = ({ isPastListing, hasFilters }) => {
       <Space
         as="p"
         $v={{ size: 'xs', properties: ['margin-bottom'] }}
-        className={font('sans', 2)}
+        className={typography('body', 'xl', 'regular')}
       >
         No {isPastListing ? 'past' : 'upcoming'} events found
       </Space>
@@ -52,7 +52,7 @@ const NoEvents: FunctionComponent<Props> = ({ isPastListing, hasFilters }) => {
       )}
       <Space
         $v={{ size: 'md', properties: ['margin-top'] }}
-        className={font('sans', -2)}
+        className={typography('body', 'sm', 'regular')}
       >
         {hasFilters ? 'Or check' : 'Check'}{' '}
         <a href={`/events${isPastListing ? '' : '/past'}`}>

--- a/content/webapp/views/pages/events/index.tsx
+++ b/content/webapp/views/pages/events/index.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'styled-components';
 
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import { transformImage } from '@weco/common/services/prismic/transformers/images';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formDataAsUrlQuery } from '@weco/common/utils/forms';
 import { pluralize } from '@weco/common/utils/grammar';
 import {
@@ -122,7 +122,9 @@ const EventsPage: NextPage<Props> = props => {
 
         {pageDescriptions.events && (
           <ContaineredLayout gridSizes={gridSize8(false)}>
-            <div className={`body-text spaced-text ${font('sans', 0)}`}>
+            <div
+              className={`body-text spaced-text ${typography('body', 'lg', 'regular')}`}
+            >
               <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
                 <p>{pageDescriptions.events}</p>
               </Space>

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.BeingHuman.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.BeingHuman.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent } from 'react';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { arrow, download } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import { defaultSerializer } from '@weco/common/views/components/HTMLSerializers';
@@ -77,7 +77,7 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
           <Space
             as="h2"
             $v={{ size: 'sm', properties: ['margin-bottom'] }}
-            className={font('brand-bold', 1)}
+            className={typography('heading', 'lg', 'strong', 'brand')}
           >{`${exhibitionFormat} access content`}</Space>
           {(accessResourceLinks.length > 0 ||
             exhibition.accessResourcesPdfs.length > 0) && (
@@ -96,14 +96,18 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
                         $borderColor={borderColor}
                       >
                         {link.type === 'exhibition-guide' && (
-                          <h3 className={font('sans-bold', 0)}>
+                          <h3 className={typography('body', 'lg', 'strong')}>
                             Digital exhibition guide
                           </h3>
                         )}
                         {link.type === 'visual-story' && (
-                          <h3 className={font('sans-bold', 0)}>Visual story</h3>
+                          <h3 className={typography('body', 'lg', 'strong')}>
+                            Visual story
+                          </h3>
                         )}
-                        <span className={font('sans', -2)}>{link.text}</span>
+                        <span className={typography('body', 'sm', 'regular')}>
+                          {link.text}
+                        </span>
                         <ResourceLinkIconWrapper>
                           <Icon icon={arrow} />
                         </ResourceLinkIconWrapper>
@@ -124,7 +128,7 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
                         $borderColor={borderColor}
                         $underlineText={true}
                       >
-                        <span className={font('sans', -1)}>
+                        <span className={typography('body', 'md', 'regular')}>
                           {`${pdf.text} PDF`} {`(${pdf.size}kb)`}
                         </span>
                         <ResourceLinkIconWrapper>
@@ -164,7 +168,10 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
       {exhibition.end && !isPast(exhibition.end) && (
         <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
           <InfoBox title="Visit us" items={getInfoItems(exhibition)}>
-            <p className={font('sans', -1)} style={{ margin: 0 }}>
+            <p
+              className={typography('body', 'md', 'regular')}
+              style={{ margin: 0 }}
+            >
               For more information, please visit our{' '}
               <a href={`/visit-us/${prismicPageIds.access}`}>Accessibility</a>{' '}
               page. If you have any queries about accessibility, please email us

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Exhibition.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Exhibition.tsx
@@ -7,7 +7,7 @@ import {
   ExhibitionTextsDocument,
 } from '@weco/common/prismicio-types';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
@@ -207,7 +207,7 @@ const Exhibition: FunctionComponent<Props> = ({
                 <GridCell $sizeMap={{ s: [12] }}>
                   <Space
                     as="h2"
-                    className={font('brand-bold', 1)}
+                    className={typography('heading', 'lg', 'strong', 'brand')}
                     $v={{
                       size: 'md',
                       properties: ['margin-top', 'margin-bottom'],
@@ -220,7 +220,9 @@ const Exhibition: FunctionComponent<Props> = ({
 
               {visualStoryLink && (
                 <>
-                  <h3 className={font('sans-bold', 0)}>Plan your visit</h3>
+                  <h3 className={typography('body', 'lg', 'strong')}>
+                    Plan your visit
+                  </h3>
                   <NextLink href={visualStoryLink.url}>
                     Exhibition visual story
                   </NextLink>{' '}
@@ -231,7 +233,9 @@ const Exhibition: FunctionComponent<Props> = ({
                 </>
               )}
 
-              <h3 className={font('sans-bold', 0)}>{`When you're here`}</h3>
+              <h3
+                className={typography('body', 'lg', 'strong')}
+              >{`When you're here`}</h3>
               <p>
                 Resources designed to support your visit are available online
                 and in the gallery.
@@ -247,7 +251,7 @@ const Exhibition: FunctionComponent<Props> = ({
 
               <Space
                 as="h3"
-                className={font('sans-bold', 0)}
+                className={typography('body', 'lg', 'strong')}
                 $v={{ size: 'md', properties: ['margin-bottom'] }}
               >
                 Access information, tours and queries

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Installation.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Installation.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
 import { createScreenreaderLabel } from '@weco/common/utils/telephone-numbers';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -132,7 +132,10 @@ const Installation: FunctionComponent<Props> = ({
     >
       {installation.end && !isPast(installation.end) && (
         <InfoBox title="Visit us" items={getInfoItems(installation)}>
-          <p className={font('sans', -1)} style={{ margin: 0 }}>
+          <p
+            className={typography('body', 'md', 'regular')}
+            style={{ margin: 0 }}
+          >
             For more information, please visit our{' '}
             <a href={`/visit-us/${prismicPageIds.access}`}>Accessibility</a>{' '}
             page. If you have any queries about accessibility, please email us

--- a/content/webapp/views/pages/exhibitions/explore-more.tsx
+++ b/content/webapp/views/pages/exhibitions/explore-more.tsx
@@ -3,7 +3,7 @@ import { NextPage } from 'next';
 import styled from 'styled-components';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import {
   ContaineredLayout,
@@ -113,7 +113,16 @@ const ExploreMorePage: NextPage<Props> = ({
                 hasWorkCards={true}
                 CopyContent={
                   <>
-                    <h3 className={font('brand', 1)}>{group.heading}</h3>
+                    <h3
+                      className={typography(
+                        'heading',
+                        'lg',
+                        'regular',
+                        'brand'
+                      )}
+                    >
+                      {group.heading}
+                    </h3>
                     <div
                       dangerouslySetInnerHTML={{ __html: group.description }}
                     ></div>

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/exhibition.OtherExhibitionGuides.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/exhibition.OtherExhibitionGuides.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import {
   ContaineredLayout,
   gridSize8,
@@ -25,7 +25,7 @@ const OtherExhibitionGuides: FunctionComponent<Props> = ({
     <Space $v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}>
       <ContaineredLayout gridSizes={gridSize8(false)}>
         <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
-          <h2 className={font('brand-bold', 1)}>
+          <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
             Other exhibition guides available
           </h2>
         </Space>

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/exhibition.TypeOption.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/exhibition.TypeOption.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import cookies from '@weco/common/data/cookies';
 import { arrow } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import { plainListStyles } from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -77,7 +77,9 @@ const TypeOption: FunctionComponent<Props> = ({ url, title, type }) => {
     <TypeItem>
       <TypeLink href={url} $backgroundColor="warmNeutral.300" onClick={onClick}>
         <CardBody style={{ height: '100%' }}>
-          <h2 className={font('brand-bold', 1)}>{title}</h2>
+          <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+            {title}
+          </h2>
 
           <TypeIconsWrapper>
             <RelevantGuideIcons types={[type]} />

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/index.tsx
@@ -5,7 +5,7 @@ import { NextPage } from 'next';
 import cookies from '@weco/common/data/cookies';
 import { pageDescriptions } from '@weco/common/data/microcopy';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { exhibitionGuidesLinks } from '@weco/common/views/components/Header';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
@@ -132,7 +132,9 @@ const ExhibitionGuideTypePage: NextPage<Props> = ({
       />
 
       <ContaineredLayout gridSizes={gridSize8(false)}>
-        <h2 className={font('sans-bold', 0)}>{getTypeTitle(type)}</h2>
+        <h2 className={typography('body', 'lg', 'strong')}>
+          {getTypeTitle(type)}
+        </h2>
 
         {exhibitionGuide.introText?.length > 0 ? (
           <PrismicHtmlBlock html={exhibitionGuide.introText} />

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/stop.styles.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/stop.styles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -21,7 +21,7 @@ export const FlushContainer = styled(Container)`
 `;
 
 export const Header = styled.header.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   background-color: ${props => props.theme.color('neutral.700')};
   position: sticky;
@@ -30,7 +30,7 @@ export const Header = styled.header.attrs({
 `;
 
 export const Title = styled.h1.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   margin-bottom: 0;
 `;
@@ -49,7 +49,7 @@ export const HeaderInner = styled(Space).attrs({
 export const prevNextHeight = '50px';
 
 export const PrevNext = styled.div.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   position: fixed;
   z-index: 2;

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/type.ExhibitionGuideStops.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/type.ExhibitionGuideStops.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, ReactElement } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import VideoEmbed from '@weco/common/views/components/VideoEmbed';
 import { PaletteColor } from '@weco/common/views/themes/config';
@@ -46,7 +46,10 @@ export const VideoPlayer: FunctionComponent<VideoPlayerProps> = ({
 }) => (
   <VideoPlayerWrapper>
     <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-      <figcaption className={font('sans-bold', -1)} {...titleProps}>
+      <figcaption
+        className={typography('body', 'md', 'strong')}
+        {...titleProps}
+      >
         {title}
       </figcaption>
     </Space>

--- a/content/webapp/views/pages/index.SimpleCardGrid.tsx
+++ b/content/webapp/views/pages/index.SimpleCardGrid.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { getCrop } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import {
   ContaineredLayout,
   gridSize12,
@@ -64,9 +64,15 @@ const CardGridFeaturedCard = ({
         textColor="white"
         priority={priority}
       >
-        {item.title && <h2 className={font('brand-bold', 2)}>{item.title}</h2>}
+        {item.title && (
+          <h2 className={typography('heading', 'xl', 'strong', 'brand')}>
+            {item.title}
+          </h2>
+        )}
         {item.description && (
-          <p className={font('sans', -1)}>{item.description}</p>
+          <p className={typography('body', 'md', 'regular')}>
+            {item.description}
+          </p>
         )}
       </FeaturedCard>
     </ContaineredLayout>

--- a/content/webapp/views/pages/index.tsx
+++ b/content/webapp/views/pages/index.tsx
@@ -6,7 +6,7 @@ import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { homepageHeading, pageDescriptions } from '@weco/common/data/microcopy';
 import { ImageType } from '@weco/common/model/image';
 import { StandfirstSlice as RawStandfirstSlice } from '@weco/common/prismicio-types';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import {
@@ -106,7 +106,7 @@ const Homepage: NextPage<Props> = ({
           <SpacingSection>
             <Space
               $v={{ size: 'lg', properties: ['margin-top'] }}
-              className={font('brand-bold', 4)}
+              className={typography('heading', 'xxl', 'strong', 'brand')}
             >
               <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
                 <h1>{homepageHeading}</h1>

--- a/content/webapp/views/pages/newsletter.Signup.tsx
+++ b/content/webapp/views/pages/newsletter.Signup.tsx
@@ -13,7 +13,7 @@ import {
 } from '@weco/common/data/dotdigital';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import useValidation from '@weco/common/hooks/useValidation';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio';
 import Space from '@weco/common/views/components/styled/Space';
@@ -114,7 +114,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
     <>
       {isConfirmed && (
         <div className="body-text">
-          <p className={font('sans-bold', 1)}>
+          <p className={typography('body', 'xl', 'strong')}>
             Thank you for confirming your email address
           </p>
           <p>
@@ -135,7 +135,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
 
       {isSuccess && (
         <div className="body-text">
-          <p className={font('sans-bold', 1)}>You’re signed up</p>
+          <p className={typography('body', 'xl', 'strong')}>You’re signed up</p>
           <p>
             If this is the first time you’ve subscribed to updates from us, you
             will receive an email asking you to confirm. Please check your email
@@ -146,7 +146,9 @@ const NewsletterSignup: FunctionComponent<Props> = ({
 
       {isError && (
         <div className="body-text">
-          <p className={font('sans-bold', 1)}>Sorry, there’s been a problem</p>
+          <p className={typography('body', 'xl', 'strong')}>
+            Sorry, there’s been a problem
+          </p>
           <p>Please try again.</p>
         </div>
       )}
@@ -156,7 +158,10 @@ const NewsletterSignup: FunctionComponent<Props> = ({
           className="body-text"
           $v={{ size: 'sm', properties: ['margin-bottom'] }}
         >
-          <p className={font('sans-bold', 1)} style={{ marginBottom: '1rem' }}>
+          <p
+            className={typography('body', 'xl', 'strong')}
+            style={{ marginBottom: '1rem' }}
+          >
             Want to hear more from us?
           </p>
           <p>
@@ -190,7 +195,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
 
           <NewsletterFieldset $hasError={showCheckboxError}>
             <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-              <legend className={font('sans-bold', 0)}>
+              <legend className={typography('body', 'lg', 'strong')}>
                 Select each newsletter you'd like to receive:
               </legend>
             </Space>
@@ -293,7 +298,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
                 setHasCheckedMarketing(currentValue => !currentValue);
               }}
               text={
-                <p className={font('sans', -2)}>
+                <p className={typography('body', 'sm', 'regular')}>
                   Tick this box if you’re happy to receive other emails about
                   Wellcome Collection, upcoming events and exhibitions and/or
                   other relevant opportunities.
@@ -309,7 +314,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
                 setHasCheckedAudience(currentValue => !currentValue);
               }}
               text={
-                <p className={font('sans', -2)}>
+                <p className={typography('body', 'sm', 'regular')}>
                   Tick this box if you’d be happy for us to use your information
                   to help us understand our audience, and show you relevant
                   adverts about Wellcome Collection on social networks (such as
@@ -317,7 +322,7 @@ const NewsletterSignup: FunctionComponent<Props> = ({
                 </p>
               }
             />
-            <p className={font('sans', -2)}>
+            <p className={typography('body', 'sm', 'regular')}>
               By clicking subscribe, you agree to receive this newsletter. You
               can unsubscribe any time. For information about how we handle your
               data,{' '}

--- a/content/webapp/views/pages/search/concepts/concepts.SearchResults.styles.tsx
+++ b/content/webapp/views/pages/search/concepts/concepts.SearchResults.styles.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -46,18 +46,18 @@ export const Details = styled.div`
 `;
 
 export const ConceptTitleHeading = styled.h3.attrs({
-  className: font('sans-bold', 0),
+  className: typography('body', 'lg', 'strong'),
 })``;
 
 export const ConceptDescription = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.700')};
 `;
 
 export const AlternativeLabels = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.600')};
@@ -68,7 +68,7 @@ export const AlternativeLabels = styled(Space).attrs({
 `;
 
 export const ConceptInformation = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'xs', properties: ['margin-bottom'] },
 })`
   color: ${props => props.theme.color('neutral.600')};

--- a/content/webapp/views/pages/search/concepts/concepts.SearchResults.tsx
+++ b/content/webapp/views/pages/search/concepts/concepts.SearchResults.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import Space from '@weco/common/views/components/styled/Space';
 import { Concept } from '@weco/content/services/wellcome/catalogue/types';
@@ -61,7 +61,7 @@ const ConceptSearchResult: FunctionComponent<{
               )}
 
             <ConceptInformation>
-              <span className={font('sans-bold', -1)}>
+              <span className={typography('body', 'md', 'strong')}>
                 Type: {concept.type}
               </span>
               {concept.id && (

--- a/content/webapp/views/pages/search/index.tsx
+++ b/content/webapp/views/pages/search/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSearchContext } from '@weco/common/contexts/SearchContext';
 import { arrow } from '@weco/common/icons';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatNumber } from '@weco/common/utils/grammar';
 import { getQueryResults } from '@weco/common/utils/search';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -221,7 +221,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
         ) : (
           <BasicSection>
             <Container>
-              <p className={font('sans', -1)}>
+              <p className={typography('body', 'md', 'regular')}>
                 {contentQueryFailed ? (
                   <>
                     There was a problem fetching some search results. Please try
@@ -235,7 +235,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
                       <>
                         {' '}
                         for{' '}
-                        <span className={font('sans-bold', -1)}>
+                        <span className={typography('body', 'md', 'strong')}>
                           {queryString}
                         </span>
                       </>
@@ -263,7 +263,7 @@ const SearchPage: NextPage<Props> = withSearchLayout(
                         properties: ['margin-left', 'margin-right'],
                       }}
                     >
-                      <h3 className={font('sans-bold', 0)}>
+                      <h3 className={typography('body', 'lg', 'strong')}>
                         Are you looking for our online collections?
                       </h3>
                     </Space>

--- a/content/webapp/views/pages/search/search.NoResults.tsx
+++ b/content/webapp/views/pages/search/search.NoResults.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useEffect } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
 
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const QuerySpan = styled.span.attrs({
-  className: font('sans-bold', 2),
+  className: typography('heading', 'xl', 'strong', 'sans'),
 })``;
 
 const SearchNoResults: FunctionComponent<Props> = ({
@@ -43,12 +43,18 @@ const SearchNoResults: FunctionComponent<Props> = ({
             xl: [10],
           }}
         >
-          <p data-testid="search-no-results" className={font('sans', 2)}>
+          <p
+            data-testid="search-no-results"
+            className={typography('body', 'xl', 'regular')}
+          >
             We couldn&rsquo;t find anything that matched{' '}
             {query ? <QuerySpan>{query}</QuerySpan> : 'your search'}
             {hasFilters ? ' with the filters you have selected.' : '.'}
           </p>
-          <p className={font('sans', 1)} style={{ maxWidth: '800px' }}>
+          <p
+            className={typography('body', 'xl', 'regular')}
+            style={{ maxWidth: '800px' }}
+          >
             Please adjust your search terms and try again. If you think this
             search should show some results, please email{' '}
             <a href="mailto:digital@wellcomecollection.org">

--- a/content/webapp/views/pages/search/search.styles.tsx
+++ b/content/webapp/views/pages/search/search.styles.tsx
@@ -1,12 +1,12 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const WorksLink = styled(NextLink).attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   border: 2px solid;
   padding: 4px 12px;
@@ -53,7 +53,7 @@ export const CatalogueSectionTitle = styled(Space).attrs<{
   $isSmallGallery?: boolean;
 }>(props => ({
   as: 'h3',
-  className: `${font('sans-bold', 0)} is-hidden-s is-hidden-m`,
+  className: `${typography('body', 'lg', 'strong')} is-hidden-s is-hidden-m`,
   $v: props.$isSmallGallery
     ? { size: 'sm', properties: ['margin-bottom'] }
     : undefined,
@@ -62,7 +62,7 @@ export const CatalogueSectionTitle = styled(Space).attrs<{
 `;
 
 export const AllLink = styled(NextLink).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: inline-flex;
   align-items: center;

--- a/content/webapp/views/pages/seasons/season/season.Header.tsx
+++ b/content/webapp/views/pages/seasons/season/season.Header.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { getCrop } from '@weco/common/model/image';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { WobblyBottom } from '@weco/common/views/components/DecorativeEdge';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import {
@@ -61,14 +61,19 @@ const SeasonsHeader: FunctionComponent<Props> = ({ season }) => {
                     <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
                       <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
                         <h1
-                          className={font('brand-bold', 4)}
+                          className={typography(
+                            'heading',
+                            'xxl',
+                            'strong',
+                            'brand'
+                          )}
                           style={{ display: 'inline-block', marginBottom: 0 }}
                         >
                           {title}
                         </h1>
                       </Space>
                       {start && end && (
-                        <div className={font('sans', -1)}>
+                        <div className={typography('body', 'md', 'regular')}>
                           <DateRange start={start} end={end} />
                         </div>
                       )}

--- a/content/webapp/views/pages/stories/story/index.tsx
+++ b/content/webapp/views/pages/stories/story/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { getCrop } from '@weco/common/model/image';
 import { ServerData } from '@weco/common/server-data/types';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
@@ -206,7 +206,11 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
             <RelatedStoryContainer>
               {relatedDocument.type === 'Article' ? (
                 <>
-                  <h2 className={font('brand-bold', 2)}>Your next story</h2>
+                  <h2
+                    className={typography('heading', 'xl', 'strong', 'brand')}
+                  >
+                    Your next story
+                  </h2>
                   <FeaturedCard
                     type="article"
                     background="neutral.700"
@@ -217,7 +221,9 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
               ) : (
                 relatedDocument.type === 'exhibitions' && (
                   <>
-                    <h2 className={font('brand-bold', 2)}>
+                    <h2
+                      className={typography('heading', 'xl', 'strong', 'brand')}
+                    >
                       You may also be interested in
                     </h2>
                     <FeaturedCard

--- a/content/webapp/views/pages/stories/story/story.ContentTypeInfo.tsx
+++ b/content/webapp/views/pages/stories/story/story.ContentTypeInfo.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { commissioningEditorRoleId } from '@weco/common/data/hardcoded-ids';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
 import Space from '@weco/common/views/components/styled/Space';
@@ -14,7 +14,7 @@ const ContentTypeWrapper = styled.div`
 `;
 
 const ContentTypeText = styled.p.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   margin: 0;
 `;
@@ -26,7 +26,9 @@ const ContentTypeInfoSection = styled.span`
   }
 `;
 
-const HTMLDateWrapper = styled.span.attrs({ className: font('sans', -2) })`
+const HTMLDateWrapper = styled.span.attrs({
+  className: typography('body', 'sm', 'regular'),
+})`
   display: block;
   color: ${props => props.theme.color('neutral.600')};
 `;
@@ -61,7 +63,7 @@ const ContentTypeInfo = (article: Article) => (
                       by{' '}
                     </span>
                   )}
-                  <span className={font('sans-bold', -2)}>
+                  <span className={typography('body', 'sm', 'strong')}>
                     {contributor.name}
                   </span>
                 </ContentTypeInfoSection>
@@ -69,7 +71,7 @@ const ContentTypeInfo = (article: Article) => (
           {article.readingTime ? (
             <ContentTypeInfoSection>
               average reading time{' '}
-              <span className={font('sans-bold', -2)}>
+              <span className={typography('body', 'sm', 'strong')}>
                 {article.readingTime}
               </span>
             </ContentTypeInfoSection>

--- a/content/webapp/views/pages/visit-us/index.tsx
+++ b/content/webapp/views/pages/visit-us/index.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent } from 'react';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { usePrismicData } from '@weco/common/server-data/Context';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import FindUs from '@weco/common/views/components/FindUs';
 import {
   ContaineredLayout,
@@ -35,9 +35,12 @@ const VisitUsStaticContent: FunctionComponent = () => {
           </GridCell>
           <GridCell
             $sizeMap={{ s: [12], l: [5], xl: [5] }}
-            className={font('sans', -1)}
+            className={typography('body', 'md', 'regular')}
           >
-            <h2 style={{ marginBottom: 0 }} className={font('sans-bold', -1)}>
+            <h2
+              style={{ marginBottom: 0 }}
+              className={typography('body', 'md', 'strong')}
+            >
               Today’s opening times
             </h2>
             <OpeningTimes venues={venues} />

--- a/content/webapp/views/pages/visual-stories/visual-story/index.tsx
+++ b/content/webapp/views/pages/visual-stories/visual-story/index.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from 'next';
 
 import linkResolver from '@weco/common/services/prismic/link-resolver';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { capitalize } from '@weco/common/utils/grammar';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import Divider from '@weco/common/views/components/Divider';
@@ -124,7 +124,10 @@ const VisualStoryPage: NextPage<Props> = ({
                 properties: ['padding-top', 'padding-bottom'],
               }}
             >
-              <h2 className={font('brand-bold', 2)} id="more-visual-stories">
+              <h2
+                className={typography('heading', 'xl', 'strong', 'brand')}
+                id="more-visual-stories"
+              >
                 More Visual Stories
               </h2>
             </Space>

--- a/content/webapp/views/pages/whats-on/index.tsx
+++ b/content/webapp/views/pages/whats-on/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@weco/common/services/prismic/opening-times';
 import { transformCollectionVenues } from '@weco/common/services/prismic/transformers/collection-venues';
 import { Period } from '@weco/common/types/periods';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import AccessibilityProvision from '@weco/common/views/components/AccessibilityProvision';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
@@ -243,10 +243,17 @@ const WhatsOnPage: NextPage<Props> = props => {
                         justifyContent: 'space-between',
                       }}
                     >
-                      <h2 className={font('brand-bold', 2)}>
+                      <h2
+                        className={typography(
+                          'heading',
+                          'xl',
+                          'strong',
+                          'brand'
+                        )}
+                      >
                         Exhibitions and Events
                       </h2>
-                      <span className={font('sans-bold', 0)}>
+                      <span className={typography('body', 'lg', 'strong')}>
                         Free admission
                       </span>
                     </div>

--- a/content/webapp/views/pages/whats-on/whats-on.ClosedMessage.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.ClosedMessage.tsx
@@ -2,7 +2,7 @@ import { useTheme } from 'styled-components';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { clock, information } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import InfoBox, {
@@ -26,7 +26,7 @@ const ClosedMessage = () => {
         <InfoIconWrapper>
           <Icon icon={information} />
         </InfoIconWrapper>
-        <p className={font('sans', -1)}>
+        <p className={typography('body', 'md', 'regular')}>
           Our exhibitions are closed today, but our{' '}
           <a href={`/visit-us/${prismicPageIds.cafe}`}>café</a> and{' '}
           <a href={`/visit-us/${prismicPageIds.shop}`}>shop</a> are open for
@@ -36,7 +36,10 @@ const ClosedMessage = () => {
         <InfoIconWrapper>
           <Icon icon={clock} />
         </InfoIconWrapper>
-        <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+        <p
+          className={typography('body', 'md', 'regular')}
+          style={{ marginBottom: 0 }}
+        >
           Galleries open Tuesday–Sunday,{' '}
           <a href={`/visit-us/${prismicPageIds.openingTimes}`}>
             see full opening times

--- a/content/webapp/views/pages/whats-on/whats-on.DateRange.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.DateRange.tsx
@@ -1,4 +1,4 @@
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatDate, formatDayName } from '@weco/common/utils/format-date';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
 import Space from '@weco/common/views/components/styled/Space';
@@ -17,7 +17,7 @@ const DateRange = ({ dateRange, period }: DateRangeProps) => {
         properties: ['margin-bottom'],
       }}
       as="p"
-      className={font('sans', -1)}
+      className={typography('body', 'md', 'regular')}
     >
       {period === 'today' && <HTMLDateAndTime variant="date" date={start} />}
       {period === 'this-weekend' && (

--- a/content/webapp/views/pages/whats-on/whats-on.FacilityCard.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.FacilityCard.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import PrismicImage from '@weco/common/views/components/PrismicImage';
 import Space from '@weco/common/views/components/styled/Space';
@@ -14,14 +14,14 @@ const ImageWrapper = styled.div`
 `;
 
 const Description = styled.p.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   margin: 0;
   padding: 0;
 `;
 
 const Meta = styled.div.attrs({
-  className: font('sans-bold', -2),
+  className: typography('body', 'sm', 'strong'),
 })`
   display: flex;
   align-items: center;
@@ -54,7 +54,9 @@ const FacilityCard: FunctionComponent<FacilityCardType> = ({
 
         <CardBody>
           <div>
-            <h3 className={font('brand-bold', 0)}>{title}</h3>
+            <h3 className={typography('heading', 'md', 'strong', 'brand')}>
+              {title}
+            </h3>
             <Description>{description}</Description>
 
             {metaText && (

--- a/content/webapp/views/pages/whats-on/whats-on.Header.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.Header.tsx
@@ -8,7 +8,7 @@ import {
   ExceptionalOpeningHoursDay,
   OpeningHoursDay,
 } from '@weco/common/model/opening-hours';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import { TitleWrapper } from '@weco/common/views/components/PageHeader/PageHeader.styles';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -62,7 +62,7 @@ const Header: FunctionComponent<HeaderProps> = ({
                     <Space
                       as="span"
                       $h={{ size: 'sm', properties: ['margin-right'] }}
-                      className={font('sans-bold', -1)}
+                      className={typography('body', 'md', 'strong')}
                     >
                       Galleries
                       {todaysOpeningHours.isClosed ? ' closed ' : ' open '}
@@ -80,7 +80,7 @@ const Header: FunctionComponent<HeaderProps> = ({
                         <Space
                           as="span"
                           $h={{ size: 'sm', properties: ['margin-right'] }}
-                          className={font('sans', -1)}
+                          className={typography('body', 'md', 'regular')}
                         >
                           <>
                             <time>{todaysOpeningHours.opens}</time>
@@ -94,7 +94,7 @@ const Header: FunctionComponent<HeaderProps> = ({
                 )}
                 <NextLink
                   href={`/visit-us/${prismicPageIds.openingTimes}`}
-                  className={font('sans-bold', -1)}
+                  className={typography('body', 'md', 'strong')}
                 >
                   Full opening times
                 </NextLink>

--- a/content/webapp/views/pages/works/work/ArchiveTree/ArchiveTree.WorkItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveTree/ArchiveTree.WorkItemRenderer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { chevron } from '@weco/common/icons';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import { toWorkLink } from '@weco/content/views/components/WorkLink';
@@ -17,7 +17,7 @@ import { UiTreeNode } from '@weco/content/views/pages/works/work/work.types';
 import { StyledLink } from './ArchiveTree.styles';
 
 const RefNumber = styled.span.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   line-height: 1;
   display: block;
@@ -51,7 +51,7 @@ const WorkItem: FunctionComponent<WorkItemRendererProps> = ({
   return (
     <div
       style={{ display: 'flex', width: '100%' }}
-      className={font('sans', -2)}
+      className={typography('body', 'sm', 'regular')}
     >
       {isEnhanced && (level > 1 || showFirstLevelGuideline) && hasControl && (
         <TreeControl
@@ -65,8 +65,8 @@ const WorkItem: FunctionComponent<WorkItemRendererProps> = ({
       <StyledLink
         {...toWorkLink({ id: item.work.id, scroll: false })}
         className={classNames({
-          [font('sans-bold', -2)]: level === 1,
-          [font('sans', -2)]: level > 1,
+          [typography('body', 'sm', 'strong')]: level === 1,
+          [typography('body', 'sm', 'regular')]: level > 1,
         })}
         tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
         $isCurrent={currentWorkId === item.work.id}

--- a/content/webapp/views/pages/works/work/ArchiveTree/index.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveTree/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { treeInstructions } from '@weco/common/data/microcopy';
 import { tree } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Modal from '@weco/common/views/components/Modal';
 import Space from '@weco/common/views/components/styled/Space';
@@ -189,7 +189,9 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
           <Space
             $v={{ size: 'md', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <h2 className={font('brand-bold', 0)}>Collection contents</h2>
+            <h2 className={typography('heading', 'md', 'strong', 'brand')}>
+              Collection contents
+            </h2>
             <Tree $isEnhanced={isEnhanced} $maxWidth={375}>
               {isEnhanced && (
                 <TreeInstructions>{treeInstructions}</TreeInstructions>

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Download.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Download.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { bornDigitalWarning } from '@weco/common/data/microcopy';
 import { file, pdf } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Buttons from '@weco/common/views/components/Buttons';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -69,14 +69,16 @@ const IIIFItemDownload: FunctionComponent<Props> = ({
       />
 
       <Space
-        className={font('sans-bold', -1)}
+        className={typography('body', 'md', 'strong')}
         $v={{ size: 'sm', properties: ['margin-top', 'margin-bottom'] }}
       >
         {displayLabel}
       </Space>
 
       {showWarning && (
-        <div className={font('sans', -2)}>{bornDigitalWarning}</div>
+        <div className={typography('body', 'sm', 'regular')}>
+          {bornDigitalWarning}
+        </div>
       )}
 
       <Buttons
@@ -90,9 +92,11 @@ const IIIFItemDownload: FunctionComponent<Props> = ({
         }}
       />
 
-      <span className={font('sans', -2)}>
+      <span className={typography('body', 'sm', 'regular')}>
         Size:{' '}
-        <span className={font('sans-bold', -2)}>{fileSize || 'unknown'}</span>
+        <span className={typography('body', 'sm', 'strong')}>
+          {fileSize || 'unknown'}
+        </span>
       </span>
     </DownloadContainer>
   );

--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -20,7 +20,7 @@ import {
   unavailableContentMessage,
 } from '@weco/common/data/microcopy';
 import { LinkProps } from '@weco/common/model/link-props';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import {
   ContaineredLayout,
@@ -245,12 +245,14 @@ const PublicRestrictedMessage: FunctionComponent<{
   return (
     <MessageContainer>
       {externalAccessService?.label && (
-        <h2 className={font('sans-bold', 0)}>{externalAccessService.label}</h2>
+        <h2 className={typography('body', 'lg', 'strong')}>
+          {externalAccessService.label}
+        </h2>
       )}
-      <div className={font('sans', -1)}>
+      <div className={typography('body', 'md', 'regular')}>
         {externalAccessService?.description && (
           <div
-            className={font('sans', -1)}
+            className={typography('body', 'md', 'regular')}
             dangerouslySetInnerHTML={{
               __html: externalAccessService.description,
             }}

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { audio, file, pdf, video } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Icon from '@weco/common/views/components/Icon';
 import LL from '@weco/common/views/components/styled/LL';
@@ -60,7 +60,7 @@ const ImageContainer = styled.span`
 `;
 
 const IIIFViewerThumbNumber = styled.span.attrs({
-  className: font('sans-bold', -2),
+  className: typography('body', 'sm', 'strong'),
 })`
   padding: 3px 6px;
   border-radius: 3px;

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFSearchWithin.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { search } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { pluralize } from '@weco/common/utils/grammar';
 import Button from '@weco/common/views/components/Buttons';
 import LL from '@weco/common/views/components/styled/LL';
@@ -54,7 +54,7 @@ const ResultsHeader = styled(Space).attrs({
 `;
 
 const ListItem = styled.li.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   list-style: none;
   border-bottom: 1px solid ${props => props.theme.color('neutral.500')};
@@ -72,7 +72,7 @@ const ListItem = styled.li.attrs({
 
 const HitData = styled(Space).attrs({
   as: 'span',
-  className: font('sans-bold', -2),
+  className: typography('body', 'sm', 'strong'),
 })`
   display: block;
 `;
@@ -84,7 +84,7 @@ const ResultsList = styled.ul`
 const ErrorMessage = styled(Space).attrs({
   as: 'p',
   $v: { size: 'sm', properties: ['margin-top'] },
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })``;
 
 const Loading = () => (

--- a/content/webapp/views/pages/works/work/IIIFViewer/ToolbarSegmentedControl.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ToolbarSegmentedControl.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, SyntheticEvent } from 'react';
 import styled from 'styled-components';
 
 import { IconSvg } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -32,7 +32,7 @@ const Button = styled.button.attrs({
 
 const ButtonInner = styled(Space).attrs({
   as: 'span',
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $h: { size: '2xs', properties: ['padding-right', 'padding-left'] },
   $v: { size: '2xs', properties: ['padding-top', 'padding-bottom'] },
 })`

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerBottomBar.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { chevron, gridView, maximise, singlePage } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
@@ -115,29 +115,38 @@ const ViewerBottomBar: FunctionComponent = () => {
         <NavigationBar>
           {previousCanvasLink ? (
             <NextLink {...previousCanvasLink} passHref legacyBehavior>
-              <NavButton className={font('sans', -1)}>
+              <NavButton className={typography('body', 'md', 'regular')}>
                 <Icon icon={chevron} rotate={90} />
                 Previous
               </NavButton>
             </NextLink>
           ) : (
-            <NavButton $disabled className={font('sans', -1)}>
+            <NavButton
+              $disabled
+              className={typography('body', 'md', 'regular')}
+            >
               <Icon icon={chevron} rotate={90} />
               Previous
             </NavButton>
           )}
-          <span className={font('sans', -1)} style={{ color: 'white' }}>
+          <span
+            className={typography('body', 'md', 'regular')}
+            style={{ color: 'white' }}
+          >
             {canvas}/{totalCanvases}
           </span>
           {nextCanvasLink ? (
             <NextLink {...nextCanvasLink} passHref legacyBehavior>
-              <NavButton className={font('sans', -1)}>
+              <NavButton className={typography('body', 'md', 'regular')}>
                 Next
                 <Icon icon={chevron} rotate={270} />
               </NavButton>
             </NextLink>
           ) : (
-            <NavButton $disabled className={font('sans', -1)}>
+            <NavButton
+              $disabled
+              className={typography('body', 'md', 'regular')}
+            >
               Next
               <Icon icon={chevron} rotate={270} />
             </NavButton>

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerSidebar.tsx
@@ -11,7 +11,7 @@ import { useAppContext } from '@weco/common/contexts/AppContext';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { arrow, chevron } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import { DataGtmProps, dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import { getCatalogueLicenseData } from '@weco/common/utils/licenses';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
@@ -65,7 +65,7 @@ const Inner = styled(Space).attrs({
 `;
 
 const AccordionInner = styled(Space).attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
 })`
   button {
@@ -134,7 +134,7 @@ const AccordionItem = ({
           aria-controls={toHtmlId(title)}
         >
           <span>
-            <h2 className={font('sans-bold', -1)}>{title}</h2>
+            <h2 className={typography('body', 'md', 'strong')}>{title}</h2>
             <Icon
               icon={chevron}
               iconColor="white"
@@ -225,9 +225,11 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
           <RestrictedItemMessage plural={true} />
         </RestrictedMessage>
       )}
-      <Inner className={font('sans-bold', -1)}>
+      <Inner className={typography('body', 'md', 'strong')}>
         {manifestLabel && (
-          <span className={font('sans', -1)}>{manifestLabel}</span>
+          <span className={typography('body', 'md', 'regular')}>
+            {manifestLabel}
+          </span>
         )}
         <h1>
           <WorkTitle title={work.title} />
@@ -256,7 +258,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
         <Space $v={{ size: 'sm', properties: ['margin-top'] }}>
           <WorkLink
             id={work.id}
-            className={font('sans', -1)}
+            className={typography('body', 'md', 'regular')}
             style={{ display: 'flex', alignItems: 'center' }}
           >
             Catalogue details
@@ -275,7 +277,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
           title="Licence and re-use"
           gtmData={{ trigger: 'licence_and_re_use' }}
         >
-          <div className={font('sans', -2)}>
+          <div className={typography('body', 'sm', 'regular')}>
             {license && license.label && (
               <p>
                 <strong>Licence:</strong>{' '}

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerStructures.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerStructures.tsx
@@ -3,7 +3,7 @@ import NextLink from 'next/link';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -30,7 +30,7 @@ export const List = styled(PlainList)`
 
 export const Item = styled(Space).attrs({
   as: 'li',
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: '2xs', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
 })<{ $isActive: boolean }>`

--- a/content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.tsx
@@ -12,7 +12,7 @@ import {
   singlePage,
 } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -35,7 +35,7 @@ import { queryParamToArrayIndex } from '.';
 import ToolbarSegmentedControl from './ToolbarSegmentedControl';
 
 export const ViewerButton = styled.button.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })<{ $isDark?: boolean }>`
   line-height: 1.5;
   border-radius: ${props => props.theme.borderRadiusUnit}px;
@@ -178,7 +178,7 @@ const LeftZone = styled.div`
 `;
 
 const MiddleZone = styled.div.attrs({
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
 })`
   display: flex;
   justify-content: center;

--- a/content/webapp/views/pages/works/work/NestedList/index.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/index.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { UiTree } from '@weco/content/views/pages/works/work/work.types';
 
 import { ListProps } from './NestedList.helpers';
@@ -38,7 +38,7 @@ const NestedList: FunctionComponent<NestedListProps> = ({
       }
       tabIndex={level === 1 && isEnhanced ? 0 : undefined}
       role={isEnhanced ? (level === 1 ? 'tree' : 'group') : undefined}
-      className={font('sans', -1)}
+      className={typography('body', 'md', 'regular')}
     >
       {archiveTree &&
         archiveTree.map((item, i) => {

--- a/content/webapp/views/pages/works/work/RelatedWorks/index.tsx
+++ b/content/webapp/views/pages/works/work/RelatedWorks/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { classNames, font } from '@weco/common/utils/classnames';
+import { classNames, typography } from '@weco/common/utils/classnames';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import LL from '@weco/common/views/components/styled/LL';
@@ -118,7 +118,9 @@ const RelatedWorks = ({
   return (
     <SectionWrapper>
       <Container>
-        <h2 className={font('brand-bold', 1)}>More works</h2>
+        <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+          More works
+        </h2>
 
         {Object.keys(relatedWorksTabs).length > 1 && (
           <SelectableTags

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/ItemRequestModal.ConfirmedDialog.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/ItemRequestModal.ConfirmedDialog.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { allowedRequests } from '@weco/common/values/requests';
 import Button from '@weco/common/views/components/Buttons';
 
@@ -19,7 +19,9 @@ const ConfirmedDialog: FunctionComponent<ConfirmedDialogProps> = ({
   return (
     <>
       <Header>
-        <span className={font('brand-bold', 1)}>Request confirmed</span>
+        <span className={typography('heading', 'lg', 'strong', 'brand')}>
+          Request confirmed
+        </span>
         <CurrentRequests
           allowedHoldRequests={allowedRequests}
           currentHoldRequests={currentHoldNumber}

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/ItemRequestModal.ErrorDialog.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/ItemRequestModal.ErrorDialog.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import { useTheme } from 'styled-components';
 
 import { defaultRequestErrorMessage } from '@weco/common/data/microcopy';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 
 import { CTAs, Header } from './ItemRequestModal.styles';
@@ -21,7 +21,9 @@ const ErrorDialog: FunctionComponent<ErrorDialogProps> = ({
   return (
     <>
       <Header>
-        <span className={font('brand-bold', 1)}>Request failed</span>
+        <span className={typography('heading', 'lg', 'strong', 'brand')}>
+          Request failed
+        </span>
       </Header>
       <p style={{ marginBottom: 0 }}>
         {errorMessage || defaultRequestErrorMessage}

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/RequestDialog/index.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/RequestDialog/index.tsx
@@ -2,7 +2,7 @@ import { FormEvent, FunctionComponent, useEffect } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { itemRequestDialog } from '@weco/common/data/microcopy';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatDayMonth, formatDayName } from '@weco/common/utils/format-date';
 import { allowedRequests } from '@weco/common/values/requests';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
@@ -62,7 +62,7 @@ const WorkTitle = styled.span`
 `;
 
 const PickupDeadline = styled.p.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   ${props => props.theme.media('md')`
     margin: 0;
@@ -131,13 +131,18 @@ const RequestDialog: FunctionComponent<RequestDialogProps> = ({
   return (
     <Request onSubmit={handleConfirmRequest}>
       <Header>
-        <span className={font('brand-bold', 1)}>Request item</span>
+        <span className={typography('heading', 'lg', 'strong', 'brand')}>
+          Request item
+        </span>
         <CurrentRequests
           allowedHoldRequests={allowedRequests}
           currentHoldRequests={currentHoldNumber}
         />
       </Header>
-      <p className={font('sans-bold', -1)} style={{ marginBottom: 0 }}>
+      <p
+        className={typography('body', 'md', 'strong')}
+        style={{ marginBottom: 0 }}
+      >
         You are about to request the following item:
       </p>
       <Space $v={{ size: 'xs', properties: ['margin-bottom'] }}>

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
@@ -4,7 +4,7 @@ import styled, { useTheme } from 'styled-components';
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { sierraAccessMethodtoNewLabel } from '@weco/common/data/microcopy';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import StackingTable from '@weco/common/views/components/StackingTable';
 import Space from '@weco/common/views/components/styled/Space';
@@ -55,7 +55,7 @@ const ButtonWrapper = styled.div<ButtonWrapperProps>`
 `;
 
 const DetailHeading = styled.h3.attrs({
-  className: `${font('sans-bold', -1)}`,
+  className: `${typography('body', 'md', 'strong')}`,
 })`
   margin-bottom: 0;
 `;

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -7,7 +7,7 @@ import { bornDigitalMessage } from '@weco/common/data/microcopy';
 import { eye } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { LinkProps } from '@weco/common/model/link-props';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Layout, { gridSize12 } from '@weco/common/views/components/Layout';
@@ -41,7 +41,7 @@ import WorksTree from './WorkDetails.Tree';
 const RestrictedMessage = styled(Space).attrs({
   $v: { size: 'md', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'md', properties: ['padding-left', 'padding-right'] },
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   position: relative;
   border-radius: 3px;
@@ -62,7 +62,7 @@ const RestrictedMessage = styled(Space).attrs({
 `;
 
 const MessageBox = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: { size: 'md', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'md', properties: ['padding-left', 'padding-right'] },
 })`
@@ -172,7 +172,10 @@ const ItemPageLink = ({
               </Space>
             )}
           >
-            <p className={font('mono', -2)} style={{ marginBottom: 0 }}>
+            <p
+              className={typography('caption', 'md', 'regular')}
+              style={{ marginBottom: 0 }}
+            >
               Contains:{' '}
               {(collectionManifestsCount && collectionManifestsCount > 0) ||
               canvasCount
@@ -298,7 +301,7 @@ const WorkDetailsAvailableOnline = ({
         {shouldShowDownloadTree && (
           <>
             {Number(canvases?.length) > 0 && (
-              <p className={font('mono', -2)}>
+              <p className={typography('caption', 'md', 'regular')}>
                 Contains {canvases?.length} files
               </p>
             )}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.tsx
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { file, imageFile } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import {
@@ -27,7 +27,7 @@ import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 import { controlDimensions } from '@weco/content/views/pages/works/work/work.helpers';
 
 export const DownloadTable = styled.table.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })<{ $padFirstHeading?: boolean; $isActive?: boolean }>`
   border-collapse: collapse;
   position: relative;

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Holdings.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Holdings.tsx
@@ -1,4 +1,4 @@
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { Holding } from '@weco/content/services/wellcome/catalogue/types';
 import {
@@ -43,7 +43,10 @@ const WorkDetailsHoldings = ({ holdings }: { holdings: Holding[] }) => {
                 )}
                 <Space $v={{ size: 'xs', properties: ['margin-bottom'] }}>
                   {locationLink && (
-                    <a className={font('sans', -1)} href={locationLink.url}>
+                    <a
+                      className={typography('body', 'md', 'regular')}
+                      href={locationLink.url}
+                    >
                       {locationLink.linkText}
                     </a>
                   )}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.IIIFClickthrough.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.IIIFClickthrough.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import useShowClickthrough from '@weco/content/hooks/useShowClickthrough';
@@ -45,9 +45,9 @@ const IIIFClickthrough: FunctionComponent<Props> = ({
         />
       )}
       {showClickthroughMessage ? (
-        <div className={font('sans', -1)}>
+        <div className={typography('body', 'md', 'regular')}>
           {clickThroughService?.label && (
-            <h2 className={font('sans-bold', 0)}>
+            <h2 className={typography('body', 'lg', 'strong')}>
               {clickThroughService?.label}
             </h2>
           )}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.LibraryMembersBar.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.LibraryMembersBar.tsx
@@ -5,7 +5,7 @@ import { useUserContext } from '@weco/common/contexts/UserContext';
 import { requestingDisabled } from '@weco/common/data/microcopy';
 import { memberCard } from '@weco/common/icons';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useLoginURLWithReturnToCurrent } from '@weco/content/utils/useLoginURLWithReturnToCurrent';
@@ -30,14 +30,14 @@ const SignInLink: FunctionComponent = () => {
     <>
       <Space
         $h={{ size: 'xs', properties: ['margin-right'] }}
-        className={font('sans-bold', -1)}
+        className={typography('body', 'md', 'strong')}
       >
         Library members:
       </Space>
       <a
         href={loginURL}
         data-gtm-trigger="library_account_login"
-        className={font('sans', -1)}
+        className={typography('body', 'md', 'regular')}
       >
         sign in to your library account to request items
       </a>
@@ -51,11 +51,11 @@ type ReloadProps = {
 const Reload: FunctionComponent<ReloadProps> = ({ reload }) => {
   return (
     <>
-      <span className={font('sans-bold', -1)}>
+      <span className={typography('body', 'md', 'strong')}>
         Something went wrong trying to check if you are signed in
       </span>{' '}
       <button
-        className={font('sans', -1)}
+        className={typography('body', 'md', 'regular')}
         onClick={() => {
           reload();
         }}
@@ -83,11 +83,14 @@ const LibraryMembersBar: FunctionComponent = () => {
         </Space>
         <Space
           $h={{ size: 'xs', properties: ['margin-right'] }}
-          className={font('sans-bold', -1)}
+          className={typography('body', 'md', 'strong')}
         >
           Library members:
         </Space>
-        <span data-testid="requesting-disabled" className={font('sans', -1)}>
+        <span
+          data-testid="requesting-disabled"
+          className={typography('body', 'md', 'regular')}
+        >
           {requestingDisabled}
         </span>
       </StyledComponent>

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.OnlineResources.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.OnlineResources.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import { Work } from '@weco/content/services/wellcome/catalogue/types';
 import { getItemsByLocationType } from '@weco/content/utils/works';
@@ -10,7 +10,7 @@ import { getItemsByLocationType } from '@weco/content/utils/works';
 import WorkDetailsSection from './WorkDetails.Section';
 
 const ShowHideButton = styled.button.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })`
   text-decoration: underline;
   padding: 0;
@@ -58,7 +58,10 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
     <WorkDetailsSection headingText="Online resources">
       <PlainList>
         {firstThreeOnlineResources.map(item => (
-          <li className={font('sans', -1)} key={item.location.url}>
+          <li
+            className={typography('body', 'md', 'regular')}
+            key={item.location.url}
+          >
             {item.title && `${item.title}: `}
             <a href={item.location.url}>
               {item.title ? 'View resource' : item.location.linkText}
@@ -68,7 +71,10 @@ const OnlineResources: FunctionComponent<Props> = ({ work }: Props) => {
         {isShowingRemainingOnlineResources && (
           <>
             {remainingOnlineResources.map((item, index) => (
-              <li className={font('sans', -1)} key={item.location.url}>
+              <li
+                className={typography('body', 'md', 'regular')}
+                key={item.location.url}
+              >
                 {item.title && `${item.title}: `}
                 <a
                   href={item.location.url}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Property.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Property.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingComponent from '@weco/common/views/components/styled/SpacingComponent';
@@ -11,14 +11,14 @@ type InlineHeadingProps = {
 };
 
 const Wrapper = styled.div.attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
 })<InlineHeadingProps>`
   ${props => (props.$inlineHeading ? 'display: flex;' : '')}
 `;
 
 const Title = styled(Space).attrs<InlineHeadingProps>(props => ({
   as: 'h3',
-  className: font('sans-bold', -1),
+  className: typography('body', 'md', 'strong'),
   $h: { size: 'xs', properties: props.$inlineHeading ? ['margin-right'] : [] },
 }))<InlineHeadingProps>`
   ${props => (!props.$inlineHeading ? 'margin: 0;' : '')}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Section.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Section.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import SpacingSection from '@weco/common/views/components/styled/SpacingSection';
 import { useIsArchiveContext } from '@weco/content/contexts/IsArchiveContext';
@@ -35,7 +35,9 @@ const WorkDetailsSection: FunctionComponent<Props> = ({
     <SectionWithDivider $isArchive={isArchive}>
       <SpacingSection>
         {headingText && (
-          <h2 className={font('brand-bold', 0)}>{headingText}</h2>
+          <h2 className={typography('heading', 'md', 'strong', 'brand')}>
+            {headingText}
+          </h2>
         )}
 
         {children}

--- a/content/webapp/views/pages/works/work/WorkDetails/index.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/index.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { formatDuration } from '@weco/common/utils/format-date';
 import Button from '@weco/common/views/components/Buttons';
 import {
@@ -428,7 +428,7 @@ const WorkDetails: FunctionComponent<Props> = ({
       )}
 
       <WorkDetailsSection headingText="Permanent link">
-        <div className={font('sans', -1)}>
+        <div className={typography('body', 'md', 'regular')}>
           <CopyButtons
             variant="url"
             url={`https://wellcomecollection.org/works/${work.id}`}

--- a/content/webapp/views/pages/works/work/download.tsx
+++ b/content/webapp/views/pages/works/work/download.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 import { FunctionComponent } from 'react';
 
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import {
   getCatalogueLicenseData,
   LicenseData,
@@ -127,7 +127,7 @@ const WorkDownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
             <Space
               as="h1"
               id="work-info"
-              className={font('sans-bold', 0)}
+              className={typography('body', 'lg', 'strong')}
               $v={{ size: 'md', properties: ['margin-top'] }}
             >
               {displayTitle}

--- a/content/webapp/views/pages/works/work/items.tsx
+++ b/content/webapp/views/pages/works/work/items.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
 import { DigitalLocation } from '@weco/common/model/catalogue';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { ApiToolbarLink } from '@weco/common/views/components/ApiToolbar';
 import Button from '@weco/common/views/components/Buttons';
 import Modal from '@weco/common/views/components/Modal';
@@ -200,12 +200,14 @@ const WorkItemPage: NextPage<Props> = ({
         removeCloseButton={true}
         openButtonRef={{ current: null }}
       >
-        <div className={font('sans', -1)}>
+        <div className={typography('body', 'md', 'regular')}>
           {modalContent?.label && (
             // When this modal is displayed, the rest of the page is hidden and we need to make
             // sure there is an appropriate h1 available to assistive technologies
             // https://github.com/wellcomecollection/wellcomecollection.org/issues/7545
-            <h1 className={font('sans-bold', 0)}>{modalContent?.label}</h1>
+            <h1 className={typography('body', 'lg', 'strong')}>
+              {modalContent?.label}
+            </h1>
           )}
           {modalContent?.description && (
             <div

--- a/content/webapp/views/pages/works/work/work.BackToResults.tsx
+++ b/content/webapp/views/pages/works/work/work.BackToResults.tsx
@@ -2,7 +2,7 @@ import NextLink from 'next/link';
 import { FunctionComponent } from 'react';
 
 import { useSearchContext } from '@weco/common/contexts/SearchContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 
 const BackToResults: FunctionComponent = () => {
   const { link } = useSearchContext();
@@ -14,7 +14,7 @@ const BackToResults: FunctionComponent = () => {
     <NextLink
       {...link}
       data-gtm-trigger="back_to_search_results"
-      className={font('sans', -1)}
+      className={typography('body', 'md', 'regular')}
     >
       <span>Back to search results</span>
     </NextLink>

--- a/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { chevron, closedFolder, openFolder } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import { controlDimensions } from '@weco/content/views/pages/works/work/work.helpers';
@@ -12,7 +12,7 @@ import DownloadItem from '@weco/content/views/pages/works/work/WorkDetails/WorkD
 import { TreeControl } from './NestedList';
 
 const ItemWrapper = styled.div.attrs({
-  className: font('sans', -2),
+  className: typography('body', 'sm', 'regular'),
 })`
   display: flex;
   height: ${controlDimensions.controlHeight}px;

--- a/content/webapp/views/pages/works/work/work.Header.tsx
+++ b/content/webapp/views/pages/works/work/work.Header.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider';
 import LabelsList from '@weco/common/views/components/LabelsList';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
@@ -12,7 +12,9 @@ import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
 import LinkLabels from '@weco/content/views/components/LinkLabels';
 import Number from '@weco/content/views/components/Number';
 import WorkTitle from '@weco/content/views/components/WorkTitle';
-const WorkTitleWrapper = styled.h1.attrs({ className: font('sans-bold', 2) })`
+const WorkTitleWrapper = styled.h1.attrs({
+  className: typography('heading', 'xl', 'strong', 'sans'),
+})`
   margin: 0;
   display: inline-block;
 `;
@@ -102,7 +104,7 @@ const WorkHeader: FunctionComponent<Props> = ({
               ) && (
                 <Space $v={{ size: 'sm', properties: ['margin-top'] }}>
                   <p
-                    className={font('sans-bold', -1)}
+                    className={typography('body', 'md', 'strong')}
                     style={{ marginBottom: 0 }}
                   >
                     <Number

--- a/content/webapp/views/pages/works/work/work.RestrictedItemMessage.tsx
+++ b/content/webapp/views/pages/works/work/work.RestrictedItemMessage.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { info2 } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 
 const Title = styled.div`
@@ -33,12 +33,12 @@ const RestrictedItemMessage: FunctionComponent<Props> = ({
     <>
       <Title>
         <Icon icon={info2} />
-        <Heading className={font('sans-bold', -1)}>
+        <Heading className={typography('body', 'md', 'strong')}>
           {plural ? 'Contains restricted ' : 'Restricted '}{' '}
           {`item${plural ? 's' : ''}`}
         </Heading>
       </Title>
-      <p className={font('sans', -1)}>
+      <p className={typography('body', 'md', 'regular')}>
         Only staff with the right permissions can view{' '}
         {`${plural ? 'restricted items' : 'this item'}`} online.
       </p>

--- a/content/webapp/views/pages/works/work/work.StoriesOnWorks.tsx
+++ b/content/webapp/views/pages/works/work/work.StoriesOnWorks.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Divider from '@weco/common/views/components/Divider';
 import { Container } from '@weco/common/views/components/styled/Container';
 import LL from '@weco/common/views/components/styled/LL';
@@ -85,7 +85,9 @@ const WorkStoriesOnWorks: FunctionComponent<Props> = ({
     <SectionWrapper>
       <Container>
         <Space $v={{ size: 'md', properties: ['padding-top'] }}>
-          <h2 className={font('brand-bold', 1)}>Stories featuring this work</h2>
+          <h2 className={typography('heading', 'lg', 'strong', 'brand')}>
+            Stories featuring this work
+          </h2>
         </Space>
 
         <Space $v={{ size: 'sm', properties: ['padding-top'] }}>

--- a/identity/webapp/views/components/PasswordRules/index.tsx
+++ b/identity/webapp/views/components/PasswordRules/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { check } from '@weco/common/icons';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import PlainList from '@weco/common/views/components/styled/PlainList';
 import Space from '@weco/common/views/components/styled/Space';
@@ -16,7 +16,7 @@ const RulesListItem = styled(Space).attrs({
 `;
 
 const RulesListWrapper = styled(Space).attrs({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $h: { size: 'sm', properties: ['padding-left', 'padding-right'] },
   $v: { size: 'sm', properties: ['padding-top', 'padding-bottom'] },
 })`

--- a/identity/webapp/views/components/styled/Layouts.ts
+++ b/identity/webapp/views/components/styled/Layouts.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const Container = styled(Space).attrs({
@@ -14,7 +14,7 @@ export const Container = styled(Space).attrs({
 export const Wrapper = styled(Space).attrs<{
   $removeBottomPadding?: boolean;
 }>(props => ({
-  className: font('sans', -1),
+  className: typography('body', 'md', 'regular'),
   $v: {
     size: 'md',
     properties: props.$removeBottomPadding
@@ -34,7 +34,7 @@ type SectionHeadingProps = {
 export const SectionHeading = styled(Space).attrs<SectionHeadingProps>(
   props => ({
     as: props.as || 'h2',
-    className: font('brand-bold', 1),
+    className: typography('heading', 'lg', 'strong', 'brand'),
     $v: {
       size: 'sm',
       properties: props.$addBottomPadding ? ['padding-bottom'] : [],

--- a/identity/webapp/views/components/styled/Modal.ts
+++ b/identity/webapp/views/components/styled/Modal.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 
 export const ModalContainer = styled.aside`
@@ -11,6 +11,6 @@ export const ModalContainer = styled.aside`
 
 export const ModalTitle = styled(Space).attrs({
   as: 'h2',
-  className: font('brand-bold', 1),
+  className: typography('heading', 'lg', 'strong', 'brand'),
   $v: { size: 'md', properties: ['margin-bottom'] },
 })``;

--- a/identity/webapp/views/pages/index.ChangeEmail.tsx
+++ b/identity/webapp/views/pages/index.ChangeEmail.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { useUserContext } from '@weco/common/contexts/UserContext';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import Space from '@weco/common/views/components/styled/Space';
 import TextInput, {
@@ -100,10 +100,16 @@ const ChangeEmail: FunctionComponent<ChangeDetailsModalContentProps> = ({
       )}
 
       <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-        <h3 className={font('sans-bold', -1)} style={{ marginBottom: 0 }}>
+        <h3
+          className={typography('body', 'md', 'strong')}
+          style={{ marginBottom: 0 }}
+        >
           Email
         </h3>
-        <p className={font('sans', -1)} style={{ marginBottom: 0 }}>
+        <p
+          className={typography('body', 'md', 'regular')}
+          style={{ marginBottom: 0 }}
+        >
           {user?.email}
         </p>
       </Space>

--- a/identity/webapp/views/pages/index.DeleteAccount.tsx
+++ b/identity/webapp/views/pages/index.DeleteAccount.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import styled, { useTheme } from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import { InputErrorMessage } from '@weco/common/views/components/TextInput';
 import {
@@ -97,7 +97,7 @@ const DeleteAccount: FunctionComponent<ChangeDetailsModalContentProps> = ({
       {submissionErrorMessage && (
         <StatusAlert type="failure">{submissionErrorMessage}</StatusAlert>
       )}
-      <div className={font('sans', -1)}>
+      <div className={typography('body', 'md', 'regular')}>
         <p>
           Are you sure you want to delete your account? Your account will be
           closed and you won’t be able to request any items.

--- a/identity/webapp/views/pages/index.tsx
+++ b/identity/webapp/views/pages/index.tsx
@@ -16,7 +16,7 @@ import {
   Auth0UserProfile,
   auth0UserProfileToUserInfo,
 } from '@weco/common/model/user';
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import { allowedRequests } from '@weco/common/values/requests';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
 import HTMLDateAndTime from '@weco/common/views/components/HTMLDateAndTime';
@@ -68,8 +68,10 @@ const DetailList: FunctionComponent<{
     <StyledDl>
       {listItems.map(item => (
         <Fragment key={item.label}>
-          <dt className={font('sans-bold', -1)}>{item.label}</dt>
-          <StyledDd className={font('sans', -1)}>{item.value}</StyledDd>
+          <dt className={typography('body', 'md', 'strong')}>{item.label}</dt>
+          <StyledDd className={typography('body', 'md', 'regular')}>
+            {item.value}
+          </StyledDd>
         </Fragment>
       ))}
     </StyledDl>
@@ -79,10 +81,10 @@ const DetailList: FunctionComponent<{
 const RequestsFailed: FunctionComponent<{ retry: () => void }> = ({
   retry,
 }) => (
-  <p className={font('sans', -1)}>
+  <p className={typography('body', 'md', 'regular')}>
     Something went wrong fetching your item requests.
     <button
-      className={font('sans', -1)}
+      className={typography('body', 'md', 'regular')}
       style={{
         border: 'none',
         background: 'none',
@@ -113,7 +115,7 @@ const AccountStatus: FunctionComponent<PropsWithChildren<StatusAlertProps>> = ({
 const NoRequestedItems = () => (
   <Space
     as="p"
-    className={font('sans', -1)}
+    className={typography('body', 'md', 'regular')}
     $v={{
       size: 'xs',
       properties: ['margin-bottom'],
@@ -174,7 +176,9 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
           <Space
             $v={{ size: 'md', properties: ['padding-top', 'padding-bottom'] }}
           >
-            <h1 className={font('brand-bold', 5)}>Library account</h1>
+            <h1 className={typography('display', 'md', 'strong')}>
+              Library account
+            </h1>
           </Space>
         </ContaineredLayout>
         <div className="is-hidden-s">
@@ -253,7 +257,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                             <>
                               <Space
                                 as="p"
-                                className={font('sans-bold', -1)}
+                                className={typography('body', 'md', 'strong')}
                                 $v={{
                                   size: 'xs',
                                   properties: ['margin-bottom'],
@@ -324,7 +328,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
                                 ]}
                               />
                               <Space
-                                className={font('sans', -1)}
+                                className={typography('body', 'md', 'regular')}
                                 $v={{
                                   size: 'md',
                                   properties: ['margin-top'],
@@ -353,7 +357,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
           </SectionHeading>
           <Container>
             <Wrapper>
-              <p className={font('sans', -1)}>
+              <p className={typography('body', 'md', 'regular')}>
                 If you no longer wish to be a library member, you can cancel
                 your membership. The library team will be notified and your
                 online account will be closed.

--- a/identity/webapp/views/pages/registration/index.tsx
+++ b/identity/webapp/views/pages/registration/index.tsx
@@ -4,7 +4,7 @@ import { FormEvent, FunctionComponent } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import styled from 'styled-components';
 
-import { font } from '@weco/common/utils/classnames';
+import { typography } from '@weco/common/utils/classnames';
 import Button, { ButtonTypes } from '@weco/common/views/components/Buttons';
 import CheckboxRadio from '@weco/common/views/components/CheckboxRadio';
 import Divider from '@weco/common/views/components/Divider';
@@ -40,10 +40,10 @@ const RegistrationInformation: FunctionComponent<{
     <>
       <SectionHeading as="h1">Apply for a library membership</SectionHeading>
 
-      <h2 className={font('sans-bold', 0)}>Your details</h2>
+      <h2 className={typography('body', 'lg', 'strong')}>Your details</h2>
       <p style={{ marginBottom: 0 }}>
         Email address:{' '}
-        <strong className={font('sans-bold', -1)}>{email}</strong>
+        <strong className={typography('body', 'md', 'strong')}>{email}</strong>
       </p>
       <Space $v={{ size: 'sm', properties: ['margin-top', 'margin-bottom'] }}>
         <Divider />
@@ -157,7 +157,7 @@ const RegistrationPage: NextPage<Props> = ({
                     </SpacingComponent>
 
                     <SpacingComponent>
-                      <h3 className={font('sans-bold', -1)}>
+                      <h3 className={typography('body', 'md', 'strong')}>
                         Collections research agreement
                       </h3>
                       <Controller

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-preset-react": "^6.24.1",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-import-x": "^4.17.0",
     "eslint-plugin-jest": "^29.15.0",
     "eslint-plugin-jest-playwright": "^0.9.0",
     "eslint-plugin-local-rules": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-preset-react": "^6.24.1",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-import-x": "^4.17.0",
+    "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.15.0",
     "eslint-plugin-jest-playwright": "^0.9.0",
     "eslint-plugin-local-rules": "^3.0.2",

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -151,14 +151,6 @@ const toggleConfig = {
       description: 'Allows testing of vertical videos.',
       type: 'experimental',
     },
-    {
-      id: 'compositeTypography',
-      title: 'Composite typography',
-      initialValue: false,
-      description:
-        'Uses the composite typography classes (.type-{x}) instead of the font classes (.font-{x}).',
-      type: 'experimental',
-    },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth


### PR DESCRIPTION
- For #12482

## What does this change?

Replaces all `font()` calls with `typography()` and remove the interim dual-class system.

We have verified that the composite typography classes (`.type-*`) produce the correct output, so we can now commit fully to that system. This PR:

- Replaces every call to `font(family, size)` with the equivalent `typography(category, size, weight[, family])` call, using the `fontCompositeMap` as the source of truth for the mapping (454 call sites across 218 files)
- Removes the `font`, `fontSize`, `fontFamily`, `FontFamily`, `FontSize`, and `fontCompositeMap` exports from `classnames.ts`
- Removes `makeFontSizeClasses` from `typography.ts` — the function that generated `.font-size-f*` class definitions that are no longer applied to any element
- Removes the `compositeTypography` feature flag and all conditional logic around it in `GlobalStyle`, making `makeTypographyClasses()` unconditional

## How to test

The best I can suggest is opening www-dev and prod side-by-side and clicking around

## Have we considered potential risks?

Lorra lorra file changes. But Firebreak week is a good time to do it. And since we've done the QA with a toggle, we can trust the changes, so if the tests pass it should be all good.

We're still using `body` everywhere even where it could be `label`, but we can change this later when we have clarified where to use which for sure.
