### PR TITLE
Dark mode that nobody was asking for

### DIFF
--- a/common/icons/wellcome_collection_black.tsx
+++ b/common/icons/wellcome_collection_black.tsx
@@ -1,7 +1,14 @@
 import { FunctionComponent } from 'react';
+import styled from 'styled-components';
+
+const Svg = styled.svg`
+  @media (prefers-color-scheme: dark) {
+    filter: invert(1);
+  }
+`;
 
 const WellcomeCollectionBlack: FunctionComponent = () => (
-  <svg
+  <Svg
     width="128"
     height="42"
     xmlns="http://www.w3.org/2000/svg"
@@ -21,7 +28,7 @@ const WellcomeCollectionBlack: FunctionComponent = () => (
       width="128"
       height="42"
     />
-  </svg>
+  </Svg>
 );
 
 export default WellcomeCollectionBlack;

--- a/common/views/components/CivicUK/index.tsx
+++ b/common/views/components/CivicUK/index.tsx
@@ -4,6 +4,7 @@ import { useTheme } from 'styled-components';
 import cookies from '@weco/common/data/cookies';
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import { typography } from '@weco/common/utils/classnames';
+import { colors } from '@weco/common/views/themes/config';
 
 const headingStyles =
   'style="font-weight: 500; font-family: Inter, sans-serif;"';
@@ -58,20 +59,23 @@ const CivicUK = ({ apiKey, defer }: { apiKey: string; defer?: boolean }) => {
   style="display: block; margin: ${theme.spacingUnits['150']} 0;"
 `;
 
+  // Civic UK's branding values are passed to a third-party JS API and applied
+  // as inline styles. CSS custom properties (var(--color-...)) are not
+  // resolved in that context, so we use raw hex values here instead.
   const branding = {
     removeIcon: true,
     removeAbout: true,
     fontFamily: 'Inter, sans-serif',
     fontSize: '0.9375rem',
     fontSizeHeaders: '1.175rem',
-    fontColor: theme.color('black'),
-    backgroundColor: theme.color('warmNeutral.200'),
-    acceptText: theme.color('black'),
-    acceptBackground: theme.color('yellow'),
-    rejectText: theme.color('black'),
+    fontColor: colors.black,
+    backgroundColor: colors['warmNeutral.200'],
+    acceptText: colors.black,
+    acceptBackground: colors.yellow,
+    rejectText: colors.black,
     toggleColor: '#0055cc',
-    toggleBackground: theme.color('neutral.300'),
-    toggleText: theme.color('black'),
+    toggleBackground: colors['neutral.300'],
+    toggleText: colors.black,
   };
 
   const text = {

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -192,7 +192,7 @@ const Footer: FunctionComponent<Props> = ({
   const hasVenuesInfo = Array.isArray(venues) && venues.length > 0;
 
   return (
-    <Wrapper ref={footer} data-component="footer">
+    <Wrapper ref={footer} data-component="footer" data-color-scheme="light">
       <Container>
         {isSimpleFooter ? (
           <SimpleFooterLogoHeading>

--- a/common/views/components/HeaderBackground/index.tsx
+++ b/common/views/components/HeaderBackground/index.tsx
@@ -20,12 +20,24 @@ const Background = styled.div<{ $texture: string | null }>`
   width: 100%;
   overflow: hidden;
   z-index: -1;
+  isolation: isolate;
 
   background-color: ${props => props.theme.color('warmNeutral.300')};
+
   ${props =>
     props.$texture &&
-    `background-image: url(${props.$texture});
-      background-size: cover;`};
+    `&::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      background-image: url(${props.$texture});
+      background-size: cover;
+
+      @media (prefers-color-scheme: dark) {
+        filter: invert(1);
+      }
+    }`};
 `;
 
 const WobblyEdgeContainer = styled.div`

--- a/common/views/components/InfoBanner/InfoBanner.Default.tsx
+++ b/common/views/components/InfoBanner/InfoBanner.Default.tsx
@@ -70,7 +70,7 @@ const InfoBannerDefault: FunctionComponent<Props> = ({
 
   return (
     <BannerContainer role="region" aria-labelledby="note" id="notification">
-      <BannerWrapper>
+      <BannerWrapper data-color-scheme="light">
         <CopyContainer>
           <Space
             $h={{ size: 'sm', properties: ['margin-right'] }}

--- a/common/views/components/LabelsList/LabelsList.Label.tsx
+++ b/common/views/components/LabelsList/LabelsList.Label.tsx
@@ -12,6 +12,7 @@ type LabelContainerProps = {
 };
 
 const LabelContainer = styled(Space).attrs({
+  'data-color-scheme': 'light',
   className: font('sans-bold', -2),
 })<LabelContainerProps>`
   white-space: nowrap;

--- a/common/views/components/PageHeader/PageHeader.styles.tsx
+++ b/common/views/components/PageHeader/PageHeader.styles.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
@@ -6,12 +6,24 @@ import { PaletteColor } from '@weco/common/views/themes/config';
 
 export const Container = styled.div<{ $backgroundTexture?: string }>`
   position: relative;
-  background-image: ${props =>
-    props.$backgroundTexture
-      ? `url(${props.$backgroundTexture})`
-      : 'undefined'};
-  background-size: ${props =>
-    props.$backgroundTexture ? 'cover' : 'undefined'};
+  isolation: isolate;
+
+  ${props =>
+    props.$backgroundTexture &&
+    css`
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        background-image: url(${props.$backgroundTexture});
+        background-size: cover;
+
+        @media (prefers-color-scheme: dark) {
+          filter: invert(1);
+        }
+      }
+    `}
 `;
 
 export const Wrapper = styled(Space)`

--- a/common/views/components/ThemeCard/index.tsx
+++ b/common/views/components/ThemeCard/index.tsx
@@ -147,7 +147,7 @@ const ThemeCard: FunctionComponent<ThemeCardProps> = ({
       {...linkProps}
       {...dataGtmPropsToAttributes(dataGtmProps)}
     >
-      <CardWrapper data-component="theme-promo">
+      <CardWrapper data-component="theme-promo" data-color-scheme="light">
         <CompositeGrid $isSingleImage={isSingleImage}>
           {slots.map((slot, index) => (
             <ImageContainer key={index}>

--- a/common/views/themes/base/row.ts
+++ b/common/views/themes/base/row.ts
@@ -1,5 +1,10 @@
 import { css } from 'styled-components';
 
+const wobblyBgUrl = (fill: string) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 100"><path fill="${fill}" d="M0,1l142.8,58.2c0,0,74.6-35.7,167-44.5c0,0,201.1,42.9,261.9,68.2S882.9,15,882.9,15L1000,1H0z"/></svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
+};
+
 export const row = css`
   .row--has-wobbly-background {
     position: relative;
@@ -24,8 +29,12 @@ export const row = css`
       right: 0;
       content: '';
       margin-top: -5px;
-      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTAwMCAxMDAiPjxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik0wLDFsMTQyLjgsNTguMmMwLDAsNzQuNi0zNS43LDE2Ny00NC41YzAsMCwyMDEuMSw0Mi45LDI2MS45LDY4LjJTODgyLjksMTUsODgyLjksMTVMMTAwMCwxSDB6Ii8+PC9zdmc+');
+      background-image: ${wobblyBgUrl('#ffffff')};
       background-size: cover;
+
+      @media (prefers-color-scheme: dark) {
+        background-image: ${wobblyBgUrl('#121212')};
+      }
     }
   }
 `;

--- a/common/views/themes/base/wellcome-normalize.ts
+++ b/common/views/themes/base/wellcome-normalize.ts
@@ -6,6 +6,17 @@ export const focusStyle = css`
 `;
 
 export const wellcomeNormalize = css`
+  :root {
+    /* Tells the browser to adapt scrollbars, form controls, and the UA canvas
+       to the OS colour scheme. Without this, native controls stay light in dark mode. */
+    color-scheme: light dark;
+  }
+
+  html,
+  body {
+    background-color: ${props => props.theme.color('white')};
+  }
+
   input,
   button {
     border-radius: 0;

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -24,7 +24,7 @@ export type ColumnKey =
   | 'shiftXl';
 
 // suggested new colors
-const colors = {
+export const colors = {
   // Core
   // Wrap in core? Looks better for lightYellow but worse for the others...
   white: '#ffffff',

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -66,12 +66,19 @@ const colors = {
   'focus.yellow': '#ffea00',
 };
 
+const colorKeyToVarName = (key: string): string =>
+  '--color-' + key.replace(/\./g, '-');
+
+export const colorCustomProperties = `:root {\n${Object.entries(colors)
+  .map(([key, value]) => `  ${colorKeyToVarName(key)}: ${value};`)
+  .join('\n')}\n}`;
+
 const getColor = (name: PaletteColor): string => {
   // In some cases, these get passed in, see ButtonColors for example.
   // But better not to use it if possible.
   if (['currentColor', 'transparent', 'inherit'].includes(name)) return name;
 
-  return colors[name];
+  return `var(${colorKeyToVarName(name)})`;
 };
 
 export const sizes = {
@@ -349,7 +356,7 @@ export const themeValues = {
   sizes,
   gutter,
   basicBoxShadow: `0 2px 8px 0 rgb(18, 18, 18, 0.4)`,
-  focusBoxShadow: `0 0 0 3px ${colors['focus.yellow']}`,
+  focusBoxShadow: `0 0 0 3px var(--color-focus-yellow)`,
   keyframes: {
     hoverBounce: keyframes`
       0% {

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -73,6 +73,55 @@ export const colorCustomProperties = `:root {\n${Object.entries(colors)
   .map(([key, value]) => `  ${colorKeyToVarName(key)}: ${value};`)
   .join('\n')}\n}`;
 
+// Starting-point dark mode palette — values here need design review.
+// The neutrals mirror the lightness scale in reverse; accents are lightly
+// adjusted for contrast on dark surfaces; core black/white swap.
+const darkModeColors: typeof colors = {
+  // Core
+  white: '#121212',
+  black: '#ffffff',
+  yellow: '#ffce3c',
+  lightYellow: '#3d2e00',
+
+  // Accents — regular variants slightly lightened; light variants become dark surfaces
+  'accent.purple': '#9b71b8',
+  'accent.lightPurple': '#2d1e3d',
+  'accent.turquoise': '#23d4d0',
+  'accent.lightTurquoise': '#0d2e2e',
+  'accent.blue': '#6b9fd4',
+  'accent.lightBlue': '#0d1e2e',
+  'accent.green': '#6aaa8d',
+  'accent.lightGreen': '#1a2e24',
+  'accent.salmon': '#ff8a73',
+  'accent.lightSalmon': '#3d1a10',
+
+  // Neutrals — lightness scale mirrored (97→10, 91→15, 85→22, 56≈56, 42→62, 20→85)
+  'neutral.200': '#1a1a1a',
+  'neutral.300': '#262626',
+  'neutral.400': '#383838',
+  'neutral.500': '#8f8f8f',
+  'neutral.600': '#a0a0a0',
+  'neutral.700': '#d9d9d9',
+
+  // Warm neutrals — dark surfaces with a warm yellow tint
+  'warmNeutral.200': '#1a1900',
+  'warmNeutral.300': '#262510',
+  'warmNeutral.400': '#353420',
+
+  // Validation — lightened for sufficient contrast on dark backgrounds
+  'validation.red': '#ff6b6b',
+  'validation.green': '#4caf87',
+
+  // Focus — unchanged; must remain high contrast in all modes
+  'focus.yellow': '#ffea00',
+};
+
+export const darkModeColorCustomProperties = `@media (prefers-color-scheme: dark) {\n  :root {\n${Object.entries(
+  darkModeColors
+)
+  .map(([key, value]) => `    ${colorKeyToVarName(key)}: ${value};`)
+  .join('\n')}\n  }\n}`;
+
 const getColor = (name: PaletteColor): string => {
   // In some cases, these get passed in, see ButtonColors for example.
   // But better not to use it if possible.

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -69,10 +69,6 @@ const colors = {
 const colorKeyToVarName = (key: string): string =>
   '--color-' + key.replace(/\./g, '-');
 
-export const colorCustomProperties = `:root {\n${Object.entries(colors)
-  .map(([key, value]) => `  ${colorKeyToVarName(key)}: ${value};`)
-  .join('\n')}\n}`;
-
 // Starting-point dark mode palette — values here need design review.
 // The neutrals mirror the lightness scale in reverse; accents are lightly
 // adjusted for contrast on dark surfaces; core black/white swap.
@@ -116,11 +112,23 @@ const darkModeColors: typeof colors = {
   'focus.yellow': '#ffea00',
 };
 
-export const darkModeColorCustomProperties = `@media (prefers-color-scheme: dark) {\n  :root {\n${Object.entries(
-  darkModeColors
-)
-  .map(([key, value]) => `    ${colorKeyToVarName(key)}: ${value};`)
-  .join('\n')}\n  }\n}`;
+// light-dark() is resolved at used-value time per element, so changing
+// color-scheme on a subtree root switches which branch is applied there —
+// without needing to redeclare any variable values.
+export const colorCustomProperties = `:root {\n${Object.entries(colors)
+  .map(([key, value]) => {
+    const dark = darkModeColors[key as keyof typeof colors];
+    return `  ${colorKeyToVarName(key)}: light-dark(${value}, ${dark});`;
+  })
+  .join('\n')}\n}`;
+
+// Escape hatch for components that must keep their light-mode appearance
+// regardless of OS colour scheme (e.g. the footer's intentionally dark band).
+// Apply data-color-scheme="light" to the component's root element.
+// light-dark() within that subtree will resolve to its light branch.
+// :where() gives this zero specificity so any component's own color declaration
+// always wins, regardless of stylesheet injection order.
+export const pinnedLightModeColorCustomProperties = `:where([data-color-scheme="light"]) {\n  color-scheme: light;\n  color: var(--color-black);\n}`;
 
 const getColor = (name: PaletteColor): string => {
   // In some cases, these get passed in, see ButtonColors for example.

--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -138,6 +138,12 @@ const getColor = (name: PaletteColor): string => {
   return `var(${colorKeyToVarName(name)})`;
 };
 
+const getColorWithAlpha = (name: PaletteColor, alpha: number): string => {
+  if (['currentColor', 'transparent', 'inherit'].includes(name)) return name;
+  const percent = Math.round(alpha * 100);
+  return `color-mix(in srgb, var(${colorKeyToVarName(name)}) ${percent}%, transparent)`;
+};
+
 export const sizes = {
   zero: '0rem',
   sm: designSystemTheme.breakpoints.sm, // 48rem = 768px
@@ -438,6 +444,7 @@ export const themeValues = {
   fontVerticalOffset: '0.15em',
   colors,
   color: getColor,
+  colorWithAlpha: getColorWithAlpha,
   minCardHeight: 385,
   media,
   mediaBetween,

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -5,7 +5,7 @@ import { layout } from './base/layout';
 import { normalize } from './base/normalize';
 import { row } from './base/row';
 import { wellcomeNormalize } from './base/wellcome-normalize';
-import { Size, themeValues } from './config';
+import { colorCustomProperties, Size, themeValues } from './config';
 import {
   makeCompositeTypographyClasses,
   makeFontSizeClasses,
@@ -48,6 +48,7 @@ const cls = {
 } as unknown as Classes & SizedClasses;
 
 const GlobalStyle = createGlobalStyle<{ $compositeTypography: boolean }>`
+  ${colorCustomProperties}
   ${css`
     .${cls.displayBlock} {
       display: block;

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -7,7 +7,7 @@ import { row } from './base/row';
 import { wellcomeNormalize } from './base/wellcome-normalize';
 import {
   colorCustomProperties,
-  darkModeColorCustomProperties,
+  pinnedLightModeColorCustomProperties,
   Size,
   themeValues,
 } from './config';
@@ -54,7 +54,7 @@ const cls = {
 
 const GlobalStyle = createGlobalStyle<{ $compositeTypography: boolean }>`
   ${colorCustomProperties}
-  ${darkModeColorCustomProperties}
+  ${pinnedLightModeColorCustomProperties}
   ${css`
     .${cls.displayBlock} {
       display: block;

--- a/common/views/themes/default.ts
+++ b/common/views/themes/default.ts
@@ -5,7 +5,12 @@ import { layout } from './base/layout';
 import { normalize } from './base/normalize';
 import { row } from './base/row';
 import { wellcomeNormalize } from './base/wellcome-normalize';
-import { colorCustomProperties, Size, themeValues } from './config';
+import {
+  colorCustomProperties,
+  darkModeColorCustomProperties,
+  Size,
+  themeValues,
+} from './config';
 import {
   makeCompositeTypographyClasses,
   makeFontSizeClasses,
@@ -49,6 +54,7 @@ const cls = {
 
 const GlobalStyle = createGlobalStyle<{ $compositeTypography: boolean }>`
   ${colorCustomProperties}
+  ${darkModeColorCustomProperties}
   ${css`
     .${cls.displayBlock} {
       display: block;

--- a/common/views/themes/typography.ts
+++ b/common/views/themes/typography.ts
@@ -161,7 +161,8 @@ export const typography = css`
     }
 
     *::selection {
-      background: ${props => props.theme.color('accent.turquoise')}4d;
+      background: ${props =>
+        props.theme.colorWithAlpha('accent.turquoise', 0.3)};
     }
 
     /* stylelint-disable no-descending-specificity */

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -310,7 +310,7 @@ const Body: FunctionComponent<Props> = ({
       condition={isTwoColumns}
       wrapper={children => (
         <Container>
-          <Grid style={{ background: 'white', rowGap: 0 }}>
+          <Grid style={{ background: 'var(--color-white)', rowGap: 0 }}>
             <InPageNavigation
               links={onThisPage!}
               sizeMap={{ s: [12], m: [12], l: [3], xl: [3] }}

--- a/content/webapp/views/components/ImageGallery/ImageGallery.styles.tsx
+++ b/content/webapp/views/components/ImageGallery/ImageGallery.styles.tsx
@@ -169,12 +169,14 @@ export const StandaloneWobblyEdge = styled.div`
   top: 0;
   width: 100%;
   z-index: 2;
+  color-scheme: light dark;
 `;
 
 export const DecorativeEdgeWrapper = styled.div`
   position: absolute;
   bottom: -2px;
   width: 100%;
+  color-scheme: light dark;
 `;
 
 type ButtonContainerProps = { $isHidden: boolean };

--- a/content/webapp/views/components/ImageGallery/index.tsx
+++ b/content/webapp/views/components/ImageGallery/index.tsx
@@ -129,7 +129,7 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
   };
 
   return (
-    <div data-component="image-gallery">
+    <div data-component="image-gallery" data-color-scheme="light">
       {!isStandalone && !isFrames && (
         <ContaineredLayout gridSizes={gridSize8()}>
           <GalleryTitle>

--- a/content/webapp/views/components/InPageNavigation/index.tsx
+++ b/content/webapp/views/components/InPageNavigation/index.tsx
@@ -196,6 +196,7 @@ const InPageNavigation: FunctionComponent<Props> = ({
       ref={navGridCellRef}
       $isOnWhite={!!isOnWhite}
       $sizeMap={sizeMap}
+      data-color-scheme="light"
     >
       {shouldLockScroll && (
         <>

--- a/content/webapp/views/components/InPageNavigation/index.tsx
+++ b/content/webapp/views/components/InPageNavigation/index.tsx
@@ -57,6 +57,7 @@ const InPageNavigation: FunctionComponent<Props> = ({
   const loadedWithHashRef = useRef(
     typeof window !== 'undefined' && !!window.location.hash
   );
+  const [isDarkMobileNav, setIsDarkMobileNav] = useState(false);
 
   const shouldLockScroll = windowSize !== 'md' && isListActive && hasStuck;
 
@@ -114,6 +115,10 @@ const InPageNavigation: FunctionComponent<Props> = ({
     }
     prevHasStuckRef.current = hasStuck;
   }, [hasStuck, isListActive, clickedId, windowSize]);
+
+  useEffect(() => {
+    setIsDarkMobileNav(windowSize === 'sm' && hasStuck);
+  }, [hasStuck, windowSize]);
 
   useEffect(() => {
     // We close the mobile nav if the user resizes their window to the large bp
@@ -196,7 +201,7 @@ const InPageNavigation: FunctionComponent<Props> = ({
       ref={navGridCellRef}
       $isOnWhite={!!isOnWhite}
       $sizeMap={sizeMap}
-      data-color-scheme="light"
+      data-color-scheme={!isDarkMobileNav ? 'light' : ''}
     >
       {shouldLockScroll && (
         <>

--- a/content/webapp/views/components/InfoBox/index.tsx
+++ b/content/webapp/views/components/InfoBox/index.tsx
@@ -18,9 +18,10 @@ type Props = PropsWithChildren<{
   hasBiggerHeading?: boolean;
 }>;
 
-const InfoContainer = styled(Space).attrs({
+const InfoContainer = styled(Space).attrs<{ 'data-color-scheme': 'light' }>({
   $v: { size: 'md', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'md', properties: ['padding-left', 'padding-right'] },
+  'data-color-scheme': 'light',
 })`
   background-color: ${props => props.theme.color('yellow')};
 `;

--- a/content/webapp/views/components/SourcedDescription/index.tsx
+++ b/content/webapp/views/components/SourcedDescription/index.tsx
@@ -50,7 +50,8 @@ const SourcePill = styled.div.attrs({
   display: inline-flex;
   align-items: center;
   border-radius: 20px;
-  background-color: ${props => props.theme.color('accent.green')}40;
+  background-color: ${props =>
+    props.theme.colorWithAlpha('accent.green', 0.25)};
   cursor: default;
   height: 22px;
   vertical-align: middle;

--- a/content/webapp/views/pages/collections/subjects/sub-theme/index.tsx
+++ b/content/webapp/views/pages/collections/subjects/sub-theme/index.tsx
@@ -88,7 +88,9 @@ const WellcomeSubThemePage: NextPage<Props> & {
       slice.slice_type === 'cardListing'
   );
   const hasNewOnlineWorks = newOnlineWorks.length > 0;
-  const hasRelatedStories = cardListingSlices.some(slice => slice.items.length > 0);
+  const hasRelatedStories = cardListingSlices.some(
+    slice => slice.items.length > 0
+  );
   const hasWorksAbout =
     !!worksAndImagesAbout.works && worksAndImagesAbout.works.totalResults > 0;
   const hasImagesAbout = !!(

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -193,11 +193,12 @@ const ThemeHeader: FunctionComponent<{
           </>
         </Container>
       </ConceptHero>
-
-      <DecorativeEdge
-        variant="wobbly"
-        backgroundColor={hasImages ? 'neutral.700' : 'white'}
-      />
+      <span data-color-scheme="light">
+        <DecorativeEdge
+          variant="wobbly"
+          backgroundColor={hasImages ? 'neutral.700' : 'white'}
+        />
+      </span>
     </>
   );
 };

--- a/content/webapp/views/pages/concepts/concept/concept.Header.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.Header.tsx
@@ -193,12 +193,12 @@ const ThemeHeader: FunctionComponent<{
           </>
         </Container>
       </ConceptHero>
-      <span data-color-scheme="light">
+      <div data-color-scheme="light">
         <DecorativeEdge
           variant="wobbly"
           backgroundColor={hasImages ? 'neutral.700' : 'white'}
         />
-      </span>
+      </div>
     </>
   );
 };

--- a/content/webapp/views/pages/concepts/concept/concept.styles.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.styles.tsx
@@ -4,7 +4,10 @@ import { font } from '@weco/common/utils/classnames';
 import Space from '@weco/common/views/components/styled/Space';
 import { PaletteColor } from '@weco/common/views/themes/config';
 
-export const MobileNavBackground = styled(Space).attrs({
+export const MobileNavBackground = styled(Space).attrs<{
+  'data-color-scheme': 'light';
+}>({
+  'data-color-scheme': 'light',
   className: 'is-hidden-l is-hidden-xl',
   $v: { size: 'md', properties: ['height'] },
 })<{ $isOnWhite: boolean }>`

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -133,7 +133,7 @@ const ConceptPage: NextPage<Props> = ({
         <MobileNavBackground $isOnWhite={!hasImages} />
 
         <Container>
-          <Grid style={{ background: 'white', rowGap: 0 }}>
+          <Grid style={{ background: 'var(--color-white)', rowGap: 0 }}>
             <InPageNavigation
               links={navLinks}
               isOnWhite={!hasImages}
@@ -142,7 +142,7 @@ const ConceptPage: NextPage<Props> = ({
 
             <GridCell $sizeMap={{ s: [12], m: [12], l: [9], xl: [10] }}>
               {shouldDisplayImages && (
-                <StretchWrapper>
+                <StretchWrapper data-color-scheme="light">
                   <ImagesResults
                     sectionsData={sectionsData}
                     concept={conceptResponse}

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/index.tsx
@@ -130,7 +130,7 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
       hideNewsletterPromo={true}
       apiToolbarLinks={[createPrismicLink(exhibitionGuideId)]}
     >
-      <Page>
+      <Page data-color-scheme="light">
         <Header ref={headerRef}>
           <Container>
             <HeaderInner>

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
@@ -74,7 +74,9 @@ type GridProps = {
   $hasMultipleCanvases?: boolean;
 };
 
-const Grid = styled.div<GridProps>`
+const Grid = styled.div.attrs<{ 'data-color-scheme': 'light' }>({
+  'data-color-scheme': 'light',
+})<GridProps>`
   display: grid;
   height: ${props =>
     props.$isFullSupportBrowser

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.Placeholder.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.Placeholder.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 const getGradient = (theme: DefaultTheme) => {
-  const bgColor = theme.colors['neutral.300'];
+  const bgColor = theme.color('neutral.300');
   const highlightColor = 'rgb(255, 255, 255, 0.6)';
 
   // We make the background periodic so that it can be animated easily


### PR DESCRIPTION
## What does this change?

- Changes the colours to use css custom properties
- Uses the [light-dark function](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark) to determine which colour to use depending on value of `prefers-color-scheme`
- Overrides inverting UI that is already dark in default/light mode (e.g. the footer/viewer), using `data-color-scheme` attribute

## How to test
- Turn on dark appearance in MacOS Settings
- Visit the site, click about that place

## Have we considered potential risks?

- Nobody has asked for this and it isn't behind a toggle!
- I chose the colours – history tells us this is a bad idea
- I think I've gone way too far with it, but there might be something in keeping the [first commit](https://github.com/wellcomecollection/wellcomecollection.org/pull/13193/changes/1048a3017ecabbeb5bf9eba646dffd7a5c9c49a1)?
- There's no way to turn dark mode on/off without going to the system level – if we do ever add dark mode I think we'd want a switch to allow overriding default setting