### PR TITLE
Make `GenericContentFields` generic over body slice type

### DIFF
--- a/cardigan/stories/data/content.ts
+++ b/cardigan/stories/data/content.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import untransformedBody from '@weco/cardigan/stories/data/untransformed-body';
+import { ArticlesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import {
   ArticleBasic,
   Article as TransformedPrismicArticle,
@@ -302,7 +303,8 @@ export const article: TransformedPrismicArticle = {
       },
     },
   ],
-  untransformedBody,
+  untransformedBody:
+    untransformedBody as unknown as ArticlesDocumentDataBodySlice[],
   promo: {
     caption: 'Do you have any dark clouds following you?',
     image: {

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import { EventsDocumentDataBodySlice } from '@weco/common/prismicio-types';
+import { PlacesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { Event } from '@weco/content/types/events';
 
 const image = {
@@ -17,7 +17,7 @@ export const location = {
   id: 'Wn1fvyoAACgAH_yG',
   title: 'Reading Room',
   body: [],
-  untransformedBody: [] as prismic.SliceZone<EventsDocumentDataBodySlice>,
+  untransformedBody: [] as prismic.SliceZone<PlacesDocumentDataBodySlice>,
   labels: [],
   level: 2,
   information: [

--- a/content/webapp/__mocks__/events.ts
+++ b/content/webapp/__mocks__/events.ts
@@ -1,7 +1,7 @@
 import * as prismic from '@prismicio/client';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
-import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
+import { EventsDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { Event } from '@weco/content/types/events';
 
 const image = {
@@ -17,7 +17,7 @@ export const location = {
   id: 'Wn1fvyoAACgAH_yG',
   title: 'Reading Room',
   body: [],
-  untransformedBody: [] as prismic.SliceZone<PagesDocumentDataBodySlice>,
+  untransformedBody: [] as prismic.SliceZone<EventsDocumentDataBodySlice>,
   labels: [],
   level: 2,
   information: [

--- a/content/webapp/pages/collections/index.tsx
+++ b/content/webapp/pages/collections/index.tsx
@@ -3,7 +3,6 @@ import { NextPage } from 'next';
 
 import { prismicPageIds } from '@weco/common/data/hardcoded-ids';
 import {
-  PagesDocumentDataBodySlice,
   FullWidthBannerSlice as RawFullWidthBannerSlice,
   PagesDocument as RawPagesDocument,
   TextSlice as RawTextSlice,
@@ -59,11 +58,11 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       getInsideOurCollectionsCards(collectionsPage);
 
     const bannerOne = collectionsPage.untransformedBody.find(
-      (slice: prismic.Slice) => slice.slice_type === 'fullWidthBanner'
+      slice => slice.slice_type === 'fullWidthBanner'
     ) as RawFullWidthBannerSlice | undefined;
 
     const bannerTwo = collectionsPage.untransformedBody.find(
-      (slice: prismic.Slice) =>
+      slice =>
         slice.slice_type === 'fullWidthBanner' && slice.id !== bannerOne?.id
     ) as RawFullWidthBannerSlice | undefined;
 
@@ -72,8 +71,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
       .filter(isFullWidthBanner);
 
     const themeCardsListSlices = collectionsPage.untransformedBody.filter(
-      (slice: PagesDocumentDataBodySlice) =>
-        slice.slice_type === 'themeCardsList'
+      slice => slice.slice_type === 'themeCardsList'
     ) as RawThemeCardsListSlice[];
 
     let newOnlineDocuments: WorkBasic[] = [];
@@ -81,7 +79,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
     // Find the "New online" text block in Prismic that contains work IDs
     // Format should be: "New online: [ptfqa2te, bbsjt2ex, a3cyqwec, sh37yy5n]"
     const newOnlineBlock = collectionsPage.untransformedBody.find(
-      (slice: prismic.Slice) =>
+      slice =>
         slice.slice_type === 'text' &&
         Array.isArray(slice.primary.text) &&
         slice.primary.text.some((block: prismic.RTParagraphNode) =>

--- a/content/webapp/services/prismic/transformers/index.ts
+++ b/content/webapp/services/prismic/transformers/index.ts
@@ -2,7 +2,6 @@ import * as prismic from '@prismicio/client';
 
 import { ImageType } from '@weco/common/model/image';
 import {
-  PagesDocumentDataBodySlice,
   EditorialImageSlice as RawEditorialImageSlice,
   StandfirstSlice as RawStandfirstSlice,
   WebcomicSeriesDocument as RawWebcomicSeriesDocument,
@@ -22,7 +21,11 @@ import {
 } from '@weco/content/services/prismic/types';
 import { isEditorialImage } from '@weco/content/types/body';
 import { Format } from '@weco/content/types/format';
-import { GenericContentFields } from '@weco/content/types/generic-content-fields';
+import {
+  BodySliceOf,
+  GenericContentFields,
+  PrismicBodySlice,
+} from '@weco/content/types/generic-content-fields';
 
 import { transformImagePromo } from './images';
 
@@ -92,24 +95,17 @@ export function asTitle(title: prismic.RichTextField): string {
 }
 
 /**
- * Build the shared "generic" content fields from a Prismic relationship field.
- *
- * Why this exists:
- * - Prismic content relationships are not full documents at runtime (even when
- *   they have `data` via `fetchLinks`/GraphQuery), so using `transformGenericFields`
- *   would require unsafe casts like `relationship as RawXDocument`.
- * - This helper lets us safely use the subset of fields we expect to be present
- *   on relationship `data` (e.g. title/body/promo) without pretending we have a
- *   complete Prismic document.
+ * Like `transformGenericFields`, but for relationship fields rather than full documents.
+ * Relationship data is a partial subset even when populated via fetchLinks/GraphQuery.
  */
-export function transformGenericFieldsFromRelationship(field: {
+export function transformGenericFieldsFromRelationship<
+  TSlice extends PrismicBodySlice = PrismicBodySlice,
+>(field: {
   id: string;
   data: Record<string, unknown>;
-}): GenericContentFields {
+}): GenericContentFields<TSlice> {
   const { data } = field;
 
-  // Only process promo if it exists in the fetched data
-  // (not all relationships include promo in fetchLinks)
   const promoSlices =
     Array.isArray(data.promo) && data.promo.length > 0
       ? (data.promo as unknown[]).filter(isEditorialImage)
@@ -132,16 +128,15 @@ export function transformGenericFieldsFromRelationship(field: {
       | undefined
   );
 
-  // Only process body if it exists in the fetched data
-  // (not all relationships include body in fetchLinks)
-  const untransformedBody = (
-    Array.isArray(data.body) && data.body.length > 0 ? data.body : []
-  ) as prismic.SliceZone<PagesDocumentDataBodySlice>;
+  // Body may not be present if not included in fetchLinks
+  const untransformedBody = (Array.isArray(data.body) && data.body.length > 0
+    ? data.body
+    : []) as unknown as TSlice[];
 
   const untransformedStandfirst =
     untransformedBody.length > 0
-      ? (untransformedBody.find(
-          (slice: prismic.Slice) => slice.slice_type === 'standfirst'
+      ? ((untransformedBody as PrismicBodySlice[]).find(
+          slice => slice.slice_type === 'standfirst'
         ) as RawStandfirstSlice | undefined)
       : undefined;
 
@@ -163,7 +158,7 @@ export function transformGenericFieldsFromRelationship(field: {
     image,
     metadataDescription,
     labels: [],
-  };
+  } as GenericContentFields<TSlice>;
 }
 
 export function transformSingleLevelGroup(
@@ -215,9 +210,9 @@ export const isGenericDocWithMetaDescription = (
   return Boolean(doc.data && 'metaDescription' in doc.data);
 };
 
-export function transformGenericFields(
-  doc: GenericDoc | RelatedGenericDoc
-): GenericContentFields {
+export function transformGenericFields<
+  T extends GenericDoc | RelatedGenericDoc,
+>(doc: T): GenericContentFields<BodySliceOf<T>> {
   const { data } = doc;
   const promo = isGenericDocWithPromo(doc)
     ? transformImagePromo(doc.data.promo)
@@ -234,10 +229,12 @@ export function transformGenericFields(
     ? transformImage(primaryPromo.primary.image)
     : undefined;
 
-  const untransformedBody = data?.body || [];
-  const untransformedStandfirst = untransformedBody.find(
-    (slice: prismic.Slice) => slice.slice_type === 'standfirst'
-  ) as RawStandfirstSlice | undefined;
+  const untransformedBody = (data?.body || []) as unknown as BodySliceOf<T>[];
+  const untransformedStandfirst = (
+    untransformedBody as PrismicBodySlice[]
+  ).find(slice => slice.slice_type === 'standfirst') as
+    | RawStandfirstSlice
+    | undefined;
   const metadataDescription = isGenericDocWithMetaDescription(doc)
     ? asText(doc.data.metadataDescription)
     : undefined;
@@ -253,5 +250,5 @@ export function transformGenericFields(
     // we pass an empty array here to be overriden by each content type
     // TODO: find a way to enforce this.
     labels: [],
-  };
+  } as GenericContentFields<BodySliceOf<T>>;
 }

--- a/content/webapp/services/prismic/transformers/places.ts
+++ b/content/webapp/services/prismic/transformers/places.ts
@@ -1,6 +1,9 @@
 import * as prismic from '@prismicio/client';
 
-import { PlacesDocument as RawPlacesDocument } from '@weco/common/prismicio-types';
+import {
+  PlacesDocumentDataBodySlice,
+  PlacesDocument as RawPlacesDocument,
+} from '@weco/common/prismicio-types';
 import { isFilledLinkToDocumentWithTypedData } from '@weco/common/services/prismic/types';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { Place } from '@weco/content/types/places';
@@ -35,10 +38,11 @@ export function transformPlaceFromRelationship(
   }
 
   const data = maybeField.data;
-  const genericFields = transformGenericFieldsFromRelationship({
-    id: maybeField.id,
-    data: data as unknown as Record<string, unknown>,
-  });
+  const genericFields =
+    transformGenericFieldsFromRelationship<PlacesDocumentDataBodySlice>({
+      id: maybeField.id,
+      data: data as unknown as Record<string, unknown>,
+    });
 
   const title = Array.isArray(data.title)
     ? asTitle(data.title as prismic.RichTextField)

--- a/content/webapp/services/prismic/transformers/seasons.ts
+++ b/content/webapp/services/prismic/transformers/seasons.ts
@@ -1,6 +1,9 @@
 import * as prismic from '@prismicio/client';
 
-import { SeasonsDocument as RawSeasonsDocument } from '@weco/common/prismicio-types';
+import {
+  SeasonsDocument as RawSeasonsDocument,
+  SeasonsDocumentDataBodySlice,
+} from '@weco/common/prismicio-types';
 import { transformTimestamp } from '@weco/common/services/prismic/transformers';
 import { isFilledLinkToDocumentWithTypedData } from '@weco/common/services/prismic/types';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -42,10 +45,11 @@ export function transformSeasonFromRelationship(
 
   const data = maybeField.data;
 
-  const genericFields = transformGenericFieldsFromRelationship({
-    id: maybeField.id,
-    data: data as unknown as Record<string, unknown>,
-  });
+  const genericFields =
+    transformGenericFieldsFromRelationship<SeasonsDocumentDataBodySlice>({
+      id: maybeField.id,
+      data: data as unknown as Record<string, unknown>,
+    });
 
   const title = Array.isArray(data.title)
     ? asTitle(data.title as prismic.RichTextField)

--- a/content/webapp/types/articles.ts
+++ b/content/webapp/types/articles.ts
@@ -1,5 +1,6 @@
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
+import { ArticlesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { ArticleFormatId } from '@weco/content/data/content-format-ids';
 
 import { ColorSelection } from './color-selections';
@@ -27,7 +28,7 @@ export type ArticleBasic = {
   hasLinkedWorks: boolean;
 };
 
-export type Article = GenericContentFields & {
+export type Article = GenericContentFields<ArticlesDocumentDataBodySlice> & {
   type: 'articles';
   uid: string;
   format?: Format<ArticleFormatId>;

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -1,5 +1,4 @@
 import {
-  PagesDocumentDataBodySlice,
   ContentListSlice as RawContentListSlice,
   EditorialImageSlice as RawEditorialImageSlice,
   EmbedSlice as RawEmbedSlice,
@@ -12,6 +11,7 @@ import { Card } from './card';
 import { EventSeries } from './event-series';
 import { EventBasic } from './events';
 import { ExhibitionBasic } from './exhibitions';
+import { PrismicBodySlice } from './generic-content-fields';
 import { Guide } from './guides';
 import { Page } from './pages';
 import { Season } from './seasons';
@@ -21,31 +21,31 @@ export type Slice<TypeName extends string, Value> = {
   value: Value;
 };
 
+// These predicates accept PrismicBodySlice so they work on any untransformedBody array.
 export function isContentList(
-  slice: PagesDocumentDataBodySlice | undefined
+  slice: PrismicBodySlice | undefined
 ): slice is RawContentListSlice {
   return !!slice && slice.slice_type === 'contentList';
 }
 
 export function isFullWidthBanner(
-  slice: PagesDocumentDataBodySlice | undefined
+  slice: PrismicBodySlice | undefined
 ): slice is RawFullWidthBannerSlice {
   return !!slice && slice.slice_type === 'fullWidthBanner';
 }
 
 export function isVideoEmbed(
-  slice: PagesDocumentDataBodySlice | undefined
+  slice: PrismicBodySlice | undefined
 ): slice is RawEmbedSlice {
-  return (
-    !!slice &&
-    slice.slice_type === 'embed' &&
-    'provider_name' in slice.primary &&
-    slice.primary.provider_name === 'youtube'
-  );
+  if (!slice || slice.slice_type !== 'embed') return false;
+  // PrismicBodySlice doesn't carry `primary`, so widen via `unknown` to access it.
+  const primary = (slice as unknown as { primary: Record<string, unknown> })
+    .primary;
+  return 'provider_name' in primary && primary.provider_name === 'youtube';
 }
 
 export function isEditorialImage(
-  slice: PagesDocumentDataBodySlice | undefined
+  slice: PrismicBodySlice | undefined
 ): slice is RawEditorialImageSlice {
   return !!slice && slice.slice_type === 'editorialImage';
 }

--- a/content/webapp/types/body.ts
+++ b/content/webapp/types/body.ts
@@ -38,10 +38,7 @@ export function isVideoEmbed(
   slice: PrismicBodySlice | undefined
 ): slice is RawEmbedSlice {
   if (!slice || slice.slice_type !== 'embed') return false;
-  // PrismicBodySlice doesn't carry `primary`, so widen via `unknown` to access it.
-  const primary = (slice as unknown as { primary: Record<string, unknown> })
-    .primary;
-  return 'provider_name' in primary && primary.provider_name === 'youtube';
+  return (slice as RawEmbedSlice).primary.embed.provider_name === 'youtube';
 }
 
 export function isEditorialImage(

--- a/content/webapp/types/books.ts
+++ b/content/webapp/types/books.ts
@@ -2,6 +2,7 @@ import * as prismic from '@prismicio/client';
 
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
+import { BooksDocumentDataBodySlice } from '@weco/common/prismicio-types';
 
 import { Contributor } from './contributors';
 import { GenericContentFields } from './generic-content-fields';
@@ -26,7 +27,7 @@ export type BookBasic = {
   labels: Label[];
 };
 
-export type Book = GenericContentFields & {
+export type Book = GenericContentFields<BooksDocumentDataBodySlice> & {
   type: 'books';
   uid: string;
   subtitle?: string;

--- a/content/webapp/types/event-series.ts
+++ b/content/webapp/types/event-series.ts
@@ -1,11 +1,14 @@
+import { EventSeriesDocumentDataBodySlice } from '@weco/common/prismicio-types';
+
 import { Contributor } from './contributors';
 import { GenericContentFields } from './generic-content-fields';
 
-export type EventSeries = GenericContentFields & {
-  type: 'event-series';
-  uid: string;
-  contributors: Contributor[];
-};
+export type EventSeries =
+  GenericContentFields<EventSeriesDocumentDataBodySlice> & {
+    type: 'event-series';
+    uid: string;
+    contributors: Contributor[];
+  };
 
 export type EventSeriesBasic = {
   type: 'event-series';

--- a/content/webapp/types/events.ts
+++ b/content/webapp/types/events.ts
@@ -2,6 +2,7 @@ import * as prismic from '@prismicio/client';
 
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
+import { EventsDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { Props as VideoEmbedProps } from '@weco/common/views/components/VideoEmbed';
 import { LabelField } from '@weco/content/model/label-field';
 
@@ -101,7 +102,7 @@ export type EventBasic = HasTimes & {
   contributors: Contributor[];
 };
 
-export type Event = GenericContentFields & {
+export type Event = GenericContentFields<EventsDocumentDataBodySlice> & {
   type: 'events';
   uid: string;
   format?: Format;

--- a/content/webapp/types/exhibitions.ts
+++ b/content/webapp/types/exhibitions.ts
@@ -2,7 +2,10 @@ import * as prismic from '@prismicio/client';
 
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
-import { ExhibitionsDocumentDataOnwardJourneysSlice } from '@weco/common/prismicio-types';
+import {
+  ExhibitionsDocumentDataBodySlice,
+  ExhibitionsDocumentDataOnwardJourneysSlice,
+} from '@weco/common/prismicio-types';
 import { Props as VideoEmbedProps } from '@weco/common/views/components/VideoEmbed';
 import { Link } from '@weco/content/types/link';
 
@@ -41,25 +44,26 @@ export type ExhibitionBasic = {
   hideStatus?: boolean;
 };
 
-export type Exhibition = GenericContentFields & {
-  type: 'exhibitions';
-  uid: string;
-  shortTitle?: string;
-  format?: ExhibitionFormat;
-  start: Date;
-  end?: Date;
-  isPermanent: boolean;
-  statusOverride?: string;
-  place?: Place;
-  exhibits: Exhibit[];
-  relatedIds: string[];
-  seasons: Season[];
-  contributors: Contributor[];
-  accessResourcesPdfs: AccessPDF[];
-  accessResourcesText?: prismic.RichTextField;
-  bslLeafletVideo?: VideoEmbedProps & { title?: string };
-  untransformedOnwardJourneys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>;
-};
+export type Exhibition =
+  GenericContentFields<ExhibitionsDocumentDataBodySlice> & {
+    type: 'exhibitions';
+    uid: string;
+    shortTitle?: string;
+    format?: ExhibitionFormat;
+    start: Date;
+    end?: Date;
+    isPermanent: boolean;
+    statusOverride?: string;
+    place?: Place;
+    exhibits: Exhibit[];
+    relatedIds: string[];
+    seasons: Season[];
+    contributors: Contributor[];
+    accessResourcesPdfs: AccessPDF[];
+    accessResourcesText?: prismic.RichTextField;
+    bslLeafletVideo?: VideoEmbedProps & { title?: string };
+    untransformedOnwardJourneys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>;
+  };
 
 export type Exhibit = {
   item: Exhibition;

--- a/content/webapp/types/generic-content-fields.ts
+++ b/content/webapp/types/generic-content-fields.ts
@@ -1,17 +1,28 @@
-import * as prismic from '@prismicio/client';
-
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
-import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { StandfirstSlice as RawStandfirstSlice } from '@weco/common/prismicio-types';
 
 import { ImagePromo } from './image-promo';
 
-export type GenericContentFields = {
+/** Minimal shape satisfied by all Prismic REST v2 body slices. */
+export type PrismicBodySlice = {
+  slice_type: string;
+  id: string;
+};
+
+/** Extracts the body slice union from a Prismic document type. */
+export type BodySliceOf<T> = T extends { data: { body: (infer S)[] } }
+  ? S
+  : never;
+
+/** Fields shared by every content type. `TSlice` defaults to the minimal `PrismicBodySlice`. */
+export type GenericContentFields<
+  TSlice extends PrismicBodySlice = PrismicBodySlice,
+> = {
   id: string;
   title: string;
   promo?: ImagePromo;
-  untransformedBody: prismic.SliceZone<PagesDocumentDataBodySlice>;
+  untransformedBody: TSlice[];
   untransformedStandfirst?: RawStandfirstSlice;
   image?: ImageType;
   metadataDescription?: string;

--- a/content/webapp/types/generic-content-fields.ts
+++ b/content/webapp/types/generic-content-fields.ts
@@ -11,8 +11,8 @@ export type PrismicBodySlice = {
 };
 
 /** Extracts the body slice union from a Prismic document type. */
-export type BodySliceOf<T> = T extends { data: { body: (infer S)[] } }
-  ? S
+export type BodySliceOf<T> = T extends { data?: { body?: (infer S)[] } }
+  ? NonNullable<S>
   : never;
 
 /** Fields shared by every content type. `TSlice` defaults to the minimal `PrismicBodySlice`. */

--- a/content/webapp/types/guides.ts
+++ b/content/webapp/types/guides.ts
@@ -1,10 +1,11 @@
 import { SiteSection } from '@weco/common/model/site-section';
+import { GuidesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 
 import { Format } from './format';
 import { GenericContentFields } from './generic-content-fields';
 import { Link } from './link';
 
-export type Guide = GenericContentFields & {
+export type Guide = GenericContentFields<GuidesDocumentDataBodySlice> & {
   type: 'guides';
   uid: string;
   format?: Format;

--- a/content/webapp/types/pages.ts
+++ b/content/webapp/types/pages.ts
@@ -1,6 +1,7 @@
 import type * as prismic from '@prismicio/client';
 
 import { SiteSection } from '@weco/common/model/site-section';
+import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 
 import { Contributor } from './contributors';
 import { Format } from './format';
@@ -8,7 +9,7 @@ import { GenericContentFields } from './generic-content-fields';
 import { Link } from './link';
 import { Season } from './seasons';
 
-export type BasePage = GenericContentFields & {
+export type BasePage = GenericContentFields<PagesDocumentDataBodySlice> & {
   introText?: prismic.RichTextField;
   uid: string;
   format: Format | undefined;

--- a/content/webapp/types/places.ts
+++ b/content/webapp/types/places.ts
@@ -1,8 +1,10 @@
 import * as prismic from '@prismicio/client';
 
+import { PlacesDocumentDataBodySlice } from '@weco/common/prismicio-types';
+
 import { GenericContentFields } from './generic-content-fields';
 
-export type Place = GenericContentFields & {
+export type Place = GenericContentFields<PlacesDocumentDataBodySlice> & {
   id: string;
   title: string;
   level: number;

--- a/content/webapp/types/projects.ts
+++ b/content/webapp/types/projects.ts
@@ -1,11 +1,12 @@
 import { SiteSection } from '@weco/common/model/site-section';
+import { ProjectsDocumentDataBodySlice } from '@weco/common/prismicio-types';
 
 import { Contributor } from './contributors';
 import { Format } from './format';
 import { GenericContentFields } from './generic-content-fields';
 import { Season } from './seasons';
 
-export type Project = GenericContentFields & {
+export type Project = GenericContentFields<ProjectsDocumentDataBodySlice> & {
   type: 'projects';
   uid: string;
   format?: Format;

--- a/content/webapp/types/seasons.ts
+++ b/content/webapp/types/seasons.ts
@@ -1,6 +1,8 @@
+import { SeasonsDocumentDataBodySlice } from '@weco/common/prismicio-types';
+
 import { GenericContentFields } from './generic-content-fields';
 
-export type Season = GenericContentFields & {
+export type Season = GenericContentFields<SeasonsDocumentDataBodySlice> & {
   type: 'seasons';
   uid: string;
   start?: Date;

--- a/content/webapp/types/series.ts
+++ b/content/webapp/types/series.ts
@@ -1,5 +1,6 @@
 import { ImageType } from '@weco/common/model/image';
 import { Label } from '@weco/common/model/labels';
+import { SeriesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 
 import { ArticleScheduleItem } from './article-schedule-items';
 import { ArticleBasic } from './articles';
@@ -21,7 +22,7 @@ export type SeriesBasic = {
   labels: Label[];
 };
 
-export type Series = GenericContentFields & {
+export type Series = GenericContentFields<SeriesDocumentDataBodySlice> & {
   type: 'series';
   uid: string;
   color?: ColorSelection;

--- a/content/webapp/types/visual-stories.ts
+++ b/content/webapp/types/visual-stories.ts
@@ -1,24 +1,26 @@
 import { ImageType } from '@weco/common/model/image';
 import { SiteSection } from '@weco/common/model/site-section';
+import { VisualStoriesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { ImagePromo } from '@weco/content/types/image-promo';
 
 import { GenericContentFields } from './generic-content-fields';
 import { Link } from './link';
 
-export type VisualStory = GenericContentFields & {
-  type: 'visual-stories';
-  uid: string;
-  onThisPage: Link[];
-  datePublished?: Date;
-  relatedDocument?: {
-    title?: string;
-    id: string;
-    uid?: string;
-    type: 'exhibitions' | 'events';
+export type VisualStory =
+  GenericContentFields<VisualStoriesDocumentDataBodySlice> & {
+    type: 'visual-stories';
+    uid: string;
+    onThisPage: Link[];
+    datePublished?: Date;
+    relatedDocument?: {
+      title?: string;
+      id: string;
+      uid?: string;
+      type: 'exhibitions' | 'events';
+    };
+    siteSection?: SiteSection;
+    showOnThisPage: boolean;
   };
-  siteSection?: SiteSection;
-  showOnThisPage: boolean;
-};
 
 export type VisualStoryBasic = {
   type: 'visual-stories';

--- a/content/webapp/utils/reading-time.ts
+++ b/content/webapp/utils/reading-time.ts
@@ -1,4 +1,3 @@
-import * as prismic from '@prismicio/client';
 import readingTime from 'reading-time';
 
 import { Label } from '@weco/common/model/labels';
@@ -6,22 +5,24 @@ import {
   QuoteSlice as RawQuoteSlice,
   TextSlice as RawTextSlice,
 } from '@weco/common/prismicio-types';
-import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { pluralize } from '@weco/common/utils/grammar';
 import { asText } from '@weco/content/services/prismic/transformers';
 import { Format } from '@weco/content/types/format';
+import { PrismicBodySlice } from '@weco/content/types/generic-content-fields';
 
 // Calculating the full reading time of the article by getting all article text
-function allArticleText(
-  genericBody: prismic.SliceZone<PagesDocumentDataBodySlice>
-) {
+function allArticleText(genericBody: PrismicBodySlice[]) {
   return genericBody
     .map(slice => {
       switch (slice.slice_type) {
         case 'text':
-          return asText(slice.primary.text as RawTextSlice['primary']['text']);
+          // PrismicBodySlice doesn't carry `primary`, but inside these
+          // case branches we know the concrete slice type from the runtime
+          // slice_type check. TypeScript can't narrow a minimal type like
+          // PrismicBodySlice automatically, so we cast explicitly.
+          return asText((slice as RawTextSlice).primary.text);
         case 'quote':
-          return asText(slice.primary.text as RawQuoteSlice['primary']['text']);
+          return asText((slice as RawQuoteSlice).primary.text);
         default:
           return '';
       }
@@ -30,7 +31,7 @@ function allArticleText(
 }
 
 export function calculateReadingTime(
-  body: prismic.SliceZone<PagesDocumentDataBodySlice>
+  body: PrismicBodySlice[]
 ): string | undefined {
   const articleText = allArticleText(body);
 

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 
 import { officialLandingPagesUid } from '@weco/common/data/hardcoded-ids';
 import { ContentListSlice as RawContentListSlice } from '@weco/common/prismicio-types';
-import { PagesDocumentDataBodySlice } from '@weco/common/prismicio-types';
 import { classNames, typography } from '@weco/common/utils/classnames';
 import ConditionalWrapper from '@weco/common/views/components/ConditionalWrapper';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
@@ -27,6 +26,7 @@ import { transformContentListSlice } from '@weco/content/services/prismic/transf
 import { ArchiveWorkData } from '@weco/content/services/wellcome/catalogue/works';
 import { isContentList } from '@weco/content/types/body';
 import { convertItemToCardProps } from '@weco/content/types/card';
+import { PrismicBodySlice } from '@weco/content/types/generic-content-fields';
 import { Link } from '@weco/content/types/link';
 import Card from '@weco/content/views/components/Card';
 import FeaturedCard, {
@@ -58,7 +58,7 @@ export type BodySliceContexts = {
 };
 
 export type Props = {
-  untransformedBody: prismic.SliceZone<PagesDocumentDataBodySlice>;
+  untransformedBody: PrismicBodySlice[];
   introText?: prismic.RichTextField;
   onThisPage?: Link[];
   showOnThisPage?: boolean;
@@ -146,7 +146,7 @@ const Body: FunctionComponent<Props> = ({
   bodySliceContexts,
 }: Props) => {
   const filteredUntransformedBody = untransformedBody.filter(
-    (slice: prismic.Slice) => slice.slice_type !== 'standfirst'
+    slice => slice.slice_type !== 'standfirst'
   );
 
   const firstTextSliceIndex =

--- a/content/webapp/views/pages/about-us/cookie-policy.tsx
+++ b/content/webapp/views/pages/about-us/cookie-policy.tsx
@@ -1,3 +1,4 @@
+import { asText } from '@prismicio/client';
 import { SliceZone } from '@prismicio/react';
 import { NextPage } from 'next';
 
@@ -44,8 +45,9 @@ const CookiePolicyPage: NextPage<page.Props> = props => {
   // Find their positions so we can insert them in the correct order
   const tablesPosition = props.page.untransformedBody
     .map((slice, index) => {
-      if (EXPECTED_TABLE_NAMES.includes(slice.primary?.text?.[0]?.text))
-        return index;
+      if (slice.slice_type !== 'text') return undefined;
+      const sliceText = asText(slice.primary.text);
+      if (EXPECTED_TABLE_NAMES.includes(sliceText)) return index;
       return undefined;
     })
     .filter(isNotUndefined);
@@ -97,7 +99,13 @@ const CookiePolicyPage: NextPage<page.Props> = props => {
               return tablesPosition.includes(index) ? (
                 <CookieTable
                   key={index}
-                  rows={cookiesTableCopy[slice.primary?.text?.[0]?.text]}
+                  rows={
+                    cookiesTableCopy[
+                      slice.slice_type === 'text'
+                        ? asText(slice.primary.text)
+                        : ''
+                    ]
+                  }
                 />
               ) : (
                 <SliceZone


### PR DESCRIPTION

## What does this change?

Previously, the `untransformedBody` field on `GenericContentFields` was hardcoded to `prismic.SliceZone<PagesDocumentDataBodySlice>` — the slice union for the Pages document type — regardless of which content type was actually being represented. This meant that for articles, exhibitions, events, and every other content type, the body was typed as if it were a page, which was inaccurate and could mask type errors.

This PR makes `GenericContentFields` generic:

```ts
export type GenericContentFields<
  TSlice extends PrismicBodySlice = PrismicBodySlice,
> = { ... }
```

Each content type now passes its own Prismic-generated slice union as the type argument (e.g. `GenericContentFields<ArticlesDocumentDataBodySlice>`), so `untransformedBody` carries the correct slice types for each content type.

Two supporting types are introduced in `generic-content-fields.ts`:

- `PrismicBodySlice` — a minimal structural type (`{ slice_type: string; id: string }`) that all Prismic body slices satisfy. Used as the default type parameter and as the parameter type for utilities that need to work across content types.
- `BodySliceOf<T>` — a utility type that extracts the body slice union from a Prismic document type, used to make `transformGenericFields` infer the correct return type from the document it receives.

### Content types updated

All types that extend `GenericContentFields` now supply their specific slice union:

`Article`, `Book`, `Event`, `EventSeries`, `Exhibition`, `Guide`, `Place`, `Project`, `Season`, `Series`, `VisualStory`, `BasePage`

### Transformers updated

- `transformGenericFields` is now generic over the document type `T`, returning `GenericContentFields<BodySliceOf<T>>` so callers get a correctly-typed result without casting.
- `transformGenericFieldsFromRelationship` is generic over `TSlice` so callers (e.g. `transformPlaceFromRelationship`, `transformSeasonFromRelationship`) can supply the correct slice type.

### Downstream consumers updated

- The type predicates in `body.ts` (`isContentList`, `isFullWidthBanner`, `isVideoEmbed`, `isEditorialImage`) now accept `PrismicBodySlice` instead of `PagesDocumentDataBodySlice`, making them usable with any content type's body.
- `Body` component, `reading-time.ts`, `collections/index.tsx`, and the events mock no longer reference `PagesDocumentDataBodySlice` in places where it was wrong.
- `cookie-policy.tsx` fixes an unsafe `slice.primary?.text?.[0]?.text` access by adding a `slice_type === 'text'` guard and using `asText()` from `@prismicio/client`.

## How to test

The changes are type-level only — there is no runtime behaviour change. Verify by running:

```bash
yarn tsc
yarn test
```

Spot-check that pages, articles, exhibitions, and events still render correctly on the local dev server.

## Have we considered potential risks?

Low risk. No runtime logic has changed — the `as unknown as TSlice[]` casts in the transformers preserve existing behaviour while satisfying the stricter types. The main risk would be a TypeScript error surfacing a previously hidden type mismatch elsewhere in the codebase; `yarn tsc` will catch that.
