### PR TITLE
use visualViewportStyle for inactivity modal

### DIFF
--- a/common/views/components/Modal/Modal.styles.tsx
+++ b/common/views/components/Modal/Modal.styles.tsx
@@ -45,6 +45,21 @@ export const CloseButton = styled(Space).attrs<{ type?: string }>(props => ({
   `)}
 `;
 
+// Modal positioning is applied in three places, each building on the last:
+//
+// 1. BaseModalWindow (below): default styles — full-screen on mobile, centred
+//    at 50%/50% with translateX/Y(-50%) on sm+ screens.
+//
+// 2. Variant styled components in this file (FiltersModal, InactivityModal,
+//    etc.): override colours, padding, or specific layout concerns for each
+//    modal type.
+//
+// 3. The VisualViewport useEffect in index.tsx: for the 'inactivity' modal
+//    only, dynamically calculates inline styles to re-centre the modal inside
+//    the *visual* viewport when the user is zoomed in. The browser's layout
+//    viewport (used by position:fixed) does not account for pinch-zoom, so
+//    without this the modal can appear off-screen. The inline style overrides
+//    the top/left/maxWidth/maxHeight values set here.
 export const BaseModalWindow = styled(Space).attrs({
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'xl', properties: ['padding-left', 'padding-right'] },

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -6,6 +6,7 @@ import {
   RefObject,
   useEffect,
   useRef,
+  useState,
 } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
@@ -72,6 +73,8 @@ const Modal: FunctionComponent<Props> = ({
   const nodeRef = useRef(null);
   const { hasAcknowledgedCookieBanner, setHasAcknowledgedCookieBanner } =
     useAppContext();
+  const [visualViewportStyle, setVisualViewportStyle] =
+    useState<React.CSSProperties>({});
 
   useEffect(() => {
     if (isActive) {
@@ -102,6 +105,50 @@ const Modal: FunctionComponent<Props> = ({
     }
   }, [isActive]);
 
+  // Use VisualViewport API for inactivity modal to ensure it's visible when zoomed
+  useEffect(() => {
+    if (modalStyle !== 'inactivity' || !isActive) {
+      setVisualViewportStyle({});
+      return;
+    }
+
+    if (typeof window === 'undefined' || !window.visualViewport) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const vv = window.visualViewport;
+      if (!vv) return;
+
+      // Calculate position to center the modal in the visual viewport
+      // Use fixed positioning relative to the visual viewport
+      const style: React.CSSProperties = {
+        position: 'fixed',
+        top: `${vv.offsetTop + vv.height / 2}px`,
+        left: `${vv.offsetLeft + vv.width / 2}px`,
+        transform: 'translate(-50%, -50%)',
+        maxWidth: `${Math.min(550, vv.width * 0.9)}px`,
+        maxHeight: `${vv.height * 0.9}px`,
+        width: '80%',
+      };
+
+      setVisualViewportStyle(style);
+    };
+
+    // Update position initially and on viewport changes
+    updatePosition();
+
+    window.visualViewport.addEventListener('resize', updatePosition);
+    window.visualViewport.addEventListener('scroll', updatePosition);
+
+    return () => {
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', updatePosition);
+        window.visualViewport.removeEventListener('scroll', updatePosition);
+      }
+    };
+  }, [modalStyle, isActive]);
+
   return (
     <FocusTrap
       active={isActive && hasAcknowledgedCookieBanner}
@@ -131,6 +178,7 @@ const Modal: FunctionComponent<Props> = ({
             ref={nodeRef}
             $width={width}
             $maxWidth={maxWidth}
+            style={visualViewportStyle}
           >
             {!removeCloseButton && (
               <CloseButton

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -141,7 +141,7 @@ const Modal: FunctionComponent<Props> = ({
     updatePosition();
 
     window.visualViewport.addEventListener('resize', updatePosition);
-    window.visualViewport.addEventListener('scroll', updatePosition);
+    window.visualViewport.addEventListener('scroll', updatePosition, { passive: true });
 
     return () => {
       if (window.visualViewport) {

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -105,7 +105,11 @@ const Modal: FunctionComponent<Props> = ({
     }
   }, [isActive]);
 
-  // Use VisualViewport API for inactivity modal to ensure it's visible when zoomed
+  // VisualViewport positioning (see Modal.styles.tsx for the base styles this overrides):
+  // position:fixed is relative to the layout viewport, which does not move when
+  // the user pinch-zooms. The VisualViewport API gives us the coordinates of the
+  // actual visible area, so we can override top/left/maxWidth/maxHeight to keep
+  // the modal centred within what the user can actually see.
   useEffect(() => {
     if (modalStyle !== 'inactivity' || !isActive) {
       setVisualViewportStyle({});
@@ -141,7 +145,9 @@ const Modal: FunctionComponent<Props> = ({
     updatePosition();
 
     window.visualViewport.addEventListener('resize', updatePosition);
-    window.visualViewport.addEventListener('scroll', updatePosition, { passive: true });
+    window.visualViewport.addEventListener('scroll', updatePosition, {
+      passive: true,
+    });
 
     return () => {
       if (window.visualViewport) {

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -1,7 +1,6 @@
 import { FocusTrap } from 'focus-trap-react';
 import {
   FunctionComponent,
-  MutableRefObject,
   PropsWithChildren,
   RefObject,
   useEffect,
@@ -33,7 +32,7 @@ type Props = PropsWithChildren<{
   maxWidth?: string;
   id: string;
   dataTestId?: string;
-  openButtonRef?: MutableRefObject<HTMLElement | null>;
+  openButtonRef?: RefObject<HTMLElement | null>;
   removeCloseButton?: boolean;
   showOverlay?: boolean;
   modalStyle?: 'filters' | 'calendar' | 'video' | 'inactivity';
@@ -110,6 +109,8 @@ const Modal: FunctionComponent<Props> = ({
   // the user pinch-zooms. The VisualViewport API gives us the coordinates of the
   // actual visible area, so we can override top/left/maxWidth/maxHeight to keep
   // the modal centred within what the user can actually see.
+  // We only do this when scale !== 1 (i.e. the user is zoomed); at scale 1 the
+  // default CSS centering works correctly.
   useEffect(() => {
     if (modalStyle !== 'inactivity' || !isActive) {
       setVisualViewportStyle({});
@@ -120,41 +121,24 @@ const Modal: FunctionComponent<Props> = ({
       return;
     }
 
-    const updatePosition = () => {
-      const vv = window.visualViewport;
-      if (!vv) return;
+    const vv = window.visualViewport;
 
-      // Calculate position to center the modal in the visual viewport
-      // Use fixed positioning relative to the visual viewport
-      const style: React.CSSProperties = {
-        position: 'fixed',
-        top: `${vv.offsetTop + vv.height / 2}px`,
-        left: `${vv.offsetLeft + vv.width / 2}px`,
-        right: 'auto',
-        bottom: 'auto',
-        transform: 'translate(-50%, -50%)',
-        maxWidth: `${Math.min(550, vv.width * 0.9)}px`,
-        maxHeight: `${vv.height * 0.9}px`,
-        width: '80%',
-      };
+    if (vv.scale === 1) {
+      setVisualViewportStyle({});
+      return;
+    }
 
-      setVisualViewportStyle(style);
-    };
-
-    // Update position initially and on viewport changes
-    updatePosition();
-
-    window.visualViewport.addEventListener('resize', updatePosition);
-    window.visualViewport.addEventListener('scroll', updatePosition, {
-      passive: true,
+    setVisualViewportStyle({
+      position: 'fixed',
+      top: `${vv.offsetTop + vv.height / 2}px`,
+      left: `${vv.offsetLeft + vv.width / 2}px`,
+      right: 'auto',
+      bottom: 'auto',
+      transform: 'translate(-50%, -50%)',
+      maxWidth: `${Math.min(550, vv.width * 0.9)}px`,
+      maxHeight: `${vv.height * 0.9}px`,
+      width: '80%',
     });
-
-    return () => {
-      if (window.visualViewport) {
-        window.visualViewport.removeEventListener('resize', updatePosition);
-        window.visualViewport.removeEventListener('scroll', updatePosition);
-      }
-    };
   }, [modalStyle, isActive]);
 
   return (

--- a/common/views/components/Modal/index.tsx
+++ b/common/views/components/Modal/index.tsx
@@ -126,6 +126,8 @@ const Modal: FunctionComponent<Props> = ({
         position: 'fixed',
         top: `${vv.offsetTop + vv.height / 2}px`,
         left: `${vv.offsetLeft + vv.width / 2}px`,
+        right: 'auto',
+        bottom: 'auto',
         transform: 'translate(-50%, -50%)',
         maxWidth: `${Math.min(550, vv.width * 0.9)}px`,
         maxHeight: `${vv.height * 0.9}px`,


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13196

## What does this change?

Ensures the redirect modal is visible regardless of the zoom state

Previously the modal could be totally offscreen or clipped.

Before:
<img width="1354" height="689" alt="Screenshot 2026-06-29 at 15 18 06" src="https://github.com/user-attachments/assets/a37b6675-9e31-4849-a76f-b87640be3d6c" />


After:
<img width="1350" height="712" alt="Screenshot 2026-06-29 at 15 15 17" src="https://github.com/user-attachments/assets/5c794a40-3861-4866-8766-0d2eca8ea2d6" />

## How to test

- pick the T&R [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- click on a story from the [kiosk homepage](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- zoom and pan the page
- wait for the modal to appear

## Have we considered potential risks?

it affects other modals? - this is gated by the 'inactivity' model type so the affect is isolated

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->
