### PR TITLE
add zoom query parameter for kiosk pro

### DIFF
--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -30,7 +30,11 @@ const InactivityRedirect: FunctionComponent<{ isCardiganStory?: boolean }> = ({
   const modalButtonRef = useRef<HTMLElement | null>(null);
 
   // Don't run outside kiosk mode, on the redirect destination itself, or if in developer mode
-  const isRedirectDestination = router.asPath === kioskHomepageUrl;
+  // Strip kp_zoomLevel param when checking if we're on the homepage
+  const currentPathWithoutZoomParam = router.asPath.split('?')[0];
+  const homepagePathWithoutZoomParam = kioskHomepageUrl?.split('?')[0];
+  const isRedirectDestination =
+    currentPathWithoutZoomParam === homepagePathWithoutZoomParam;
   const shouldNotBeActive =
     (!isKiosk ||
       isDevModeKiosk ||
@@ -54,7 +58,11 @@ const InactivityRedirect: FunctionComponent<{ isCardiganStory?: boolean }> = ({
       // Clear navigation history to start fresh
       resetNavigationHistory();
 
-      router.push(kioskHomepageUrl);
+      // Append kp_zoomLevel=100 to reset zoom in Kiosk Pro browser
+      const separator = kioskHomepageUrl.includes('?') ? '&' : '?';
+      const urlWithZoomReset = `${kioskHomepageUrl}${separator}kp_zoomLevel=100`;
+
+      router.push(urlWithZoomReset);
     },
     [router, kioskHomepageUrl, resetNavigationHistory]
   );

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -30,11 +30,11 @@ const InactivityRedirect: FunctionComponent<{ isCardiganStory?: boolean }> = ({
   const modalButtonRef = useRef<HTMLElement | null>(null);
 
   // Don't run outside kiosk mode, on the redirect destination itself, or if in developer mode
-  // Strip kp_zoomLevel param when checking if we're on the homepage
-  const currentPathWithoutZoomParam = router.asPath.split('?')[0];
-  const homepagePathWithoutZoomParam = kioskHomepageUrl?.split('?')[0];
+  // Strip query parameters when checking if we're on the homepage (e.g. kp_zoomLevel=100)
+  const currentPathWithoutQuery = router.asPath.split('?')[0];
+  const homepagePathWithoutQuery = kioskHomepageUrl?.split('?')[0];
   const isRedirectDestination =
-    currentPathWithoutZoomParam === homepagePathWithoutZoomParam;
+    currentPathWithoutQuery === homepagePathWithoutQuery;
   const shouldNotBeActive =
     (!isKiosk ||
       isDevModeKiosk ||


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13197

## What does this change?

adds a parameter (kp_zoomLevel=100) to the url on redirect that should cause kiosk pro to reset the zoom level

## How to test
- pick the T&R [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- click on a story from the [kiosk homepage](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- wait for the modal to appear and reset homepage
- check for kp_zoomLevel=100 in homepage url

We'll have to wait for it to deploy so we can test if it has the desired effect on the iPad

## Have we considered potential risks?

It's harmless if it doesn't work
