### PR TITLE
remove ‘part of’ from stories card when in kiosk mode

### DIFF
--- a/content/webapp/views/components/StoryCard/StoryCard.Prismic.tsx
+++ b/content/webapp/views/components/StoryCard/StoryCard.Prismic.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
@@ -47,6 +48,7 @@ const StoryCard: FunctionComponent<Props> = ({
   hidePromoText = false,
   positionInList,
 }) => {
+  const { isKiosk } = useKiosk();
   const image = article.promo?.image;
   const url = linkResolver(article);
 
@@ -98,7 +100,7 @@ const StoryCard: FunctionComponent<Props> = ({
         </div>
       </CardBody>
 
-      {article.series.length > 0 && (
+      {!isKiosk && article.series.length > 0 && (
         <CardPostBody>
           {article.series.map(series => (
             <PartOf key={series.id}>


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13181

## What does this change?

- removes ‘part of’ from stories card when in kiosk mode
- 
## How to test
- pick the T&R [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- visit the [kiosk homepage](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- no stories cards should include 'part of' information

## Have we considered potential risks?

none really