### PR TITLE
Kiosk tr stories

### DIFF
--- a/cardigan/stories/components/KioskNavigation/KioskNavigation.stories.tsx
+++ b/cardigan/stories/components/KioskNavigation/KioskNavigation.stories.tsx
@@ -51,6 +51,7 @@ const meta: Meta<StoryArgs> = {
         <KioskProvider
           cookieContent={context.args.kioskMode}
           readingRoomStories={{}}
+          tendernessAndRageContent={{}}
         >
           <Story />
         </KioskProvider>

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -15,7 +15,10 @@ import {
   KiosksContentType,
 } from '@weco/common/contexts/KioskContext/kiosks-content';
 import { HistoryProvider } from '@weco/common/hooks/useNavigationHistory';
-import { ReadingRoomStories } from '@weco/common/server-data/prismic';
+import {
+  ReadingRoomStories,
+  TendernessAndRageContent,
+} from '@weco/common/server-data/prismic';
 import { KioskModeOptionId } from '@weco/toggles';
 import toggleConfig from '@weco/toggles/toggles';
 
@@ -57,6 +60,7 @@ const KioskContext = createContext<KioskContextType>({
 type KioskProviderProps = PropsWithChildren<{
   cookieContent: string | null;
   readingRoomStories: ReadingRoomStories;
+  tendernessAndRageContent: TendernessAndRageContent;
 }>;
 
 export const useKiosk = (): KioskContextType => {
@@ -67,6 +71,7 @@ export const useKiosk = (): KioskContextType => {
 export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
   cookieContent,
   readingRoomStories,
+  tendernessAndRageContent,
   children,
 }) => {
   const kioskExperienceName = getKioskExperienceName(cookieContent);
@@ -88,8 +93,12 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
     () => ({
       ...initialKiosksContent,
       RR: readingRoomStories as KiosksContentType,
+      TR: {
+        ...initialKiosksContent.TR,
+        ...tendernessAndRageContent,
+      } as KiosksContentType,
     }),
-    [readingRoomStories]
+    [readingRoomStories, tendernessAndRageContent]
   );
 
   const value = useMemo(

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -95,7 +95,7 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
       RR: readingRoomStories as KiosksContentType,
       TR: {
         ...initialKiosksContent.TR,
-        ...tendernessAndRageContent,
+        ...(tendernessAndRageContent ?? {}),
       } as KiosksContentType,
     }),
     [readingRoomStories, tendernessAndRageContent]

--- a/common/contexts/KioskContext/kiosks-content.ts
+++ b/common/contexts/KioskContext/kiosks-content.ts
@@ -141,14 +141,5 @@ export const kiosksContent: Record<string, KiosksContentType> = {
         ],
       },
     ],
-    stories: [
-      'artists--activism-and-aids',
-      'telling-scotland-about-aids',
-      'guerrilla-public-health',
-      'in-the-tracks-of-derek-jarman-s-tears',
-      'aids-posters',
-      'what-are-zines-doing-in-a-museum',
-      'how-to-design-an-hiv-awareness-campaign',
-    ],
   },
 };

--- a/common/server-data/__mocks__/index.ts
+++ b/common/server-data/__mocks__/index.ts
@@ -27,6 +27,7 @@ export async function getServerData(): Promise<ServerData> {
       popupDialog: emptyPopupDialog(),
       collectionVenues: emptyPrismicQuery<RawCollectionVenueDocument>(),
       readingRoomStories: {},
+      tendernessAndRageContent: {},
     },
     consentStatus: {
       analytics: false,

--- a/common/server-data/prismic.ts
+++ b/common/server-data/prismic.ts
@@ -34,6 +34,16 @@ export type ReadingRoomStories = {
   [title: string]: string[];
 };
 
+export type TendernessAndRageContent = {
+  includedWorks?: string[];
+  workGroups?: {
+    heading: string;
+    description: string;
+    ids: string[];
+  }[];
+  stories?: string[];
+};
+
 export const defaultValue: SimplifiedPrismicData = {
   globalAlert: {
     data: {
@@ -57,6 +67,7 @@ export const defaultValue: SimplifiedPrismicData = {
     results: [],
   },
   readingRoomStories: {},
+  tendernessAndRageContent: {},
 };
 
 export type PrismicData = {
@@ -64,6 +75,7 @@ export type PrismicData = {
   popupDialog: RawPopupDialogDocument;
   collectionVenues: prismic.Query<RawCollectionVenueDocument>;
   readingRoomStories: RawPagesDocument | null;
+  tendernessAndRageContent: RawPagesDocument | null;
 };
 
 export type SimplifiedPrismicData = {
@@ -71,6 +83,7 @@ export type SimplifiedPrismicData = {
   popupDialog: { data: InferDataInterface<RawPopupDialogDocument> };
   collectionVenues: ResultsLite;
   readingRoomStories: ReadingRoomStories;
+  tendernessAndRageContent: TendernessAndRageContent;
 };
 
 export const handler: Handler<SimplifiedPrismicData, SimplifiedPrismicData> = {
@@ -100,17 +113,23 @@ async function fetchPrismicValues(): Promise<PrismicData> {
     'pages',
     'reading-room-stories'
   );
+  const tendernessAndRageContentPromise = client.getByUID(
+    'pages',
+    'tenderness-and-rage-explore-more'
+  );
 
   const [
     collectionVenuesResult,
     globalAlertResult,
     popupDialogResult,
     readingRoomStoriesResult,
+    tendernessAndRageContentResult,
   ] = await Promise.allSettled([
     collectionVenuesResultPromise,
     globalAlertResultPromise,
     popupDialogResultPromise,
     readingRoomStoriesPromise,
+    tendernessAndRageContentPromise,
   ]);
 
   // If we don't get a result from Prismic for collectionVenues, we want to
@@ -146,6 +165,10 @@ async function fetchPrismicValues(): Promise<PrismicData> {
     readingRoomStories:
       readingRoomStoriesResult.status === 'fulfilled'
         ? (readingRoomStoriesResult.value as RawPagesDocument)
+        : null,
+    tendernessAndRageContent:
+      tendernessAndRageContentResult.status === 'fulfilled'
+        ? (tendernessAndRageContentResult.value as RawPagesDocument)
         : null,
   };
 }

--- a/common/services/prismic/transformers/server-data.ts
+++ b/common/services/prismic/transformers/server-data.ts
@@ -11,6 +11,7 @@ import {
   ReadingRoomStories,
   ResultsLite,
   SimplifiedPrismicData,
+  TendernessAndRageContent,
 } from '@weco/common/server-data/prismic';
 import { InferDataInterface } from '@weco/common/services/prismic/types';
 
@@ -25,6 +26,9 @@ export function simplifyPrismicData(
     collectionVenues: simplifyCollectionVenues(prismicData.collectionVenues),
     readingRoomStories: simplifyReadingRoomStories(
       prismicData.readingRoomStories
+    ),
+    tendernessAndRageContent: simplifyTendernessAndRageContent(
+      prismicData.tendernessAndRageContent
     ),
   };
 }
@@ -116,4 +120,35 @@ function simplifyReadingRoomStories(
   }
 
   return groupedStories;
+}
+
+function simplifyTendernessAndRageContent(
+  doc: RawPagesDocument | null
+): TendernessAndRageContent {
+  if (!doc) {
+    return {};
+  }
+
+  const content: TendernessAndRageContent = {
+    stories: [],
+  };
+
+  for (const slice of doc.data.body) {
+    // Extract stories from cardListing slices (articles only)
+    if (slice.slice_type === 'cardListing' && 'items' in slice) {
+      for (const item of slice.items) {
+        if (
+          'content' in item &&
+          prismic.isFilled.contentRelationship(item.content) &&
+          item.content.isBroken === false &&
+          item.content.type === 'articles' &&
+          item.content.uid
+        ) {
+          content.stories?.push(item.content.uid);
+        }
+      }
+    }
+  }
+
+  return content;
 }

--- a/common/test/fixtures/prismicData/prismic-data.ts
+++ b/common/test/fixtures/prismicData/prismic-data.ts
@@ -214,6 +214,7 @@ const prismicData: SimplifiedPrismicData = {
     ],
   },
   readingRoomStories: {},
+  tendernessAndRageContent: {},
 };
 
 export default prismicData;

--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -163,35 +163,35 @@ function findNavigationContent({
 
   const content = kiosksContent[contentKey];
 
-  // Search all arrays in the content object to find which one contains the pageId
+  // Search workGroups first (more specific, curated collections)
   let items: string[] | undefined;
   let currentIndex = -1;
   let listName: string | undefined;
+  let label: string | undefined;
 
-  for (const [key, value] of Object.entries(content)) {
-    if (
-      Array.isArray(value) &&
-      (value.length === 0 || typeof value[0] === 'string')
-    ) {
-      const stringArray = value as string[];
-      currentIndex = stringArray.indexOf(pageId);
-      if (currentIndex !== -1) {
-        items = stringArray;
-        listName = key;
-        break;
-      }
+  for (const group of content.workGroups ?? []) {
+    currentIndex = group.ids.indexOf(pageId);
+    if (currentIndex !== -1) {
+      items = group.ids;
+      label = group.heading;
+      break;
     }
   }
 
-  let label: string | undefined;
-
+  // If not found in workGroups, search all other arrays in the content object
   if (!items || currentIndex === -1) {
-    for (const group of content.workGroups ?? []) {
-      currentIndex = group.ids.indexOf(pageId);
-      if (currentIndex !== -1) {
-        items = group.ids;
-        label = group.heading;
-        break;
+    for (const [key, value] of Object.entries(content)) {
+      if (
+        Array.isArray(value) &&
+        (value.length === 0 || typeof value[0] === 'string')
+      ) {
+        const stringArray = value as string[];
+        currentIndex = stringArray.indexOf(pageId);
+        if (currentIndex !== -1) {
+          items = stringArray;
+          listName = key;
+          break;
+        }
       }
     }
   }

--- a/common/views/components/Picture/index.tsx
+++ b/common/views/components/Picture/index.tsx
@@ -32,12 +32,15 @@ export const Picture: FunctionComponent<Props> = ({
   return (
     <Figure data-component="picture">
       <picture>
-        {images.map(image => {
+        {images.map((image, index) => {
           if (image.width) {
             const sizes = imageSizes(image.width);
             return (
               <source
-                key={image.contentUrl}
+                // Crops can share an identical contentUrl (e.g. when an
+                // editor hasn't set a distinct crop), so the index keeps
+                // each <source> distinct even when the URLs collide.
+                key={`${image.contentUrl}-${index}`}
                 media={image.minWidth ? `(min-width: ${image.minWidth})` : ''}
                 sizes="100vw"
                 srcSet={sizes

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -177,6 +177,9 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                     <KioskProvider
                       cookieContent={kioskModeCookie!}
                       readingRoomStories={serverData.prismic.readingRoomStories}
+                      tendernessAndRageContent={
+                        serverData.prismic.tendernessAndRageContent
+                      }
                     >
                       {children}
                     </KioskProvider>


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13183

## What does this change?

The stories for T&R were hard coded while building the navigation. We now have a T&R explore more page in Prismic so should fetch the stories for the navigation from there.

This does that and makes them available on the kiosk context

## How to test

- pick the T&R [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- click on a story from the [kiosk homepage](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- the pagination indicator should match the total number and position of the story you clicked on
- you can paginate through the stories

## Have we considered potential risks?

Prismic request failing (but the stories on the index page probably wouldn't render either)