### PR TITLE
make T&R explore more page public

### DIFF
--- a/content/webapp/pages/exhibitions/[exhibitionId]/explore-more.tsx
+++ b/content/webapp/pages/exhibitions/[exhibitionId]/explore-more.tsx
@@ -44,12 +44,6 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 
   const serverData = await getServerData(context);
 
-  // TODO: this is temporary and should be removed when we're happy with the
-  // page
-  if (!serverData.toggles.modes.kioskMode) {
-    return { notFound: true };
-  }
-
   if (!looksLikePrismicId(exhibitionId)) {
     return { notFound: true };
   }


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13213

## What does this change?

Makes the explore more page of T & R public without a kiosk mode.

## How to test

- turn [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes) off
- [visit the page](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more) and don't get a 404

## Have we considered potential risks?

People find the page before we have officially launched it, but think that is pretty harmless
