### PR TITLE
 force the middleware to use Node.js runtime

### DIFF
--- a/identity/webapp/middleware.ts
+++ b/identity/webapp/middleware.ts
@@ -70,6 +70,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
+  runtime: 'nodejs',
   matcher: [
     /*
      * Match all request paths except for the ones starting with:
@@ -80,5 +81,3 @@ export const config = {
     '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 };
-
-export const runtime = 'nodejs';

--- a/identity/webapp/middleware.ts
+++ b/identity/webapp/middleware.ts
@@ -80,3 +80,5 @@ export const config = {
     '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
   ],
 };
+
+export const runtime = 'nodejs';


### PR DESCRIPTION

## What does this change?

Force the middleware runtime to use Node.js so AsyncLocalStorage is available

I _think_ this will fix the error we are having in the identity app currently on stage

Error: Invariant: AsyncLocalStorage accessed in runtime where it is not available

## How to test

Deploy to stage and see if it works...
