### PR TITLE
Remove some query params from the new cache settings

### DIFF
--- a/cache/modules/cloudfront_policies/cache_policies.tf
+++ b/cache/modules/cloudfront_policies/cache_policies.tf
@@ -70,7 +70,28 @@ resource "aws_cloudfront_cache_policy" "weco_apps" {
     }
 
     query_strings_config {
-      query_string_behavior = "all"
+      query_string_behavior = "allExcept"
+
+      query_strings {
+        items = [
+          # Client-side only: the viewer reads this to decide whether to scroll to a
+          # canvas when a thumbnail link is clicked. The server always returns identical
+          # HTML regardless of its value, so including it in the cache key fragments
+          # the cache without any benefit.
+          "shouldScrollToCanvas",
+          # Client-side only: triggers a redirect banner for users arriving from old
+          # Wellcome Images URLs. Read via window.location.search in a useEffect in
+          # CataloguePageLayout — the server renders identical HTML regardless.
+          "wellcomeImagesUrl",
+          # Tracking/analytics parameters — never read by the server.
+          "utm_campaign",
+          "utm_content",
+          "utm_id",
+          "utm_medium",
+          "utm_source",
+          "utm_term",
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
- For #13144 

## What does this change?

CloudFront's `weco-apps` cache policy was set to `query_string_behavior = "all"`, meaning every unique combination of query parameters produced a separate cache entry. We think this might cause significant cache fragmentation and maybe inflates NAT Gateway costs (data that could have been served from the CloudFront edge was instead hitting our origin ECS services).

Analysis of CloudFront access logs for 29 June identified the top contributors to unnecessary cache misses:

Full-day totals for 29 June (3,176,533 requests; 1,242,824 misses — 39.1% miss rate):

| Parameter | Cache misses (29 June) | Used server-side? |
|---|---|---|
| `canvas` | ~428k | Yes — keep in cache key |
| `page` | ~272k | Yes — keep in cache key |
| `shouldScrollToCanvas` | ~227k | No — client-only |
| `wellcomeImagesUrl` | ~3.3k | No — client-only |
| UTM params (`utm_source`, etc.) | ~6.2k combined | No — analytics only |
| `fbclid`, `gclid` | ~1.2k combined | No — ad tracking (kept in cache key, low volume) |

`shouldScrollToCanvas` is the single biggest "offender". It is set on thumbnail `<a>` links in the IIIF viewer so the client knows to programmatically scroll the `FixedSizeList` when a thumbnail is clicked. The server returns identical HTML regardless of its value — it is read only in a client-side `useEffect` in `MainViewer.tsx`.

`wellcomeImagesUrl` is a legacy parameter appended to redirect links from the old Wellcome Images site. It triggers a client-side banner in `CataloguePageLayout` via `window.location.search` in a `useEffect` — the server renders identical HTML regardless of its value.

UTM and ad-click parameters are appended by marketing campaigns and social platforms. They are never read by Next.js on the server.

The fix changes the policy from `"all"` to `"allExcept"` with an 8-item exclusion list. The excluded params account for ~236,500 unnecessary misses on 29 June, **7.4 percentage points** of total requests. Expected outcome: hit rate improves from ~43.6% to ~51%, saving an estimated **$465/month** in NAT Gateway costs (based on June's $2,444 bill). All other query params (including `canvas`, `page`, `query`, `cachebust`, and anything the app may add in future) remain in the cache key automatically.

That would be nice wouldn't it, if it was true?

## How to test

**Before applying:**
- On the current branch, open a work with many images (e.g. https://wellcomecollection.org/works/p9gbr9bx/items)
- Click thumbnails and confirm the viewer scrolls to the correct canvas — this confirms `shouldScrollToCanvas` is handled correctly client-side regardless of caching behaviour

**After applying:**
- The IIIF viewer thumbnail navigation should behave identically (the param is still forwarded to the origin and still present in the URL; only the cache key changes)
- Monitor the CloudFront `CacheHitRate` metric on the `ENN4F9Q8E3GW9` distribution — expect a noticeable improvement for `/works/*/items*` requests within a few hours
- Monitor NAT Gateway costs (`EU-NatGateway-Bytes`) — expect a reduction over the following days

## Have we considered potential risks?

**Serving stale content to users with tracking params:** A user arriving via `?utm_source=newsletter` will now get the same cached response as a user without that param. This is the desired outcome — the HTML is identical either way.

**`shouldScrollToCanvas` no longer varying the cache key:** The viewer receives the param in the URL as normal; it is stripped from the *cache key* only, not from the request. Client-side scroll behaviour is unaffected.

**`cachebust` intentionally kept in the cache key:** `cachebust` is used for deliberate cache invalidation and is excluded from the `allExcept` list, so cache-busting still works.

**No risk of wrong content being served:** We reviewed `MainViewer.tsx` and confirmed `shouldScrollToCanvas` is only read in a client-side `useEffect`. None of the excluded parameters influence what the Next.js server renders.
