### PR TITLE
always show show iframe pdf viewer if in kiosk mode

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { getFileLabel } from '@weco/content/utils/works';
 
 import IIIFItemDownload from './IIIFItem.Download';
@@ -31,10 +32,10 @@ const IIIFItemPdf: FunctionComponent<Props> = ({
   const { isMobileOrTabletDevice } = useAppContext();
   const substituteTitle = 'unknown title';
   const displayLabel = getFileLabel(label, substituteTitle);
-
+  const { isKiosk } = useKiosk();
   return (
     <>
-      {isMobileOrTabletDevice ? (
+      {isMobileOrTabletDevice && !isKiosk ? (
         <IIIFItemDownload
           src={src}
           label={label}


### PR DESCRIPTION
- For #13218

## What does this change?

[We intentionally make mobile/tablet devices show a download link rather than attempt to display pdfs](https://github.com/wellcomecollection/wellcomecollection.org/pull/12026), due to inconsistent behaviour between devices and buggy implementation.

We don't want this behaviour for kiosk mode on the iPads, so this PR stops it happening if isKiosk is true.

## How to test
- with no kiosk mode chosen
- Visit [an item page with a PDF](https://www-stage.wellcomecollection.org/works/bd7tnj3t/items)
- On desktop you should still see the PDF
- Open dev tools and change the user agent to a mobile device
<img width="1018" alt="Screenshot 2025-06-17 at 17 43 41" src="https://github.com/user-attachments/assets/a4ba0ee8-8f37-4ac3-9527-3ad8fb5ae72c" />
- The page should now show a link for the PDF instead of the iframe

- in a separate tab [pick the T&R kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- refresh the item page
- the pdf should now display

## Have we considered potential risks?

We were having issues with PDFs on iOS (iPhone), with display size and scrolling. We may have something similar on the iPad. If so we will need to fix it and/or come up with another approach
