### PR TITLE
show Navigation label in kiosk navigation for medium breakpoint

### DIFF
--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -103,7 +103,7 @@ const RightSection = styled.nav`
 const NavigationLabel = styled.span`
   display: none;
 
-  ${props => props.theme.media('md')`
+  ${props => props.theme.media('sm')`
     display: inline;
   `}
 `;


### PR DESCRIPTION
- For #13237

## What does this change?

As described in the above issue, this keeps the navigation label visible on medium screens

<img width="795" height="102" alt="Screenshot 2026-07-02 at 16 07 15" src="https://github.com/user-attachments/assets/56a10151-df92-43cd-b61d-8fcb27ed7e5e" />



## How to test

- [pick a T&R kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- [visit a page with navigation ](https://www-dev.wellcomecollection.org/works/m8xw26qs)
- resize the screen from large to small
- the home text label should vanish when crossing the medium breakpoint
- the navigation text label (on the right)should vanish when crossing the small breakpoint

## Have we considered potential risks?

None really
