### PR TITLE
add breadcrumb data to explore-more page

### DIFF
--- a/content/webapp/views/pages/exhibitions/explore-more.tsx
+++ b/content/webapp/views/pages/exhibitions/explore-more.tsx
@@ -3,7 +3,9 @@ import { NextPage } from 'next';
 import styled from 'styled-components';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
+import linkResolver from '@weco/common/services/prismic/link-resolver';
 import { typography } from '@weco/common/utils/classnames';
+import { getBreadcrumbItems } from '@weco/common/views/components/Breadcrumb';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
 import {
   ContaineredLayout,
@@ -71,7 +73,10 @@ const ExploreMorePage: NextPage<Props> = ({
     >
       <PageHeader
         variant="basic"
-        breadcrumbs={{ items: [] }}
+        breadcrumbs={getBreadcrumbItems('whats-on', [
+          { url: '/exhibitions', text: 'Exhibitions' },
+          { url: linkResolver(exhibition), text: exhibition.title },
+        ])}
         title={page.title}
         isContentTypeInfoBeforeMedia={true}
         ContentTypeInfo={

--- a/content/webapp/views/pages/exhibitions/explore-more.tsx
+++ b/content/webapp/views/pages/exhibitions/explore-more.tsx
@@ -76,6 +76,11 @@ const ExploreMorePage: NextPage<Props> = ({
         breadcrumbs={getBreadcrumbItems('whats-on', [
           { url: '/exhibitions', text: 'Exhibitions' },
           { url: linkResolver(exhibition), text: exhibition.title },
+          {
+            url: `/exhibitions/${exhibition.uid}/explore-more`,
+            text: page.title,
+            isHidden: true,
+          },
         ])}
         title={page.title}
         isContentTypeInfoBeforeMedia={true}


### PR DESCRIPTION
- For #13240

## What does this change?

Adds an appropriate breadcrumb to the explore more page (when not in kiosk mode)

## How to test

- don't be in kiosk mode
- visit the [explore more page for Tenderness and Rage](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- check the breadcrumb makes sense and the links work

## Have we considered potential risks?

none really