### PR TITLE
WAF hardening after the 2026-07-06 /search bot flood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pa11y-report.html
 *.tfstate.backup
 .terraform.tfstate.lock.info
 terraform.plan
+*.plan
 
 # Privates
 .env

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -32,6 +32,8 @@ module "prod_wc_org_cloudfront_distribution" {
   google_bots_ip_set_arn    = aws_wafv2_ip_set.google_bots.arn
   github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
   header_shared_secret      = local.current_shared_secret
+
+  enable_waf_logging = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -14,20 +14,10 @@ locals {
   monitoring_infra       = data.terraform_remote_state.monitoring.outputs
   ci_vpc_nat_elastic_ip  = local.platform_account_infra["ci_vpc_nat_elastic_ip"]
 
-  # LogicMonitor SiteMonitor synthetic checks run from these IPs and request
-  # /search/works?query=botany and /search/images?query=skeletons (inherited from
-  # the old updown checks) at a steady rate, so they must not trip the rate
-  # limits or any future challenge rules on /search paths. NB the ip-allowlist
-  # rule is a terminating ALLOW, so these IPs skip every WAF rule after
-  # geo-restriction (blocklist, managed rules, etc), not just the rate limits.
-  #
-  # Verified against CloudFront logs (2026-07-05/06): all traffic from these IPs
-  # carries the "LogicMonitor SiteMonitor/1.0" user agent and hits only the check
-  # URLs, from LogicMonitor's five checkpoint regions. NB LogicMonitor warn that
-  # checkpoint IPs can change and recommend identifying checks via a custom
-  # header instead; if monitoring starts tripping the WAF, refresh this list
-  # (or move to a custom-header allow rule configured in the LM portal).
-  # The definitive list is at:
+  # LogicMonitor SiteMonitor checkpoint IPs. Their checks hit /search URLs, so
+  # they must not trip the rate limits or challenge rules there. NB the
+  # ip-allowlist rule is a terminating ALLOW: these IPs skip every later rule.
+  # LogicMonitor warn these IPs can change; the definitive list is at
   # https://www.logicmonitor.com/support/about-logicmonitor/overview/logicmonitor-public-ip-addresses-dns-names
   logicmonitor_ips = [
     "3.106.118.109",

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -11,10 +11,41 @@ locals {
   slack_webhook_url = data.aws_secretsmanager_secret_version.slack_webhook.secret_string
 
   platform_account_infra = data.terraform_remote_state.platform_account.outputs
-  monitoring_infra        = data.terraform_remote_state.monitoring.outputs
+  monitoring_infra       = data.terraform_remote_state.monitoring.outputs
   ci_vpc_nat_elastic_ip  = local.platform_account_infra["ci_vpc_nat_elastic_ip"]
+
+  # LogicMonitor SiteMonitor synthetic checks run from these IPs and request
+  # /search/works?query=botany and /search/images?query=skeletons (inherited from
+  # the old updown checks) at a steady rate, so they must bypass rate limits and
+  # any challenge rules on /search paths.
+  #
+  # Verified against CloudFront logs (2026-07-05/06): all traffic from these IPs
+  # carries the "LogicMonitor SiteMonitor/1.0" user agent and hits only the check
+  # URLs, from LogicMonitor's five checkpoint regions. NB LogicMonitor warn that
+  # checkpoint IPs can change and recommend identifying checks via a custom
+  # header instead; if monitoring starts tripping the WAF, refresh this list
+  # (or move to a custom-header allow rule configured in the LM portal).
+  # The definitive list is at:
+  # https://www.logicmonitor.com/support/about-logicmonitor/overview/logicmonitor-public-ip-addresses-dns-names
+  logicmonitor_ips = [
+    "3.106.118.109",
+    "3.106.118.110",
+    "3.106.118.111",
+    "18.139.118.201",
+    "18.139.118.202",
+    "18.139.118.203",
+    "34.223.95.106",
+    "34.223.95.107",
+    "34.223.95.108",
+    "52.202.255.79",
+    "52.202.255.82",
+    "52.202.255.87",
+    "52.215.168.132",
+    "52.215.168.133",
+    "52.215.168.134",
+  ]
 
   # We exclude requests from the CI VPC's NAT gateway from our managed firewall rules
   # because AWS sometimes identifies them as bots, causing end-to-end tests to fail with 403s
-  waf_ip_allowlist = [local.ci_vpc_nat_elastic_ip]
+  waf_ip_allowlist = concat([local.ci_vpc_nat_elastic_ip], local.logicmonitor_ips)
 }

--- a/cache/locals.tf
+++ b/cache/locals.tf
@@ -16,8 +16,10 @@ locals {
 
   # LogicMonitor SiteMonitor synthetic checks run from these IPs and request
   # /search/works?query=botany and /search/images?query=skeletons (inherited from
-  # the old updown checks) at a steady rate, so they must bypass rate limits and
-  # any challenge rules on /search paths.
+  # the old updown checks) at a steady rate, so they must not trip the rate
+  # limits or any future challenge rules on /search paths. NB the ip-allowlist
+  # rule is a terminating ALLOW, so these IPs skip every WAF rule after
+  # geo-restriction (blocklist, managed rules, etc), not just the rate limits.
   #
   # Verified against CloudFront logs (2026-07-05/06): all traffic from these IPs
   # carries the "LogicMonitor SiteMonitor/1.0" user agent and hits only the check

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -66,3 +66,9 @@ variable "github_actions_ip_set_arn" {
   type        = string
   description = "ARN of the shared github-actions IP set (defined at root level)"
 }
+
+variable "enable_waf_logging" {
+  type        = bool
+  default     = false
+  description = "Log non-allowed (blocked/counted/challenged) WAF requests to CloudWatch Logs"
+}

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -9,10 +9,8 @@ locals {
   blanket_rate_limit = 2500
 
   // A more restrictive limit for expensive URLs (eg /works)
-  // These are prefix matches (no trailing anchor) so that subpaths like
-  // /search/works, /search/images and /works/{id}/items are covered: both
-  // waves of the July 2026 bot flood targeted those subpaths, which the
-  // previous exact-match regexes (^\/works$ etc) did not restrict.
+  // Prefix matches, so subpaths like /search/works and /works/{id}/items
+  // are covered too.
   restrictive_rate_limit  = 1000
   restricted_path_regexes = ["^\\/works", "^\\/images", "^\\/concepts", "^\\/search"]
 
@@ -842,9 +840,13 @@ resource "aws_wafv2_ip_set" "blocklist" {
   scope              = "CLOUDFRONT"
   ip_address_version = "IPV4"
 
-  # Normally empty; populate during an incident with
-  # `aws wafv2 update-ip-set` or a terraform change.
+  # Managed with `aws wafv2 update-ip-set` during incidents; terraform
+  # ignores the contents so a routine apply cannot revert a live block.
   addresses = []
+
+  lifecycle {
+    ignore_changes = [addresses]
+  }
 }
 
 resource "aws_wafv2_ip_set" "watchlist" {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -9,8 +9,12 @@ locals {
   blanket_rate_limit = 2500
 
   // A more restrictive limit for expensive URLs (eg /works)
+  // These are prefix matches (no trailing anchor) so that subpaths like
+  // /search/works, /search/images and /works/{id}/items are covered: both
+  // waves of the July 2026 bot flood targeted those subpaths, which the
+  // previous exact-match regexes (^\/works$ etc) did not restrict.
   restrictive_rate_limit  = 1000
-  restricted_path_regexes = ["^\\/works$", "^\\/images$", "^\\/concepts$", "^\\/search$"]
+  restricted_path_regexes = ["^\\/works", "^\\/images", "^\\/concepts", "^\\/search"]
 
   // These come from the information security team
   // Qualys is an "enterprise vulnerability management tool"
@@ -139,8 +143,29 @@ resource "aws_wafv2_web_acl" "wc_org" {
   }
 
   rule {
-    name     = "ip-watchlist"
+    name     = "ip-blocklist"
     priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.blocklist.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "weco-cloudfront-acl-blocklist-${var.namespace}"
+    }
+  }
+
+  rule {
+    name     = "ip-watchlist"
+    priority = 3
 
     action {
       count {}
@@ -161,7 +186,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "allow-google-bots"
-    priority = 3
+    priority = 4
 
     action {
       allow {}
@@ -203,7 +228,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "allow-github-actions"
-    priority = 4
+    priority = 5
 
     action {
       allow {}
@@ -224,7 +249,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "managed-ip-blocking"
-    priority = 5
+    priority = 6
 
     override_action {
       none {}
@@ -247,7 +272,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-user-agent-manual"
-    priority = 6
+    priority = 7
 
     action {
       block {}
@@ -395,7 +420,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "apac-captcha-consent-block"
-    priority = 7
+    priority = 8
 
     action {
       captcha {}
@@ -445,7 +470,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "latam-captcha-consent-block"
-    priority = 8
+    priority = 9
 
     action {
       captcha {}
@@ -495,7 +520,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 9
+    priority = 10
 
     action {
       block {
@@ -530,7 +555,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 10
+    priority = 11
 
     action {
       block {
@@ -570,7 +595,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 11
+    priority = 12
 
     action {
       block {
@@ -607,7 +632,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 12
+    priority = 13
 
     action {
       block {}
@@ -629,7 +654,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 13
+    priority = 14
 
     action {
       block {}
@@ -667,7 +692,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 14
+    priority = 15
 
     override_action {
       none {}
@@ -690,7 +715,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 15
+    priority = 16
 
     override_action {
       none {}
@@ -713,7 +738,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 16
+    priority = 17
 
     override_action {
       none {}
@@ -735,7 +760,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 17
+    priority = 18
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -808,6 +833,18 @@ resource "aws_wafv2_ip_set" "allowlist" {
 
   # These need to be CIDR blocks rather than plain addresses
   addresses = [for ip in local.ip_allowlist : "${ip}/32"]
+}
+
+resource "aws_wafv2_ip_set" "blocklist" {
+  name        = "blocklist-${var.namespace}"
+  description = "IPs blocked outright, an emergency lever for use during incidents"
+
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+
+  # Normally empty; populate during an incident with
+  # `aws wafv2 update-ip-set` or a terraform change.
+  addresses = []
 }
 
 resource "aws_wafv2_ip_set" "watchlist" {

--- a/cache/modules/wc_org_cloudfront/waf_logging.tf
+++ b/cache/modules/wc_org_cloudfront/waf_logging.tf
@@ -1,9 +1,5 @@
-# Request-level WAF logs, for forensics during incidents. The web ACL's
-# sampled requests only retain a small sample for a few hours; these logs
-# record every request the WAF acted on (we filter out plain allows to
-# keep costs down).
-#
-# The log group name must begin with "aws-waf-logs-":
+# Request-level WAF logs for incident forensics; plain allows are filtered
+# out to keep costs down. The log group name must begin with "aws-waf-logs-":
 # https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html
 
 resource "aws_cloudwatch_log_group" "waf" {

--- a/cache/modules/wc_org_cloudfront/waf_logging.tf
+++ b/cache/modules/wc_org_cloudfront/waf_logging.tf
@@ -1,0 +1,51 @@
+# Request-level WAF logs, for forensics during incidents. The web ACL's
+# sampled requests only retain a small sample for a few hours; these logs
+# record every request the WAF acted on (we filter out plain allows to
+# keep costs down).
+#
+# The log group name must begin with "aws-waf-logs-":
+# https://docs.aws.amazon.com/waf/latest/developerguide/logging-cw-logs.html
+
+resource "aws_cloudwatch_log_group" "waf" {
+  count = var.enable_waf_logging ? 1 : 0
+
+  name              = "aws-waf-logs-weco-${var.namespace}"
+  retention_in_days = 30
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "wc_org" {
+  count = var.enable_waf_logging ? 1 : 0
+
+  resource_arn            = aws_wafv2_web_acl.wc_org.arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf[0].arn]
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior    = "KEEP"
+      requirement = "MEETS_ANY"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+      condition {
+        action_condition {
+          action = "COUNT"
+        }
+      }
+      condition {
+        action_condition {
+          action = "CAPTCHA"
+        }
+      }
+      condition {
+        action_condition {
+          action = "CHALLENGE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

First-line, edge-only remediation after the 2026-07-06 bot flood that took the site down. A follow-up PR will add a stage-gated WAF challenge rule on `/search*`.

### Background

On 2026-07-06 at 07:30 UTC a distributed bot flood hit `/search/works` and `/search/images`: 10,372 distinct IPs in 7 minutes, roughly one request per IP, rotated browser user agents, and thousands of distinct facet-filter queries. It was a distributed scraper crawling search facet links. Because every existing WAF rule is keyed on IP, user agent or geo, the traffic passed all of them. It saturated `prod-search-api` (fixed at 3 tasks, no autoscaling), drove API Gateway 5xx to 98.8% and brought the site down.

A concentrated wave the day before, on 2026-07-05 at 02:02 UTC, targeted the same paths but came from a small number of IPs, so the blanket per-IP rate limit caught it (371k blocks that hour). The distributed shape of the 07-06 wave is what defeated the per-IP rules.

### The changes

1. **Tightened restrictive rate-limit paths** (`cache/modules/wc_org_cloudfront/waf.tf`). The restrictive 1000 req / 5 min / IP limit was keyed on exact-match regexes (`^\/search$`, `^\/works$` etc), which excluded the subpaths the attacks actually hit. Switched them to prefix matches (`^\/search`, `^\/works` etc) so `/search/works`, `/search/images` and `/works/{id}/items` are now covered.

2. **Allowlisted the 15 LogicMonitor SiteMonitor checkpoint IPs** (`cache/locals.tf`). Their synthetic checks request `/search/works?query=botany` and `/search/images?query=skeletons` (URLs inherited from the removed updown checks) and would otherwise trip the tightened rate limits or a future challenge rule. Verified against CloudFront logs: 100% LogicMonitor user agent, across the five checkpoint regions. LogicMonitor's definitive IP list is linked in a code comment, and they recommend a custom-header allow as the durable approach, noted as a follow-up.

3. **Added an emergency IP blocklist** (`cache/modules/wc_org_cloudfront/waf.tf`). A new (normally empty) blocklist IP set plus a block rule at priority 2 in each web ACL, with existing rules renumbered 2-17 to 3-18. This gives responders a lever to block IPs with `aws wafv2 update-ip-set` mid-incident, without a terraform cycle.

4. **Enabled WAF request logging for prod** (new `cache/modules/wc_org_cloudfront/waf_logging.tf` plus an `enable_waf_logging` variable, true for prod only). Logs non-ALLOW actions to the CloudWatch Logs group `aws-waf-logs-weco-prod` with 30-day retention, so we have request-level forensics next time.

5. **`.gitignore`**: ignore `*.plan` terraform plan files.

## How to test

These changes have already been applied by manual `terraform apply`: stage first via a targeted apply and verified, then prod and e2e. Post-apply checks passed, the site returns 200s, ACL rule order is confirmed, LogicMonitor checks are unaffected, and `terraform plan` now reports no changes.

To review:

- Confirm `terraform plan` in `cache/` reports no changes against the applied infrastructure.
- Check the CloudFront web ACLs in the console: `ip-blocklist` sits at priority 2 (block action, empty IP set) and the previously numbered rules have shifted down by one.
- Confirm the `restrictive-rate-limiting` rule's regex set now uses prefix matches, and that a burst against `/search/works` from a single IP is rate limited.
- Confirm the LogicMonitor checkpoint IPs appear in the `allowlist` IP set and that SiteMonitor checks are still green.
- Confirm the `aws-waf-logs-weco-prod` log group exists (prod only) and is receiving non-ALLOW WAF records.

## Have we considered potential risks?

- The prefix matches are broader than the old exact matches, so more paths now fall under the restrictive 1000 req / 5 min / IP limit. That is the intent. The limit is per-IP and well above normal single-user traffic, so legitimate browsing should not be affected. The LogicMonitor allowlist covers our synthetic checks.
- This is first-line mitigation only. The 07-06 wave was distributed at roughly one request per IP, so per-IP rate limits would not have stopped it on their own. The follow-up challenge rule on `/search*` is the intended defence against that shape; this PR reduces blast radius and adds the tooling (blocklist lever, request logging) to respond faster.
- The emergency blocklist ships empty, so it has no effect until populated during an incident. Rule renumbering was applied and the resulting ACL order was verified.
- WAF logging is prod-only and filtered to non-ALLOW actions with 30-day retention to keep costs contained.
- LogicMonitor warn that checkpoint IPs can change; if monitoring starts tripping the WAF, the list needs refreshing (or moving to the recommended custom-header allow). This is called out in a code comment.
