### PR TITLE
Add a stage-gated JS challenge on /search pages

### DIFF
--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -31,4 +31,8 @@ module "stage_wc_org_cloudfront_distribution" {
   google_bots_ip_set_arn    = aws_wafv2_ip_set.google_bots.arn
   github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
   header_shared_secret      = local.current_shared_secret
+
+  # Trialling the /search challenge here before prod (see the search-challenge
+  # rule in the module for why this is high-risk).
+  enable_search_challenge = true
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -67,6 +67,12 @@ variable "github_actions_ip_set_arn" {
   description = "ARN of the shared github-actions IP set (defined at root level)"
 }
 
+variable "enable_search_challenge" {
+  type        = bool
+  default     = false
+  description = "Serve a silent JS challenge to token-less clients on /search* pages. High-risk: prove on stage before enabling elsewhere."
+}
+
 variable "enable_waf_logging" {
   type        = bool
   default     = false

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -516,20 +516,14 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
-  // Silently challenges clients without a valid WAF token on /search pages,
-  // which are expensive to render and uncacheable in practice (highly
-  // diverse query strings). Note that only the works search page is
-  // noindex,nofollow; the other /search pages are indexable, so a challenge
-  // here can affect crawling of those. During the July 2026 flood ~10k
-  // distinct IPs made one request each, so nothing keyed on IP could catch
-  // it; a challenge stops any client that does not run JavaScript before the
-  // request reaches the origin. Real browsers solve it invisibly and hold a
-  // token for the immunity period.
+  // Silently challenges clients that don't run JavaScript on /search pages,
+  // which are expensive to render and effectively uncacheable. Real browsers
+  // solve the challenge invisibly. Only the works search page is
+  // noindex,nofollow, so this can affect crawling of the other /search pages.
   //
-  // CAUTION: a challenge response served to a fetch/XHR or asset request
-  // cannot render its interstitial and will break the page. Keep the scope
-  // to /search page URLs only, and test any change on stage first (a
-  // previous broader attempt at a JS challenge white-screened the site).
+  // CAUTION: a challenge served to a fetch/XHR or asset request cannot render
+  // its interstitial and breaks the page. Keep the scope to /search page URLs
+  // only, and test any change on stage first.
   dynamic "rule" {
     for_each = var.enable_search_challenge ? [1] : []
     content {

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -519,8 +519,10 @@ resource "aws_wafv2_web_acl" "wc_org" {
   }
 
   // Silently challenges clients without a valid WAF token on /search pages,
-  // which are expensive to render, uncacheable in practice (highly diverse
-  // query strings) and noindex,nofollow. During the July 2026 flood ~10k
+  // which are expensive to render and uncacheable in practice (highly
+  // diverse query strings). Note that only the works search page is
+  // noindex,nofollow; the other /search pages are indexable, so a challenge
+  // here can affect crawling of those. During the July 2026 flood ~10k
   // distinct IPs made one request each, so nothing keyed on IP could catch
   // it; a challenge stops any client that does not run JavaScript before the
   // request reaches the origin. Real browsers solve it invisibly and hold a

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -518,9 +518,55 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // Silently challenges clients without a valid WAF token on /search pages,
+  // which are expensive to render, uncacheable in practice (highly diverse
+  // query strings) and noindex,nofollow. During the July 2026 flood ~10k
+  // distinct IPs made one request each, so nothing keyed on IP could catch
+  // it; a challenge stops any client that does not run JavaScript before the
+  // request reaches the origin. Real browsers solve it invisibly and hold a
+  // token for the immunity period.
+  //
+  // CAUTION: a challenge response served to a fetch/XHR or asset request
+  // cannot render its interstitial and will break the page. Keep the scope
+  // to /search page URLs only, and test any change on stage first (a
+  // previous broader attempt at a JS challenge white-screened the site).
+  dynamic "rule" {
+    for_each = var.enable_search_challenge ? [1] : []
+    content {
+      name     = "search-challenge"
+      priority = 10
+
+      action {
+        challenge {}
+      }
+
+      statement {
+        byte_match_statement {
+          positional_constraint = "STARTS_WITH"
+          search_string         = "/search"
+
+          field_to_match {
+            uri_path {}
+          }
+
+          text_transformation {
+            priority = 0
+            type     = "NONE"
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "search-challenge-${var.namespace}"
+      }
+    }
+  }
+
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 10
+    priority = 11
 
     action {
       block {
@@ -555,7 +601,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 11
+    priority = 12
 
     action {
       block {
@@ -595,7 +641,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 12
+    priority = 13
 
     action {
       block {
@@ -632,7 +678,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 13
+    priority = 14
 
     action {
       block {}
@@ -654,7 +700,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 14
+    priority = 15
 
     action {
       block {}
@@ -692,7 +738,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 15
+    priority = 16
 
     override_action {
       none {}
@@ -715,7 +761,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 16
+    priority = 17
 
     override_action {
       none {}
@@ -738,7 +784,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 17
+    priority = 18
 
     override_action {
       none {}
@@ -760,7 +806,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 18
+    priority = 19
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to


### PR DESCRIPTION
This is Package 2 of the remediation for the 2026-07-06 /search bot flood outage. It is stacked on top of #13241 (Package 1), which has the incident background and the IP-set allowlisting this change relies on. That PR is the base branch here, so please review and merge #13241 first.

## What does this change?

The flood was a distributed wave: roughly one request per IP from about 10k IPs, with rotated browser user agents. Nothing keyed on IP, UA or geo could catch that pattern. This adds the one mitigation that does defeat it: an AWS WAF `challenge {}` action on /search page URLs. WAF serves a silent JS interstitial at the edge to any client without a valid WAF token, and the request never reaches the origin. Real browsers solve it invisibly and hold a token for the immunity window, so there is no visible friction for actual users.

The change is deliberately narrow and gated so we can prove it on stage before it goes anywhere near prod.

- `cache/modules/wc_org_cloudfront/waf.tf`: a new `search-challenge` rule at priority 10, created through a `dynamic "rule"` block gated on the new `enable_search_challenge` module variable (default `false`). The existing rules that were at priorities 10 to 18 (the geo and blanket rate limits, and the managed rule groups) are renumbered to 11 to 19 in every environment to free up the slot. The rule scope is a `byte_match` `STARTS_WITH "/search"` on `uri_path` only, so `/_next/static` assets and `/_next/data` client-navigation requests are never challenged. To be explicit about what is covered: every search tab is challenged, i.e. `/search`, `/search/works`, `/search/images`, `/search/stories`, `/search/events` and `/search/concepts`. That is deliberate: they are all origin-rendered pages and any one of them would serve as an attack target if left out.
- `cache/modules/wc_org_cloudfront/variables.tf`: the new `enable_search_challenge` variable, documented as high-risk.
- `cache/cloudfront_stage.tf`: the challenge is enabled for stage only. Prod and e2e stay off until the stage soak is done.

## How to test

Stage is already live with this change via a targeted `terraform apply`, so the checks below have been run and pass.

- Token-less request hits the challenge: `curl -i "https://www-stage.wellcomecollection.org/search/works?query=test"` returns `202` with `x-amzn-waf-action: challenge`. A non-search page (for example the homepage) still returns `200`.
- Real browsers are unaffected: in headless Chromium via Playwright, a fresh browser loads the challenged results page fully rendered (no white screen, the challenge auto-solves), paginates to page 2, opens a work page, navigates back, and a second tab loads /search/images. Across the whole session there are zero HTTP responses of 400 or above, which confirms no asset or client-navigation request was handed a challenge.

## Have we considered potential risks?

Yes, and they shaped the design. A previous attempt at a JS challenge white-screened the site. The known failure mode is a challenge response served to a fetch/XHR or an asset request, which cannot render the interstitial. Every safeguard here exists to avoid that:

- Scope is limited to /search page URLs on `uri_path`, so `/_next/static` and `/_next/data` requests are never challenged.
- The behaviour is gated per environment on `enable_search_challenge`, defaulting off.
- Rollout is stage-first, and this PR only turns it on for stage.

Other exposure considered:

- SEO: verified Googlebot is allowlisted at a higher priority so is never challenged. Only the works search page sets `noindex,nofollow`; the other /search tabs are indexable, so their crawling by other bots (Bing etc) is affected while the challenge is on. Search results pages are a reasonable thing to keep out of indexes anyway, and adding `noindex` to the remaining tabs app-side would close the gap properly.
- Monitoring: LogicMonitor synthetic checks hit /search URLs, but their checkpoint IPs were allowlisted in #13241, so they are not challenged.
- Cost: challenge responses cost roughly $0.40 per 1,000 served, which is negligible at expected volumes.

## Rollout plan

1. Merge #13241, then merge this PR.
2. Soak on stage for at least 24 hours, watching the `search-challenge-stage` ChallengeRequests CloudWatch metric and error reports.
3. If clean, a follow-up one-line change sets `enable_search_challenge = true` in `cloudfront_prod.tf`.

