### PR TITLE
Alarm on the prod CloudFront 5xx error rate

### DIFF
--- a/cache/alarms.tf
+++ b/cache/alarms.tf
@@ -1,0 +1,22 @@
+# CloudFront metrics live in us-east-1, which is this configuration's
+# default region. The Chatbot topic renders the alarm in Slack.
+resource "aws_cloudwatch_metric_alarm" "prod_cloudfront_5xx" {
+  alarm_name          = "wc-org-prod-cloudfront-5xx-alarm"
+  alarm_description   = "wellcomecollection.org is serving over 2% 5xx responses"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 2
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DistributionId = module.prod_wc_org_cloudfront_distribution.distribution_id
+    Region         = "Global"
+  }
+
+  alarm_actions = [local.monitoring_infra["chatbot_topic_arns"]["us-east-1"]]
+  ok_actions    = [local.monitoring_infra["chatbot_topic_arns"]["us-east-1"]]
+}


### PR DESCRIPTION
> **Third PR in a stack.** Base branch is `waf-search-challenge`, not `main`. Merge order: #13241, then #13242, then this one.
> #13241 <- #13242 <- this PR

## What does this change?

This adds a CloudWatch alarm on the prod CloudFront distribution's 5xx error rate, in one new file `cache/alarms.tf`.

It is part of closing the alerting gap exposed by the 2026-07-06 outage, when wellcomecollection.org served over 20% 5xx for several minutes with no alert firing. The sibling change wellcomecollection/catalogue-api#930 adds API Gateway alarms in the catalogue account; this one covers the CloudFront edge.

The alarm:

- `aws_cloudwatch_metric_alarm "wc-org-prod-cloudfront-5xx-alarm"` watches `AWS/CloudFront` `5xxErrorRate`, Average over a 300s period, greater than 2%, with one evaluation period and `treat_missing_data = notBreaching`.
- Dimensions are the prod `DistributionId` (from the distribution module output) and `Region = Global`, which is how CloudFront reports distribution-wide metrics.
- It routes to the monitoring account's Chatbot SNS topic using the us-east-1 ARN from the monitoring remote state (`chatbot_topic_arns`), which that stack exports specifically for CloudFront alarms. CloudFront metrics live in us-east-1, so the alarm and the topic sit in the same region. `ok_actions` is set as well so recovery is announced too.

On the threshold: normal background `5xxErrorRate` sits under 0.1% averaged over five minutes. During the outage it went over 20%. 2% is comfortably above the noise floor (occasional single-request blips register up to about 0.3%) and would have fired within the first five minutes of the incident.

## How to test

The alarm has already been created via `terraform apply` from this branch. Both the ALARM and OK transitions were test-fired with `set-alarm-state` and delivered to Slack through Chatbot, so the end-to-end path is confirmed.

To re-check: run a `terraform plan` in `cache/` from this branch and confirm it reports no changes. The alarm `wc-org-prod-cloudfront-5xx-alarm` should be visible in the us-east-1 CloudWatch console for the prod account.

Note that the same apply also carried the WAF rule renumbering (priorities 11 to 19) from the parent branch through to prod and e2e. That was verified as a pure priority shift with no rule or behaviour changes.

## Have we considered potential risks?

The change only adds a new alarm, so there is no risk to request serving. The main failure modes are the alarm being too noisy or too quiet:

- Too quiet is the risk we are trying to remove. A single evaluation period over five minutes at 2% is chosen to fire quickly during a real incident while staying above the observed noise floor.
- Too noisy would show up as spurious Slack alerts. The 2% threshold sits well above normal background and above occasional single-request blips, so false positives should be rare. If they do occur we can raise the threshold or add a second evaluation period.

`treat_missing_data = notBreaching` means an absence of metric data does not trigger the alarm, which avoids alerting when the distribution is simply idle.
