### PR TITLE
Enable the /search JS challenge on prod

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -34,6 +34,10 @@ module "prod_wc_org_cloudfront_distribution" {
   header_shared_secret      = local.current_shared_secret
 
   enable_waf_logging = true
+
+  # Proven on stage; see the search-challenge rule in the module for why this
+  # is high-risk.
+  enable_search_challenge = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {


### PR DESCRIPTION
This is the final package of the remediation for the 2026-07-06 /search bot flood outage, stacked on #13242 (which is stacked on the merged #13241). It is the one-line enablement promised in #13242's rollout plan: `enable_search_challenge = true` for the prod CloudFront distribution.

## What does this change?

- `cache/cloudfront_prod.tf`: passes `enable_search_challenge = true` to the prod `wc_org_cloudfront` module, turning on the priority-10 `search-challenge` WAF rule (silent JS challenge on `uri_path STARTS_WITH /search`).

## How to test

Prod is already live with this change via a targeted `terraform apply` of exactly this diff (0 added, 2 changed, 0 destroyed — the only net rule change was the new `search-challenge` rule; the second changed resource was an unrelated missing description on the `github-actions` IP set). All checks below have been run and pass:

- Token-less request is challenged: `curl -i "https://wellcomecollection.org/search/works?query=test"` returns `202` with `x-amzn-waf-action: challenge` (same for `/search/images`). The homepage still returns `200` and `/_next/static` paths are not intercepted.
- Real browsers are unaffected: a fresh headless Chromium (Playwright, no WAF token) loaded `/search/works` fully rendered, paginated to page 2, opened a work page, navigated back, and loaded `/search/images` in a second tab — with zero HTTP responses of 400 or above across the session.
- Monitoring is recording: in the first minutes, `search-challenge-prod` showed 89 `ChallengeRequests`, 5 `ChallengesAttempted`, 5 `ChallengesSolved` — a 100% solve rate for real browsers, with the remainder being token-less clients stopped silently at the edge.

## Have we considered potential risks?

The risk analysis is in #13242; this PR only flips the environment gate for prod after the stage soak. The known failure mode (challenge served to a fetch/XHR or asset request) was re-verified as absent on prod with the browser session above. A recurring check on the ChallengesAttempted/Solved ratio and error reports is running during the prod soak.

Merge #13242 first; this PR then reconverges git with what is already applied to prod.