### PR TITLE
Block fabricated legacy-Chrome UAs ahead of the /search challenge

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -38,6 +38,10 @@ module "prod_wc_org_cloudfront_distribution" {
   # Proven on stage; see the search-challenge rule in the module for why this
   # is high-risk.
   enable_search_challenge = true
+
+  # Blocks fabricated legacy-Chrome UAs before the challenge, cutting billed
+  # challenge responses by roughly a third at 2026-07 flood volumes.
+  enable_search_legacy_ua_block = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -35,4 +35,8 @@ module "stage_wc_org_cloudfront_distribution" {
   # Trialling the /search challenge here before prod (see the search-challenge
   # rule in the module for why this is high-risk).
   enable_search_challenge = true
+
+  # Trialling the legacy-Chrome UA block here before prod: cuts billed
+  # challenge responses by blocking provably fabricated user agents first.
+  enable_search_legacy_ua_block = true
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -73,6 +73,12 @@ variable "enable_search_challenge" {
   description = "Serve a silent JS challenge to token-less clients on /search* pages. High-risk: prove on stage before enabling elsewhere."
 }
 
+variable "enable_search_legacy_ua_block" {
+  type        = bool
+  default     = false
+  description = "Block /search* requests claiming a Chrome major version below 100, ahead of the billed search challenge. Prove on stage before enabling elsewhere."
+}
+
 variable "enable_waf_logging" {
   type        = bool
   default     = false

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -516,6 +516,67 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // Blocks /search requests whose User-Agent claims a Chrome major version
+  // below 100 (released 2017-2022). Chrome auto-updates, so genuinely old
+  // majors are vanishingly rare, and the 2026-07 flood rotates these strings
+  // (a flat distribution across v60-77, with impossible pairings like Vista +
+  // Chrome 76) and never attempts the JS challenge. Blocking here is free;
+  // every challenge response the rule below serves instead is billed.
+  dynamic "rule" {
+    for_each = var.enable_search_legacy_ua_block ? [1] : []
+    content {
+      name     = "search-legacy-ua-block"
+      priority = 10
+
+      action {
+        block {}
+      }
+
+      statement {
+        and_statement {
+          statement {
+            byte_match_statement {
+              positional_constraint = "STARTS_WITH"
+              search_string         = "/search"
+
+              field_to_match {
+                uri_path {}
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
+          }
+
+          statement {
+            regex_match_statement {
+              regex_string = "Chrome/[0-9]{1,2}\\."
+
+              field_to_match {
+                single_header {
+                  name = "user-agent"
+                }
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "search-legacy-ua-block-${var.namespace}"
+      }
+    }
+  }
+
   // Silently challenges clients that don't run JavaScript on /search pages,
   // which are expensive to render and effectively uncacheable. Real browsers
   // solve the challenge invisibly. Only the works search page is
@@ -528,7 +589,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 10
+      priority = 11
 
       action {
         challenge {}
@@ -560,7 +621,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 11
+    priority = 12
 
     action {
       block {
@@ -595,7 +656,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 12
+    priority = 13
 
     action {
       block {
@@ -635,7 +696,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 13
+    priority = 14
 
     action {
       block {
@@ -672,7 +733,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 14
+    priority = 15
 
     action {
       block {}
@@ -694,7 +755,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 15
+    priority = 16
 
     action {
       block {}
@@ -732,7 +793,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 16
+    priority = 17
 
     override_action {
       none {}
@@ -755,7 +816,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 17
+    priority = 18
 
     override_action {
       none {}
@@ -778,7 +839,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 18
+    priority = 19
 
     override_action {
       none {}
@@ -800,7 +861,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 19
+    priority = 20
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to


### PR DESCRIPTION
This is a cost optimisation following on from #13242 and #13246 (both now merged).

## What does this change?

Since the /search JS challenge went live on prod, roughly a third of billed challenge responses have gone to clients whose User-Agent claims a Chrome major version between 60 and 99. These are unambiguously fabricated: Chrome auto-updates so 2017-2019 majors are vanishingly rare in 2026; the logs contain impossible pairings such as Windows Vista with Chrome 76 (a build that never existed for that OS); the version distribution is flat across v60-77 (166-180 hits each over six hours), which is the signature of a rotation list rather than a real population; and none of these clients ever attempt the challenge JS.

Each challenge response served costs $0.40 per 1,000. A `block {}` action is free. So this adds a `search-legacy-ua-block` rule at priority 10, ahead of the challenge, matching `uri_path STARTS_WITH /search` AND User-Agent regex `Chrome/[0-9]{1,2}\.` (claimed major 99 or below). The challenge moves to priority 11 and the rules previously at 11-19 renumber to 12-20, the same manoeuvre #13242 used to free its slot.

- `cache/modules/wc_org_cloudfront/waf.tf`: the new rule (dynamic, gated on `enable_search_legacy_ua_block`, default false) and the renumbering.
- `cache/modules/wc_org_cloudfront/variables.tf`: the new variable.
- `cache/cloudfront_stage.tf`, `cache/cloudfront_prod.tf`: enabled for both environments.

At 2026-07 flood volumes (~5,000 challenges/hour) this saves roughly $480/month. CloudWatch metric: `search-legacy-ua-block-{stage,prod}`.

## How to test

Applied to stage first via targeted `terraform apply` and verified:

- `curl` with a Chrome/76 or Chrome/99 UA to `/search/works?query=test` returns `403`; Chrome/100 and Chrome/126 return `202` with the challenge action, so the regex boundary is exact.
- Chrome/76 on the homepage returns `200` — the rule is scoped to /search only.
- A full Playwright browser session (fresh Chromium, modern UA: search, paginate, work page, back, image search in a second tab) passes with zero HTTP responses of 400 or above.

The same checks were then run against prod after its targeted apply.

## Have we considered potential risks?

- False positives get a hard 403 rather than an invisible auto-solving challenge. The floor is set at claimed Chrome <100 specifically because nothing real ships those tokens today; notably Samsung Internet pins older Chrome versions in its UA, but those are all well above 100 (currently 110-130s). Raising the floor toward <120 would roughly double the saving but needs a Samsung Internet carve-out, and is deliberately not done here.
- The rule only sees /search page URLs, so it inherits the challenge's asset-safety scoping; a blocked request would have been challenged (and gone unanswered) anyway.
- If the flood adapts to modern UA strings the rule saves less; the challenge behind it still holds the line either way.
