### PR TITLE
Extend the search challenge token immunity to four hours

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -42,6 +42,10 @@ module "prod_wc_org_cloudfront_distribution" {
   # Blocks fabricated legacy-Chrome UAs before the challenge, cutting billed
   # challenge responses by roughly a third at 2026-07 flood volumes.
   enable_search_legacy_ua_block = true
+
+  # Real users get re-challenged (and re-billed) once per window instead of
+  # every 5 minutes.
+  search_challenge_immunity_seconds = 14400
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -36,11 +36,11 @@ module "stage_wc_org_cloudfront_distribution" {
   # rule in the module for why this is high-risk).
   enable_search_challenge = true
 
-  # Trialling the legacy-Chrome UA block here before prod: cuts billed
-  # challenge responses by blocking provably fabricated user agents first.
+  # Cuts billed challenge responses by blocking provably fabricated user
+  # agents first. Matches prod.
   enable_search_legacy_ua_block = true
 
-  # Trialling a longer challenge-token immunity here before prod: real users
-  # get re-challenged (and billed) once per window instead of every 5 minutes.
+  # Real users get re-challenged (and billed) once per window instead of
+  # every 5 minutes. Matches prod.
   search_challenge_immunity_seconds = 14400
 }

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -39,4 +39,8 @@ module "stage_wc_org_cloudfront_distribution" {
   # Trialling the legacy-Chrome UA block here before prod: cuts billed
   # challenge responses by blocking provably fabricated user agents first.
   enable_search_legacy_ua_block = true
+
+  # Trialling a longer challenge-token immunity here before prod: real users
+  # get re-challenged (and billed) once per window instead of every 5 minutes.
+  search_challenge_immunity_seconds = 14400
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -83,6 +83,11 @@ variable "search_challenge_immunity_seconds" {
   type        = number
   default     = 300
   description = "How long a solved search challenge token stays valid. 300 is the AWS default; longer values mean fewer billed re-challenges for real users but a longer window for a token-holding client before it is re-challenged."
+
+  validation {
+    condition     = var.search_challenge_immunity_seconds >= 60 && var.search_challenge_immunity_seconds <= 259200 && floor(var.search_challenge_immunity_seconds) == var.search_challenge_immunity_seconds
+    error_message = "search_challenge_immunity_seconds must be a whole number of seconds between 60 and 259200 (3 days), the range AWS WAF accepts."
+  }
 }
 
 variable "enable_waf_logging" {

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -79,6 +79,12 @@ variable "enable_search_legacy_ua_block" {
   description = "Block /search* requests claiming a Chrome major version below 100, ahead of the billed search challenge. Prove on stage before enabling elsewhere."
 }
 
+variable "search_challenge_immunity_seconds" {
+  type        = number
+  default     = 300
+  description = "How long a solved search challenge token stays valid. 300 is the AWS default; longer values mean fewer billed re-challenges for real users but a longer window for a token-holding client before it is re-challenged."
+}
+
 variable "enable_waf_logging" {
   type        = bool
   default     = false

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -595,6 +595,12 @@ resource "aws_wafv2_web_acl" "wc_org" {
         challenge {}
       }
 
+      challenge_config {
+        immunity_time_property {
+          immunity_time = var.search_challenge_immunity_seconds
+        }
+      }
+
       statement {
         byte_match_statement {
           positional_constraint = "STARTS_WITH"


### PR DESCRIPTION
Stacked on #13247 — please review and merge that first.

## What does this change?

The search challenge's token immunity uses the AWS default of 300 seconds, so a real user browsing search results is re-challenged (and the challenge re-billed at $0.40 per 1,000) every five minutes. This makes the immunity configurable per environment and sets it to four hours on stage and prod:

- `cache/modules/wc_org_cloudfront/variables.tf`: new `search_challenge_immunity_seconds` variable, defaulting to 300 (the AWS default) so environments that don't set it are unchanged.
- `cache/modules/wc_org_cloudfront/waf.tf`: a rule-level `challenge_config` on the `search-challenge` rule wiring the variable in.
- `cache/cloudfront_stage.tf`, `cache/cloudfront_prod.tf`: set to 14400.

At current traffic this trims roughly $50-100/month of challenge spend and, more usefully, means a real user solves the challenge at most once per four-hour window instead of every five minutes.

## How to test

Applied to stage first via targeted `terraform apply`, then verified behaviourally in headless Chromium: a cold navigation to `/search/works` received the challenge (202, auto-solved), an immediate second navigation passed without a challenge, and a third navigation at t+390s — past the old 300 second boundary — also passed without a challenge. Under the previous config that third navigation would have been re-challenged. The token-less curl (202 + challenge action), legacy-UA block (403) and homepage (200) checks all still pass.

The same apply-and-verify sequence was then run against prod.

## Have we considered potential risks?

A client that solves one challenge holds access to /search for four hours instead of five minutes. Two mitigations: the geo and blanket rate limits behind the challenge still apply to every token-holding client, and the challenge exists to stop clients that cannot execute JS at all — anything that can solve it once could equally re-solve it every five minutes, so the shorter window buys little real protection while billing real users repeatedly. The variable makes it a one-line change to tighten again if the threat model changes.
