### PR TITLE
Point Bot Control at the /search flood with targeted inspection

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -50,6 +50,11 @@ module "prod_wc_org_cloudfront_distribution" {
   # Targeted Bot Control, scoped to /search with TGT_ rules counting only:
   # labels the flood for analysis without changing enforcement.
   bot_control_inspection_level = "TARGETED"
+
+  # Real browsers always send Accept-Language; the clients that omit it are
+  # crawlers and headless bots that never solve the challenge they would
+  # otherwise be served (46% of challenged traffic when measured).
+  enable_search_missing_lang_block = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -46,6 +46,10 @@ module "prod_wc_org_cloudfront_distribution" {
   # Real users get re-challenged (and re-billed) once per window instead of
   # every 5 minutes.
   search_challenge_immunity_seconds = 14400
+
+  # Targeted Bot Control, scoped to /search with TGT_ rules counting only:
+  # labels the flood for analysis without changing enforcement.
+  bot_control_inspection_level = "TARGETED"
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -55,6 +55,10 @@ module "prod_wc_org_cloudfront_distribution" {
   # crawlers and headless bots that never solve the challenge they would
   # otherwise be served (46% of challenged traffic when measured).
   enable_search_missing_lang_block = true
+
+  # Blocks fabricated-browser fraud on the indexable catalogue pages while
+  # leaving honest crawlers and user-triggered AI agents untouched.
+  enable_works_fabricated_ua_block = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -47,4 +47,9 @@ module "stage_wc_org_cloudfront_distribution" {
   # Targeted Bot Control, scoped to /search with TGT_ rules counting only.
   # Matches prod.
   bot_control_inspection_level = "TARGETED"
+
+  # Trialling the missing-Accept-Language block here before prod: real
+  # browsers always send the header; the clients that omit it are crawlers
+  # and bots that never solve the challenge they would otherwise be served.
+  enable_search_missing_lang_block = true
 }

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -44,7 +44,7 @@ module "stage_wc_org_cloudfront_distribution" {
   # every 5 minutes. Matches prod.
   search_challenge_immunity_seconds = 14400
 
-  # Trialling targeted Bot Control (scoped to /search, TGT_ rules counting
-  # only) here before prod.
+  # Targeted Bot Control, scoped to /search with TGT_ rules counting only.
+  # Matches prod.
   bot_control_inspection_level = "TARGETED"
 }

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -52,4 +52,9 @@ module "stage_wc_org_cloudfront_distribution" {
   # browsers always send the header; the clients that omit it are crawlers
   # and bots that never solve the challenge they would otherwise be served.
   enable_search_missing_lang_block = true
+
+  # Trialling the works/images/concepts fabricated-browser block here before
+  # prod: blocks fraud that poses as a browser without self-identifying,
+  # while leaving honest crawlers and user-triggered AI agents untouched.
+  enable_works_fabricated_ua_block = true
 }

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -43,4 +43,8 @@ module "stage_wc_org_cloudfront_distribution" {
   # Trialling a longer challenge-token immunity here before prod: real users
   # get re-challenged (and billed) once per window instead of every 5 minutes.
   search_challenge_immunity_seconds = 14400
+
+  # Trialling targeted Bot Control (scoped to /search, TGT_ rules counting
+  # only) here before prod.
+  bot_control_inspection_level = "TARGETED"
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -79,6 +79,12 @@ variable "enable_search_legacy_ua_block" {
   description = "Block /search* requests claiming a Chrome major version below 100, ahead of the billed search challenge. Prove on stage before enabling elsewhere."
 }
 
+variable "enable_search_missing_lang_block" {
+  type        = bool
+  default     = false
+  description = "Block /search* requests with no Accept-Language header, ahead of the billed search challenge. Real browsers always send it. Prove on stage before enabling elsewhere."
+}
+
 variable "bot_control_inspection_level" {
   type        = string
   default     = "COMMON"

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -85,6 +85,12 @@ variable "enable_search_missing_lang_block" {
   description = "Block /search* requests with no Accept-Language header, ahead of the billed search challenge. Real browsers always send it. Prove on stage before enabling elsewhere."
 }
 
+variable "enable_works_fabricated_ua_block" {
+  type        = bool
+  default     = false
+  description = "Block fabricated-browser traffic on /works*, /images* and /concepts*: a browser-posing User-Agent with no Accept-Language and no self-identification. Exempts honest crawlers, link-preview fetchers and user-triggered AI agents. Prove on stage before enabling elsewhere."
+}
+
 variable "bot_control_inspection_level" {
   type        = string
   default     = "COMMON"

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -79,6 +79,17 @@ variable "enable_search_legacy_ua_block" {
   description = "Block /search* requests claiming a Chrome major version below 100, ahead of the billed search challenge. Prove on stage before enabling elsewhere."
 }
 
+variable "bot_control_inspection_level" {
+  type        = string
+  default     = "COMMON"
+  description = "Bot Control inspection level. TARGETED also scopes the rule group down to /search* (it is billed at 10x per request analysed) and starts its TGT_ rules in count mode."
+
+  validation {
+    condition     = contains(["COMMON", "TARGETED"], var.bot_control_inspection_level)
+    error_message = "bot_control_inspection_level must be COMMON or TARGETED."
+  }
+}
+
 variable "search_challenge_immunity_seconds" {
   type        = number
   default     = 300

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -589,7 +589,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 11
+      priority = 12
 
       action {
         challenge {}
@@ -627,7 +627,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 12
+    priority = 13
 
     action {
       block {
@@ -662,7 +662,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 13
+    priority = 14
 
     action {
       block {
@@ -702,7 +702,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 14
+    priority = 15
 
     action {
       block {
@@ -739,7 +739,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 15
+    priority = 16
 
     action {
       block {}
@@ -761,7 +761,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 16
+    priority = 17
 
     action {
       block {}
@@ -799,7 +799,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 17
+    priority = 18
 
     override_action {
       none {}
@@ -822,7 +822,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 18
+    priority = 19
 
     override_action {
       none {}
@@ -845,7 +845,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 19
+    priority = 20
 
     override_action {
       none {}
@@ -867,7 +867,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 20
+    priority = 11
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -78,12 +78,26 @@ locals {
   // traffic for analysis without acting. Remove a rule from this list to
   // enable its default action once the label soak supports it.
   bot_control_targeted_count_list = [
+    // CAUTION: names must exactly match the rules in the pinned rule set
+    // version (aws wafv2 describe-managed-rule-group); an override for a
+    // name that does not exist is silently ignored and the real rule runs
+    // with its default action (Captcha or Block for several of these).
     "TGT_VolumetricIpTokenAbsent",
     "TGT_VolumetricSession",
+    "TGT_VolumetricSessionMaximum",
     "TGT_SignalBrowserAutomationExtension",
     "TGT_SignalAutomatedBrowser",
     "TGT_SignalBrowserInconsistency",
-    "TGT_TokenReuseIp",
+    "TGT_TokenAbsent",
+    "TGT_TokenReuseIpLow",
+    "TGT_TokenReuseIpMedium",
+    "TGT_TokenReuseIpHigh",
+    "TGT_TokenReuseCountryLow",
+    "TGT_TokenReuseCountryMedium",
+    "TGT_TokenReuseCountryHigh",
+    "TGT_TokenReuseAsnLow",
+    "TGT_TokenReuseAsnMedium",
+    "TGT_TokenReuseAsnHigh",
     "TGT_ML_CoordinatedActivityLow",
     "TGT_ML_CoordinatedActivityMedium",
     "TGT_ML_CoordinatedActivityHigh",

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -677,6 +677,125 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // Blocks fabricated-browser traffic on the works, images and concepts
+  // pages, which unlike /search are indexable content with no challenge
+  // behind them. The signal is a request that poses as a mainstream browser
+  // (Chrome/Safari/Firefox/Edge version token) but sends no Accept-Language
+  // and carries no self-identification (no "+http" URL and no "compatible;"
+  // token). Real browsers always send Accept-Language; honest bots always
+  // self-identify, so this exempts every declared crawler, link-preview
+  // fetcher and user-triggered AI agent (measured 2026-07-08) and blocks only
+  // the fraud fleet. Crawler-vs-agent policy for honest bots is deliberately
+  // left to robots.txt and separate rules; this rule takes no side on it.
+  dynamic "rule" {
+    for_each = var.enable_works_fabricated_ua_block ? [1] : []
+    content {
+      name     = "works-fabricated-ua-block"
+      priority = 12
+
+      action {
+        block {}
+      }
+
+      statement {
+        and_statement {
+          statement {
+            or_statement {
+              dynamic "statement" {
+                for_each = ["/works", "/images", "/concepts"]
+                content {
+                  byte_match_statement {
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = statement.value
+
+                    field_to_match {
+                      uri_path {}
+                    }
+
+                    text_transformation {
+                      priority = 0
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          # Poses as a mainstream browser.
+          statement {
+            regex_match_statement {
+              regex_string = "(Chrome|CriOS|Firefox|FxiOS|Edg|Version)/[0-9]"
+
+              field_to_match {
+                single_header {
+                  name = "user-agent"
+                }
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
+          }
+
+          # No Accept-Language: real browsers always send it.
+          statement {
+            not_statement {
+              statement {
+                size_constraint_statement {
+                  comparison_operator = "GT"
+                  size                = 0
+
+                  field_to_match {
+                    single_header {
+                      name = "accept-language"
+                    }
+                  }
+
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                }
+              }
+            }
+          }
+
+          # No self-identification: honest bots carry a "+http" contact URL or
+          # a "compatible;" token; modern real browsers carry neither.
+          statement {
+            not_statement {
+              statement {
+                regex_match_statement {
+                  regex_string = "(\\+https?://|compatible;)"
+
+                  field_to_match {
+                    single_header {
+                      name = "user-agent"
+                    }
+                  }
+
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "works-fabricated-ua-block-${var.namespace}"
+      }
+    }
+  }
+
   // Silently challenges clients that don't run JavaScript on /search pages,
   // which are expensive to render and effectively uncacheable. Real browsers
   // solve the challenge invisibly. Only the works search page is
@@ -689,7 +808,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 13
+      priority = 14
 
       action {
         challenge {}
@@ -727,7 +846,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 14
+    priority = 15
 
     action {
       block {
@@ -762,7 +881,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 15
+    priority = 16
 
     action {
       block {
@@ -802,7 +921,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 16
+    priority = 17
 
     action {
       block {
@@ -839,7 +958,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 17
+    priority = 18
 
     action {
       block {}
@@ -861,7 +980,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 18
+    priority = 19
 
     action {
       block {}
@@ -899,7 +1018,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 19
+    priority = 20
 
     override_action {
       none {}
@@ -922,7 +1041,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 20
+    priority = 21
 
     override_action {
       none {}
@@ -945,7 +1064,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 21
+    priority = 22
 
     override_action {
       none {}
@@ -967,7 +1086,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 12
+    priority = 13
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -1043,7 +1162,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // /search once the group is scoped down for targeted inspection.
   rule {
     name     = "seo-user-agent-block"
-    priority = 22
+    priority = 23
 
     action {
       block {}

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -598,6 +598,71 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // Blocks /search requests with no Accept-Language header, ahead of the
+  // billed challenge. Every real browser sends Accept-Language on every page
+  // navigation; the clients that omit it are crawlers and bots that cannot
+  // solve the challenge anyway (measured 2026-07-08: 46% of challenged
+  // traffic). Blocking here is free; each challenge response is billed.
+  dynamic "rule" {
+    for_each = var.enable_search_missing_lang_block ? [1] : []
+    content {
+      name     = "search-missing-lang-block"
+      priority = 11
+
+      action {
+        block {}
+      }
+
+      statement {
+        and_statement {
+          statement {
+            byte_match_statement {
+              positional_constraint = "STARTS_WITH"
+              search_string         = "/search"
+
+              field_to_match {
+                uri_path {}
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
+          }
+
+          statement {
+            not_statement {
+              statement {
+                size_constraint_statement {
+                  comparison_operator = "GT"
+                  size                = 0
+
+                  field_to_match {
+                    single_header {
+                      name = "accept-language"
+                    }
+                  }
+
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "search-missing-lang-block-${var.namespace}"
+      }
+    }
+  }
+
   // Silently challenges clients that don't run JavaScript on /search pages,
   // which are expensive to render and effectively uncacheable. Real browsers
   // solve the challenge invisibly. Only the works search page is
@@ -610,7 +675,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 12
+      priority = 13
 
       action {
         challenge {}
@@ -648,7 +713,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 13
+    priority = 14
 
     action {
       block {
@@ -683,7 +748,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 14
+    priority = 15
 
     action {
       block {
@@ -723,7 +788,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 15
+    priority = 16
 
     action {
       block {
@@ -760,7 +825,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 16
+    priority = 17
 
     action {
       block {}
@@ -782,7 +847,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 17
+    priority = 18
 
     action {
       block {}
@@ -820,7 +885,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 18
+    priority = 19
 
     override_action {
       none {}
@@ -843,7 +908,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 19
+    priority = 20
 
     override_action {
       none {}
@@ -866,7 +931,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 20
+    priority = 21
 
     override_action {
       none {}
@@ -888,7 +953,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 11
+    priority = 12
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -964,7 +1029,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // /search once the group is scoped down for targeted inspection.
   rule {
     name     = "seo-user-agent-block"
-    priority = 21
+    priority = 22
 
     action {
       block {}

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -72,13 +72,34 @@ locals {
     "SignalAutomatedBrowser",    // No substantial traffic
     "SignalKnownBotDataCenter",  // Known bot data centres include "good" bots such as Updown
     "SignalNonBrowserUserAgent", // High risk for breaking scripts and other application services
-    // These are for targeted Bot Control, which we don't use
-    // "TGT_VolumetricIpTokenAbsent",
-    // "TGT_VolumetricSession",
-    // "TGT_SignalAutomatedBrowser",
-    // "TGT_SignalBrowserInconsistency",
-    // "TGT_TokenReuseIp",
-    // "TGT_ML_CoordinatedActivityMedium and TGT_ML_CoordinatedActivityHigh"
+  ]
+
+  // The targeted-inspection rules start in count mode: they label /search
+  // traffic for analysis without acting. Remove a rule from this list to
+  // enable its default action once the label soak supports it.
+  bot_control_targeted_count_list = [
+    "TGT_VolumetricIpTokenAbsent",
+    "TGT_VolumetricSession",
+    "TGT_SignalBrowserAutomationExtension",
+    "TGT_SignalAutomatedBrowser",
+    "TGT_SignalBrowserInconsistency",
+    "TGT_TokenReuseIp",
+    "TGT_ML_CoordinatedActivityLow",
+    "TGT_ML_CoordinatedActivityMedium",
+    "TGT_ML_CoordinatedActivityHigh",
+  ]
+
+  // Unverified SEO crawlers blocked unconditionally, site-wide. This
+  // replaces Bot Control's CategorySeo coverage, which only sees /search
+  // once the group is scoped down for targeted inspection. Measured
+  // 2026-07-07: SemrushBot was ~85% of CategorySeo's blocks.
+  seo_block_user_agents = [
+    "SemrushBot",
+    "DotBot",
+    "MJ12bot",
+    "MojeekBot",
+    "TinEye",
+    "yacybot",
   ]
 }
 
@@ -889,12 +910,39 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
         managed_rule_group_configs {
           aws_managed_rules_bot_control_rule_set {
-            inspection_level = "COMMON"
+            inspection_level        = var.bot_control_inspection_level
+            enable_machine_learning = var.bot_control_inspection_level == "TARGETED"
+          }
+        }
+
+        // TARGETED is billed per request analysed at 10x the COMMON rate, so
+        // it is only affordable scoped down to the /search pages it exists to
+        // protect. The seo-user-agent-block rule replaces the group's
+        // site-wide CategorySeo coverage while this scope-down is active.
+        dynamic "scope_down_statement" {
+          for_each = var.bot_control_inspection_level == "TARGETED" ? [1] : []
+          content {
+            byte_match_statement {
+              positional_constraint = "STARTS_WITH"
+              search_string         = "/search"
+
+              field_to_match {
+                uri_path {}
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
           }
         }
 
         dynamic "rule_action_override" {
-          for_each = local.bot_control_rule_no_block_list
+          for_each = concat(
+            local.bot_control_rule_no_block_list,
+            var.bot_control_inspection_level == "TARGETED" ? local.bot_control_targeted_count_list : [],
+          )
           content {
             name = rule_action_override.value
             action_to_use {
@@ -909,6 +957,40 @@ resource "aws_wafv2_web_acl" "wc_org" {
       cloudwatch_metrics_enabled = true
       sampled_requests_enabled   = true
       metric_name                = "weco-cloudfront-acl-bot-control-${var.namespace}"
+    }
+  }
+
+  // Replaces Bot Control's site-wide CategorySeo blocking, which only covers
+  // /search once the group is scoped down for targeted inspection.
+  rule {
+    name     = "seo-user-agent-block"
+    priority = 21
+
+    action {
+      block {}
+    }
+
+    statement {
+      regex_match_statement {
+        regex_string = join("|", local.seo_block_user_agents)
+
+        field_to_match {
+          single_header {
+            name = "user-agent"
+          }
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "seo-user-agent-block-${var.namespace}"
     }
   }
 

--- a/playwright/url-checker/check-url.ts
+++ b/playwright/url-checker/check-url.ts
@@ -72,7 +72,10 @@ const safePageCloser =
 export const urlChecker =
   (browser: Browser) =>
   async (url: string, expectedStatus: number): Promise<Result> => {
-    const context = await browser.newContext();
+    // A locale makes headless Chromium send Accept-Language like a real
+    // browser. Without it the WAF /search and /works fabricated-traffic
+    // blocks 403 the checker when it runs from a non-allowlisted IP.
+    const context = await browser.newContext({ locale: 'en-GB' });
     const page = await context.newPage();
     const failures: Failure[] = [];
 


### PR DESCRIPTION
Follows #13247 and #13248 (both merged). #13256, the Accept-Language block, has been folded into this branch, so this PR now carries both changes and lands everything currently applied to stage and prod; the Accept-Language change's full description lives on #13256.

## What does this change?

Three commits that point the existing Bot Control subscription at the /search flood.

1. **Move the bot-control rule group from priority 20 to 11**, between the legacy-UA block and the challenge. At the bottom of the ACL it never saw token-less /search traffic (the challenge terminated those requests first), so its detection was blind to exactly the traffic that matters. The signal rules stay overridden to count, so this changed observability, not enforcement.
2. **Flip the group to TARGETED inspection, scoped down to /search, with machine learning enabled**, gated on a new `bot_control_inspection_level` module variable (default COMMON, so an environment that does not set it is unchanged). TARGETED is billed at $10 per million requests analysed, 10x the COMMON rate, which is why the scope-down accompanies the flip: at /search volumes this costs ~$30-40/month instead of ~$950 site-wide. Every `TGT_*` rule starts overridden to count, so the tier labels traffic for analysis without acting; enabling a rule's real action is a deliberate follow-up once the label soak supports it.
3. **A new site-wide `seo-user-agent-block` rule** (priority 21) replacing the group's CategorySeo coverage, which only sees /search once the scope-down is active. The list is what CategorySeo measurably blocks today: SemrushBot (~85% of its blocks), DotBot, MJ12bot, MojeekBot, TinEye, yacybot — current behaviour replicated, not new policy.

## Why

The recon (commit 1) produced a clear negative result: COMMON-level Bot Control cannot see the flood. In a sample of challenged requests, `known_bot_data_center` matched zero (the botnet is residential) and `automated_browser` matched one (the headless Chrome/118 fleet is a real Chromium sending real client hints, invisible to passive analysis). TARGETED's active interrogation, volumetric token analysis and coordinated-activity ML are the remaining detection tools for this traffic class, and they are also the ready-made response if bots ever start solving the challenge.

## How to test

Applied to stage first, then prod, each via a reviewed targeted `terraform apply`. Verified on both after each apply:

- Token-less modern-UA request to `/search/works` still returns `202` with the challenge action; a Chrome/76 UA still gets `403` from the legacy-UA block; the homepage still returns `200`.
- SemrushBot's UA now gets `403` site-wide (homepage and /works checked) from the replacement rule, which within its first half hour on prod had blocked 9 requests.
- A full Playwright browser session passes with zero HTTP responses of 400 or above.
- Bot Control labels appear on challenged requests' log records (the point of commit 1). `TGT_*` labels were still zero ~90 minutes post-enable, consistent with the documented ML training and volumetric analysis warm-up of up to 24 hours; the label soak is ongoing.

## Have we considered potential risks?

- The group's few unoverridden blocking categories (chiefly CategorySeo) now act at priority 11 instead of 20, i.e. before the rate limits rather than after. For terminating block actions the outcome is identical; only which CloudWatch counter increments changes.
- Scoping the group to /search removes CategorySeo coverage elsewhere; the replacement rule was derived from measurement of what CategorySeo actually blocks and was verified live before the scope-down reached prod.
- All TGT_ rules count only. Nothing in this PR changes what any real user or bot experiences on /search.
- Cost: ~$30-40/month for targeted analysis at /search volumes, against the ~$40/day the challenge currently costs; if the labels justify enabling TGT blocks later, they convert billed challenges to free blocks.