### PR TITLE
Block /search requests without an Accept-Language header

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -50,6 +50,11 @@ module "prod_wc_org_cloudfront_distribution" {
   # Targeted Bot Control, scoped to /search with TGT_ rules counting only:
   # labels the flood for analysis without changing enforcement.
   bot_control_inspection_level = "TARGETED"
+
+  # Real browsers always send Accept-Language; the clients that omit it are
+  # crawlers and headless bots that never solve the challenge they would
+  # otherwise be served (46% of challenged traffic when measured).
+  enable_search_missing_lang_block = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -47,4 +47,9 @@ module "stage_wc_org_cloudfront_distribution" {
   # Targeted Bot Control, scoped to /search with TGT_ rules counting only.
   # Matches prod.
   bot_control_inspection_level = "TARGETED"
+
+  # Trialling the missing-Accept-Language block here before prod: real
+  # browsers always send the header; the clients that omit it are crawlers
+  # and bots that never solve the challenge they would otherwise be served.
+  enable_search_missing_lang_block = true
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -79,6 +79,12 @@ variable "enable_search_legacy_ua_block" {
   description = "Block /search* requests claiming a Chrome major version below 100, ahead of the billed search challenge. Prove on stage before enabling elsewhere."
 }
 
+variable "enable_search_missing_lang_block" {
+  type        = bool
+  default     = false
+  description = "Block /search* requests with no Accept-Language header, ahead of the billed search challenge. Real browsers always send it. Prove on stage before enabling elsewhere."
+}
+
 variable "bot_control_inspection_level" {
   type        = string
   default     = "COMMON"

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -598,6 +598,71 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // Blocks /search requests with no Accept-Language header, ahead of the
+  // billed challenge. Every real browser sends Accept-Language on every page
+  // navigation; the clients that omit it are crawlers and bots that cannot
+  // solve the challenge anyway (measured 2026-07-08: 46% of challenged
+  // traffic). Blocking here is free; each challenge response is billed.
+  dynamic "rule" {
+    for_each = var.enable_search_missing_lang_block ? [1] : []
+    content {
+      name     = "search-missing-lang-block"
+      priority = 11
+
+      action {
+        block {}
+      }
+
+      statement {
+        and_statement {
+          statement {
+            byte_match_statement {
+              positional_constraint = "STARTS_WITH"
+              search_string         = "/search"
+
+              field_to_match {
+                uri_path {}
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
+          }
+
+          statement {
+            not_statement {
+              statement {
+                size_constraint_statement {
+                  comparison_operator = "GT"
+                  size                = 0
+
+                  field_to_match {
+                    single_header {
+                      name = "accept-language"
+                    }
+                  }
+
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "search-missing-lang-block-${var.namespace}"
+      }
+    }
+  }
+
   // Silently challenges clients that don't run JavaScript on /search pages,
   // which are expensive to render and effectively uncacheable. Real browsers
   // solve the challenge invisibly. Only the works search page is
@@ -610,7 +675,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 12
+      priority = 13
 
       action {
         challenge {}
@@ -648,7 +713,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 13
+    priority = 14
 
     action {
       block {
@@ -683,7 +748,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 14
+    priority = 15
 
     action {
       block {
@@ -723,7 +788,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 15
+    priority = 16
 
     action {
       block {
@@ -760,7 +825,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 16
+    priority = 17
 
     action {
       block {}
@@ -782,7 +847,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 17
+    priority = 18
 
     action {
       block {}
@@ -820,7 +885,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 18
+    priority = 19
 
     override_action {
       none {}
@@ -843,7 +908,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 19
+    priority = 20
 
     override_action {
       none {}
@@ -866,7 +931,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 20
+    priority = 21
 
     override_action {
       none {}
@@ -888,7 +953,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 11
+    priority = 12
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -964,7 +1029,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // /search once the group is scoped down for targeted inspection.
   rule {
     name     = "seo-user-agent-block"
-    priority = 21
+    priority = 22
 
     action {
       block {}


### PR DESCRIPTION
Stacked on #13250 — please review and merge that first.

## What does this change?

Blocks /search requests that carry no Accept-Language header, at priority 11, ahead of the billed challenge. Every headed browser (Chrome, Firefox, Safari, Samsung Internet, Tor) sends Accept-Language on every page navigation; the clients that omit it are crawlers and headless automation. When measured over four hours of the flood, 46% of challenged traffic lacked the header: meta-externalagent (~2,270/hour), fabricated modern-Chrome user agents (~750/hour), and the declared AI crawlers (PerplexityBot, ClaudeBot, SleepBot, Amzn-SearchBot, YandexBot). None of these solve the challenge they are served, so each one is a billed 202 that a free 403 now replaces — worth roughly $30/day at the 8 July flood volume.

- `cache/modules/wc_org_cloudfront/waf.tf`: the new `search-missing-lang-block` rule (dynamic, gated on `enable_search_missing_lang_block`, default false), matching `uri_path STARTS_WITH /search` AND NOT(Accept-Language present and non-empty). Rules 11-21 renumber to 12-22.
- `cache/modules/wc_org_cloudfront/variables.tf`: the new variable.
- `cache/cloudfront_stage.tf`, `cache/cloudfront_prod.tf`: enabled for both environments.

An unplanned bonus discovered during verification: default headless Chromium sends no Accept-Language unless the automation sets a locale. Our own Playwright harness was 403'd by the rule on stage until given `locale: 'en-GB'`. That means the rule also blocks bare headless automation before the challenge — including, potentially, the challenge-solving fleet that appeared against prod at 03:00 UTC on 8 July. Whether ChallengesAttempted collapses on prod is being watched by the soak checks.

## How to test

Applied to stage first, then prod, each via a reviewed targeted `terraform apply`, and verified after each:

- `/search/works?query=test` with no Accept-Language returns `403`; with `Accept-Language: en-GB` it returns `202` with the challenge action, so the challenge boundary is unchanged for real browsers. An empty `Accept-Language:` header is also blocked.
- The homepage without Accept-Language still returns `200` — the rule is scoped to /search only.
- The legacy-Chrome UA block and SEO crawler block still behave.
- A full Playwright browser session (with a locale, as real browsers have) passes with zero HTTP responses of 400 or above.

## Have we considered potential risks?

- Human false positives: headed browsers universally send the header, including privacy browsers (Tor normalises to en-US rather than omitting). The known omitters are automation frameworks without a locale configured.
- Our own monitoring: the recurring soak checks were updated in the same change window — the challenge-boundary curl now sends Accept-Language, and a separate curl asserts the 403 for the missing-header case. LogicMonitor synthetics are IP-allowlisted above this rule.
- Crawler visibility: the affected crawlers were already unable to reach /search content through the challenge; this changes their response code from 202 to 403, not their access.
- Adaptation: trivially bypassed by adding the header, like the UA floor before it. Each such ratchet is one line for us and pushes the attacker toward the fully-instrumented browser path where the challenge and Bot Control's targeted rules operate.
