### PR TITLE
Block fabricated-browser fraud on works/images/concepts pages

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -55,6 +55,10 @@ module "prod_wc_org_cloudfront_distribution" {
   # crawlers and headless bots that never solve the challenge they would
   # otherwise be served (46% of challenged traffic when measured).
   enable_search_missing_lang_block = true
+
+  # Blocks fabricated-browser fraud on the indexable catalogue pages while
+  # leaving honest crawlers and user-triggered AI agents untouched.
+  enable_works_fabricated_ua_block = true
 }
 
 data "aws_lambda_function" "versioned_edge_lambda_request" {

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -52,4 +52,9 @@ module "stage_wc_org_cloudfront_distribution" {
   # browsers always send the header; the clients that omit it are crawlers
   # and bots that never solve the challenge they would otherwise be served.
   enable_search_missing_lang_block = true
+
+  # Trialling the works/images/concepts fabricated-browser block here before
+  # prod: blocks fraud that poses as a browser without self-identifying,
+  # while leaving honest crawlers and user-triggered AI agents untouched.
+  enable_works_fabricated_ua_block = true
 }

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -85,6 +85,12 @@ variable "enable_search_missing_lang_block" {
   description = "Block /search* requests with no Accept-Language header, ahead of the billed search challenge. Real browsers always send it. Prove on stage before enabling elsewhere."
 }
 
+variable "enable_works_fabricated_ua_block" {
+  type        = bool
+  default     = false
+  description = "Block fabricated-browser traffic on /works*, /images* and /concepts*: a browser-posing User-Agent with no Accept-Language and no self-identification. Exempts honest crawlers, link-preview fetchers and user-triggered AI agents. Prove on stage before enabling elsewhere."
+}
+
 variable "bot_control_inspection_level" {
   type        = string
   default     = "COMMON"

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -677,6 +677,125 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // Blocks fabricated-browser traffic on the works, images and concepts
+  // pages, which unlike /search are indexable content with no challenge
+  // behind them. The signal is a request that poses as a mainstream browser
+  // (Chrome/Safari/Firefox/Edge version token) but sends no Accept-Language
+  // and carries no self-identification (no "+http" URL and no "compatible;"
+  // token). Real browsers always send Accept-Language; honest bots always
+  // self-identify, so this exempts every declared crawler, link-preview
+  // fetcher and user-triggered AI agent (measured 2026-07-08) and blocks only
+  // the fraud fleet. Crawler-vs-agent policy for honest bots is deliberately
+  // left to robots.txt and separate rules; this rule takes no side on it.
+  dynamic "rule" {
+    for_each = var.enable_works_fabricated_ua_block ? [1] : []
+    content {
+      name     = "works-fabricated-ua-block"
+      priority = 12
+
+      action {
+        block {}
+      }
+
+      statement {
+        and_statement {
+          statement {
+            or_statement {
+              dynamic "statement" {
+                for_each = ["/works", "/images", "/concepts"]
+                content {
+                  byte_match_statement {
+                    positional_constraint = "STARTS_WITH"
+                    search_string         = statement.value
+
+                    field_to_match {
+                      uri_path {}
+                    }
+
+                    text_transformation {
+                      priority = 0
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          # Poses as a mainstream browser.
+          statement {
+            regex_match_statement {
+              regex_string = "(Chrome|CriOS|Firefox|FxiOS|Edg|Version)/[0-9]"
+
+              field_to_match {
+                single_header {
+                  name = "user-agent"
+                }
+              }
+
+              text_transformation {
+                priority = 0
+                type     = "NONE"
+              }
+            }
+          }
+
+          # No Accept-Language: real browsers always send it.
+          statement {
+            not_statement {
+              statement {
+                size_constraint_statement {
+                  comparison_operator = "GT"
+                  size                = 0
+
+                  field_to_match {
+                    single_header {
+                      name = "accept-language"
+                    }
+                  }
+
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                }
+              }
+            }
+          }
+
+          # No self-identification: honest bots carry a "+http" contact URL or
+          # a "compatible;" token; modern real browsers carry neither.
+          statement {
+            not_statement {
+              statement {
+                regex_match_statement {
+                  regex_string = "(\\+https?://|compatible;)"
+
+                  field_to_match {
+                    single_header {
+                      name = "user-agent"
+                    }
+                  }
+
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "works-fabricated-ua-block-${var.namespace}"
+      }
+    }
+  }
+
   // Silently challenges clients that don't run JavaScript on /search pages,
   // which are expensive to render and effectively uncacheable. Real browsers
   // solve the challenge invisibly. Only the works search page is
@@ -689,7 +808,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 13
+      priority = 14
 
       action {
         challenge {}
@@ -727,7 +846,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 14
+    priority = 15
 
     action {
       block {
@@ -762,7 +881,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 15
+    priority = 16
 
     action {
       block {
@@ -802,7 +921,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 16
+    priority = 17
 
     action {
       block {
@@ -839,7 +958,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 17
+    priority = 18
 
     action {
       block {}
@@ -861,7 +980,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 18
+    priority = 19
 
     action {
       block {}
@@ -899,7 +1018,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 19
+    priority = 20
 
     override_action {
       none {}
@@ -922,7 +1041,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 20
+    priority = 21
 
     override_action {
       none {}
@@ -945,7 +1064,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 21
+    priority = 22
 
     override_action {
       none {}
@@ -967,7 +1086,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 12
+    priority = 13
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -1043,7 +1162,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // /search once the group is scoped down for targeted inspection.
   rule {
     name     = "seo-user-agent-block"
-    priority = 22
+    priority = 23
 
     action {
       block {}

--- a/playwright/url-checker/check-url.ts
+++ b/playwright/url-checker/check-url.ts
@@ -72,7 +72,10 @@ const safePageCloser =
 export const urlChecker =
   (browser: Browser) =>
   async (url: string, expectedStatus: number): Promise<Result> => {
-    const context = await browser.newContext();
+    // A locale makes headless Chromium send Accept-Language like a real
+    // browser. Without it the WAF /search and /works fabricated-traffic
+    // blocks 403 the checker when it runs from a non-allowlisted IP.
+    const context = await browser.newContext({ locale: 'en-GB' });
     const page = await context.newPage();
     const failures: Failure[] = [];
 


### PR DESCRIPTION
Stacked on the Bot Control PR (#13250) — please review and merge that first.

## What does this change?

Extends fraud blocking to the indexable catalogue pages (`/works*`, `/images*`, `/concepts*`), which unlike `/search` carry no challenge behind them. A new `works-fabricated-ua-block` rule at priority 12 blocks a request only when all of the following hold:

- the path is under `/works`, `/images` or `/concepts`, and
- the User-Agent poses as a mainstream browser (a `Chrome`/`CriOS`/`Firefox`/`FxiOS`/`Edg`/`Version` version token), and
- there is no `Accept-Language` header, and
- there is no self-identification (no `+http(s)://` contact URL and no `compatible;` token).

Real browsers always send `Accept-Language`; honest bots always self-identify. So this exempts every declared crawler, link-preview fetcher and user-triggered AI agent, and blocks only the fabricated fleet. Rules 12–22 renumber to 13–23.

- `cache/modules/wc_org_cloudfront/waf.tf`: the new rule (dynamic, gated on `enable_works_fabricated_ua_block`, default false) and the renumbering.
- `cache/modules/wc_org_cloudfront/variables.tf`: the new variable.
- `cache/cloudfront_stage.tf`, `cache/cloudfront_prod.tf`: enabled for both environments.

## Why this shape

Measurement on 2026-07-08 showed the AI bots wrap their identity inside a browser UA string (e.g. `Mozilla/5.0 ... compatible; ClaudeBot/1.0; +https://...`), so a naive "browser UA with no Accept-Language" rule would block honest crawlers and agents. The self-identification exclusion is what keeps them safe: `ChatGPT-User` sends `Accept-Language`, `Claude-User` uses a non-browser UA, and the crawlers all carry a `+http` URL or `compatible;` token. The fabricated fleet carries none of these. Crawler-vs-agent policy for honest bots (whether to block AI training crawlers on these pages) is deliberately out of scope here and left to robots.txt plus separate rules.

## How to test

Applied to stage first, then prod, each via a reviewed targeted `terraform apply`. Verified on both with a truth table:

- **Blocked (403):** fabricated Chrome UA with no Accept-Language, on `/works`, `/images` and `/concepts`.
- **Passes (200):** a real browser (Chrome + Accept-Language) renders a valid work page.
- **Passes (untouched):** `ClaudeBot`, `GPTBot`, `ChatGPT-User`, `Claude-User`, `facebookexternalhit`, `Twitterbot`, `Slackbot`, `bingbot`.
- **Unaffected:** the `/search` challenge boundary (202) and the homepage (200).
- A full Playwright browser session, which navigates to a work page with a locale-set browser, passes with zero HTTP responses of 400 or above.

## Have we considered potential risks?

- Human false positives: real browsers universally send `Accept-Language`. The only honest clients this can catch are services that drive a bare headless browser with no locale and no self-identification — the class that is genuinely indistinguishable from the fraud fleet, and the same class already blocked on `/search`.
- Our own tooling: the e2e Playwright suite and the pa11y accessibility action drive these paths with no-locale headless browsers, but both egress via IPs allowlisted at priorities 1 and 5, which terminate before this rule; verified they already pass against the live `/search` block. The manual `url-checker` diagnostic should get a `locale` set so it keeps working from any IP (follow-up).
- Adaptation: trivially bypassed by adding the header or a fake self-id token, like the UA floor before it — but on these paths a bypasser only reaches the existing rate limits, geo-captchas and CloudFront cache, so the blast radius of a bypass is low.
