### PR TITLE
use Google Docs viewer on mobile/tablet in kiosk mode

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
@@ -48,8 +48,14 @@ const IIIFItemPdf: FunctionComponent<Props> = ({
 
   // Mobile kiosk: use Google Docs viewer to fix iOS iframe scrolling issues
   if (isMobileOrTabletDevice && isKiosk) {
-    const googleDocsViewerSrc = `https://docs.google.com/viewer?url=${encodeURIComponent(src)}&embedded=true`;
-    return <IframePdfViewer title={displayLabel} src={googleDocsViewerSrc} />;
+    const googleDocsViewerSrc = `https://docs.google.com/gview?embedded=true&url=${encodeURIComponent(src)}`;
+    return (
+      <IframePdfViewer
+        title={displayLabel}
+        src={googleDocsViewerSrc}
+        referrerPolicy="no-referrer"
+      />
+    );
   }
 
   // Desktop: use direct PDF iframe

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.Pdf.tsx
@@ -33,20 +33,27 @@ const IIIFItemPdf: FunctionComponent<Props> = ({
   const substituteTitle = 'unknown title';
   const displayLabel = getFileLabel(label, substituteTitle);
   const { isKiosk } = useKiosk();
-  return (
-    <>
-      {isMobileOrTabletDevice && !isKiosk ? (
-        <IIIFItemDownload
-          src={src}
-          label={label}
-          fileSize={fileSize}
-          format={format}
-        />
-      ) : (
-        <IframePdfViewer title={displayLabel} src={src} />
-      )}
-    </>
-  );
+
+  // Mobile non-kiosk: show download link
+  if (isMobileOrTabletDevice && !isKiosk) {
+    return (
+      <IIIFItemDownload
+        src={src}
+        label={label}
+        fileSize={fileSize}
+        format={format}
+      />
+    );
+  }
+
+  // Mobile kiosk: use Google Docs viewer to fix iOS iframe scrolling issues
+  if (isMobileOrTabletDevice && isKiosk) {
+    const googleDocsViewerSrc = `https://docs.google.com/viewer?url=${encodeURIComponent(src)}&embedded=true`;
+    return <IframePdfViewer title={displayLabel} src={googleDocsViewerSrc} />;
+  }
+
+  // Desktop: use direct PDF iframe
+  return <IframePdfViewer title={displayLabel} src={src} />;
 };
 
 export default IIIFItemPdf;


### PR DESCRIPTION
- For #13259

## What does this change?

Uses the google docs viewer to render PDFs on mobile and tablet devices, when in kiosk mode

## How to test

- use browserstack to test on an iPad (or we merge and test on the iPad)
- enable a T&R [kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- visit an [item page with a pdf](https://www-dev.wellcomecollection.org/works/m8xw26qs/items)
- should be able to see the pdf and scroll through the pages

## Have we considered potential risks?
None really, it only changes for kiosk mode and is currently broken
File Size & Restriction Ceilings: the target files generally must be under 25MB.