### PR TITLE
Unskip IIIF rotation test

### DIFF
--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -115,10 +115,20 @@ export function convertIiifImageUri(
   } else {
     const imageIdentifier = originalUri.split(iiifImageUri)[1].split('/', 2)[0];
 
+    // Extract rotation from original URL if present
+    // IIIF Image API format: {identifier}/{region}/{size}/{rotation}/{quality}.{format}
+    // https://iiif.io/api/image/3.0/#21-image-request-uri-syntax
+    // For well-formed IIIF URLs, after splitting by base URL and then by '/':
+    //   urlParts[0] = identifier, [1] = region, [2] = size, [3] = rotation, [4] = quality.format
+    const urlParts = originalUri.split(iiifImageUri)[1].split('/');
+    const rotationPart = urlParts[3]; // Assumes well-formed IIIF URL with all required parameters
+    const rotation = rotationPart ? parseInt(rotationPart, 10) : undefined;
+
     const size = sizeByHeight ? `,${requiredSize}` : `${requiredSize},`;
     const params = {
       size: requiredSize === 'full' ? 'full' : `${size}`,
       format: determineFinalFormat(originalUri),
+      ...(rotation !== undefined && !isNaN(rotation) && { rotation }),
     };
     return iiifImageTemplate(`${iiifImageUri}${imageIdentifier}`)(params);
   }

--- a/content/webapp/test/utils/convert-image-uri.test.ts
+++ b/content/webapp/test/utils/convert-image-uri.test.ts
@@ -116,4 +116,14 @@ describe('convertImageUri for IIIF images', () => {
       'https://iiif.wellcomecollection.org/thumbs/b30598977_0001.jp2/full/!300,300/0/default.jpg'
     );
   });
+
+  it('preserves rotation when resizing', () => {
+    const result = convertIiifImageUri(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/640,/90/default.jpg',
+      800
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/800%2C/90/default.jpg'
+    );
+  });
 });

--- a/content/webapp/test/utils/convert-image-uri.test.ts
+++ b/content/webapp/test/utils/convert-image-uri.test.ts
@@ -126,4 +126,37 @@ describe('convertImageUri for IIIF images', () => {
       'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/800%2C/90/default.jpg'
     );
   });
+
+  it('handles rotation of 0 by including it', () => {
+    const result = convertIiifImageUri(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/640,/0/default.jpg',
+      800
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/800%2C/0/default.jpg'
+    );
+  });
+
+  it('uses default rotation when URL has incomplete path segments', () => {
+    // URL missing rotation and quality.format parts
+    const result = convertIiifImageUri(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/640,',
+      800
+    );
+    // Should not break, should use default rotation of 0
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/800%2C/0/default.jpg'
+    );
+  });
+
+  it('preserves rotation through multiple conversions', () => {
+    const result1 = convertIiifImageUri(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/640,/90/default.jpg',
+      800
+    );
+    const result2 = convertIiifImageUri(result1, 1000);
+    expect(result2).toEqual(
+      'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/1000%2C/90/default.jpg'
+    );
+  });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
@@ -67,6 +67,14 @@ const IIIFViewerImage = (
   const { isFullSupportBrowser } = useAppContext();
   const [tryLoadingSmallerImg, setTryLoadingSmallerImg] = useState(true);
   const [hasLoaded, setHasLoaded] = useState(false);
+
+  // Reset tryLoadingSmallerImg when src changes so each new image
+  // gets a chance to try the smaller size conversion if it errors
+  useEffect(() => {
+    setTryLoadingSmallerImg(true);
+    setHasLoaded(false);
+  }, [src]);
+
   return (
     <>
       {!hasLoaded && isFullSupportBrowser && <LL $lighten={true} />}

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -164,11 +164,11 @@ test('(9) | The image should rotate', async ({ page, context }) => {
   await page.getByRole('button', { name: 'Rotate' }).click();
   const currentIndex = await page.getByTestId('active-index').textContent();
 
-  expect(page.getByTestId(`image-${Number(currentIndex) - 1}`)).toHaveAttribute(
-    'src',
-    // If the image url contains /90/default.jpg then the image is rotated 90 degrees
-    'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/640%2C/90/default.jpg'
-  );
+  // Check that the image URL contains /90/default.jpg to verify rotation
+  // Using regex with toHaveAttribute provides auto-retry assertions
+  await expect(
+    page.getByTestId(`image-${Number(currentIndex) - 1}`)
+  ).toHaveAttribute('src', /\/90\/default\.jpg/);
 });
 
 test('(10) | The volumes should be browsable', async ({ page, context }) => {

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -159,9 +159,7 @@ test('(8) | Licence information should be available', async ({
   await expect(page.getByText('Credit:')).toBeVisible();
 });
 
-// Please unskip once this is fixed by Digirati
-// https://wellcome.slack.com/archives/CBT40CMKQ/p1779797736981459
-test.skip('(9) | The image should rotate', async ({ page, context }) => {
+test('(9) | The image should rotate', async ({ page, context }) => {
   await itemWithSearchAndStructures(context, page);
   await page.getByRole('button', { name: 'Rotate' }).click();
   const currentIndex = await page.getByTestId('active-index').textContent();

--- a/playwright/test/view-items.test.ts
+++ b/playwright/test/view-items.test.ts
@@ -163,11 +163,12 @@ test('(9) | The image should rotate', async ({ page, context }) => {
   await itemWithSearchAndStructures(context, page);
   await page.getByRole('button', { name: 'Rotate' }).click();
   const currentIndex = await page.getByTestId('active-index').textContent();
-  const currentImageSrc = await page
-    .getByTestId(`image-${Number(currentIndex) - 1}`)
-    .getAttribute('src');
-  // If the image url contains /90/default.jpg then the image is rotated 90 degrees
-  expect(currentImageSrc).toContain('/90/default.jpg');
+
+  expect(page.getByTestId(`image-${Number(currentIndex) - 1}`)).toHaveAttribute(
+    'src',
+    // If the image url contains /90/default.jpg then the image is rotated 90 degrees
+    'https://iiif.wellcomecollection.org/image/b29338062_0001.jp2/full/640%2C/90/default.jpg'
+  );
 });
 
 test('(10) | The volumes should be browsable', async ({ page, context }) => {


### PR DESCRIPTION
# Unskip IIIF rotation test

- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13109

## What does this change?

Donald said their work was done (see ticket for details), so we should be ok to unskip this test.

While working on this, we discovered and fixed two bugs related to image rotation:

**Bug 1: Rotation not preserved when resizing**  
When an image failed to load due to IIIF server size restrictions, the error handler would fetch a smaller version but was not preserving the rotation parameter from the original URL, causing rotated images to reset to 0°.

**Bug 2: State not resetting between rotations**  
The `tryLoadingSmallerImg` state in `IIIFViewerImage.tsx` was never resetting between image changes. This meant that if an image errored and fell back to a smaller size on the first rotation, subsequent rotations back to that same angle would skip the size fallback and display a broken image.

These bugs were only visible in Playwright automated testing:

> [!NOTE]
> The rotation bug was more visible in Playwright than manual browser testing because Playwright runs with a clean browser context (no cached images), makes rapid automated clicks, and likely triggers the IIIF server's size limit checks more consistently. In regular Chrome browsing, cached images and slower human interaction patterns mean the error path is less frequently triggered, making the rotation preservation bug harder to spot.

Here's me recording it in the Playwright environment with manual testing. First rotation doesn't work (shows the smaller version with lost rotation) and the fifth one then shows the broken image.

https://github.com/user-attachments/assets/840300b2-0560-436b-9508-6b88661eeddd



### Changes made:

1. **Unskipped the rotation test** in `playwright/test/view-items.test.ts`
2. **Improved the test assertion** to use a regex pattern with `toHaveAttribute`, which provides auto-retry behaviour but still checks the URL contains `/90/default.jpg`
3. **Fixed rotation preservation bug** in `common/utils/convert-image-uri.ts`:
   - The `convertIiifImageUri` function now extracts the rotation parameter from the original IIIF URL
   - When resizing images (e.g., due to size limit errors), the rotation (90°, 180°, 270°) is preserved in the new URL
   - Added detailed comments explaining the IIIF Image API URL structure
4. **Fixed state reset bug** in `content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx`:
   - Added a `useEffect` hook that resets both `tryLoadingSmallerImg` and `hasLoaded` whenever the `src` prop changes
   - Ensures each new image gets a fresh attempt at the size conversion fallback if needed
5. **Added unit tests** in `content/webapp/test/utils/convert-image-uri.test.ts` to verify:
   - Rotation is preserved when resizing images
   - Rotation of 0 degrees is handled correctly
   - Malformed URLs without rotation default gracefully
   - Rotation persists through multiple conversion operations

## How to test

All tests should pass.

## Have we considered potential risks?

The Playwright test could start failing again down the line if there are issues with the IIIF service, but we can always re-skip it if needed.

The rotation preservation and state reset fixes are defensive - they only apply rotation when present in the original URL, handle edge cases (missing/invalid values) gracefully, and follow standard React patterns for resetting state on prop changes.