### PR TITLE
IIIF Viewer Refactor Tests phase E

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.test.tsx
@@ -107,7 +107,7 @@ describe('IIIFItem type dispatch', () => {
     expect(screen.getByRole('link', { name: /download/i })).toBeInTheDocument();
   });
 
-  it('renders a download for each original file when there are several', () => {
+  it('renders a distinct download link for each original file when there are several', () => {
     renderItem({
       item: {
         id: 'https://example.com/placeholder',
@@ -129,7 +129,11 @@ describe('IIIFItem type dispatch', () => {
       }),
     });
 
-    expect(screen.getAllByRole('link', { name: /download/i })).toHaveLength(2);
+    const downloadLinks = screen.getAllByRole('link', { name: /download/i });
+    expect(downloadLinks.map(link => link.getAttribute('href'))).toEqual([
+      'https://example.com/file-1.docx',
+      'https://example.com/file-2.docx',
+    ]);
   });
 
   it('renders the PDF open/download control for a Text item', () => {

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.test.tsx
@@ -88,42 +88,48 @@ describe('IIIFItem restricted access', () => {
 
 describe('IIIFItem type dispatch', () => {
   it('renders a download for a born-digital image (canvas with original files)', () => {
-    // The born-digital branch in IIIFItem maps canvas.original without a React
-    // `key` on the wrapper, which logs a "unique key" warning. The production
-    // fix is deferred to the refactor, so suppress only that specific message
-    // here; any other console.error still surfaces.
-    const originalConsoleError = console.error.bind(console);
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation((...args) => {
-        const message = typeof args[0] === 'string' ? args[0] : '';
-        if (message.includes('unique "key" prop')) return;
-        originalConsoleError(...args);
-      });
+    renderItem({
+      item: {
+        id: 'https://example.com/placeholder',
+        type: 'Image',
+      } as IIIFItemProps,
+      canvas: createMockCanvas({
+        original: [
+          {
+            id: 'https://example.com/file.docx',
+            format: 'application/msword',
+            behavior: 'original',
+          },
+        ] as never,
+      }),
+    });
 
-    try {
-      renderItem({
-        item: {
-          id: 'https://example.com/placeholder',
-          type: 'Image',
-        } as IIIFItemProps,
-        canvas: createMockCanvas({
-          original: [
-            {
-              id: 'https://example.com/file.docx',
-              format: 'application/msword',
-              behavior: 'original',
-            },
-          ] as never,
-        }),
-      });
+    expect(screen.getByRole('link', { name: /download/i })).toBeInTheDocument();
+  });
 
-      expect(
-        screen.getByRole('link', { name: /download/i })
-      ).toBeInTheDocument();
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
+  it('renders a download for each original file when there are several', () => {
+    renderItem({
+      item: {
+        id: 'https://example.com/placeholder',
+        type: 'Image',
+      } as IIIFItemProps,
+      canvas: createMockCanvas({
+        original: [
+          {
+            id: 'https://example.com/file-1.docx',
+            format: 'application/msword',
+            behavior: 'original',
+          },
+          {
+            id: 'https://example.com/file-2.docx',
+            format: 'application/msword',
+            behavior: 'original',
+          },
+        ] as never,
+      }),
+    });
+
+    expect(screen.getAllByRole('link', { name: /download/i })).toHaveLength(2);
   });
 
   it('renders the PDF open/download control for a Text item', () => {

--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -504,6 +504,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
               return (
                 original.id && (
                   <IIIFItemWrapper
+                    key={original.id}
                     shouldShowItem={shouldShowItem}
                     className="download-wrapper"
                     isRestricted={isRestricted}
@@ -511,7 +512,6 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
                     externalAccessService={adjustedExternalAccessService}
                   >
                     <IIIFItemDownload
-                      key={original.id}
                       src={original.id}
                       label={itemLabel}
                       fileSize={getFileSize(canvas)}


### PR DESCRIPTION
- For #12984 

## What does this change?

Closes out the issue's second Definition-of-Done item ("we consider our test suite solid... all tests pass") with a full-repo verification pass, plus a small source fix that verification surfaced.

- **Verification (no test changes):** ran the full content test suite together (not just per-phase), and a full-repo `yarn tsc` / `yarn lint`. All green — 65 suites / 432 tests, clean typecheck across all 8 workspace projects, clean lint.
- **Bug fix:** `IIIFItem/index.tsx`'s born-digital branch (`canvas.original.map(...)`) had `key` on the inner `IIIFItemDownload` rather than the outer `IIIFItemWrapper` actually returned by the map callback, so React couldn't identify list items and warned on every render. Moved `key={original.id}` to the `IIIFItemWrapper`.
- **Test changes:** removed the `console.error` suppression from the born-digital test in `IIIFItem.test.tsx` (confirmed no longer needed — a clean run shows no warning), and added a new test rendering **two** original files, asserting two distinct download links. A single item wouldn't have caught a regression of the missing-key bug; this one would.

Notes for reviewers
- This was flagged in Phase C review as a pre-existing bug and deliberately deferred (to keep that PR test-only). Fixing it now, since Phase E is the natural point to close out surfaced issues before moving to sign-off.
- The fix is a one-line move of `key`, not a behavioural change — download rendering is unchanged.

## How to test

1. `yarn workspace @weco/content test IIIFItem` — 7 tests pass, no console output
2. `yarn test:content` — full suite passes (432 tests)
3. `yarn tsc` and `yarn lint`

## Have we considered potential risks?

Everything below is what Phases A–D of automated testing **cannot** reach — chiefly real login/cookie state and visual/interaction checks. It complements, not duplicates, the automated suite (432 tests, full repo `tsc`/`lint` clean).

### Authentication × sample-works matrix
The RFC's sample works are the ready-made list. For each work, check across all three auth states.

**Auth states:** Logged out · Logged in (regular) · Logged in (restricted-access role)

| Work | ID | Focus | Dev URL |
|---|---|---|---|
| Multi-canvas image | `a55dcp3h` | Grid view, canvas nav, thumbnails | `/works/a55dcp3h/items` |
| Single canvas image | `b5kqccbb` | No grid/nav controls | `/works/b5kqccbb/images?id=a22tjkrd&resultPosition=2` |
| Archive item | `a222zvge` | Tree nav, breadcrumbs, canvas-from-tree | `/works/a222zvge` |
| PDF work | `ndx5vuhy` | PDF rendering, download options | `/works/ndx5vuhy/items?shouldScrollToCanvas=true` |
| Mixed media (born digital) | `dn9jwck6` | Multiple media types, nav between them | `/works/dn9jwck6/items?canvas=20` |
| Regular video (unrestricted) | `a9w3qy3j` | Player accessible to all | `/works/a9w3qy3j/items` |
| Content advisory (clickthrough) | `pnud3fzb` | Modal appears for all users | `/works/pnud3fzb/items` |
| Restricted whole item | `rp9jnamu` | Blocked for logged-out/regular; accessible for restricted role | `/works/rp9jnamu/items` |
| Restricted audio | `esd6gs3s` | Player only for restricted role | `/works/esd6gs3s/items` |
| Restricted video | `zsgh5y3z` | Player only for restricted role | `/works/zsgh5y3z/items` |
| Restricted born digital | `my6bzerr` | Mixed media only for restricted role | `/works/my6bzerr/items` |

**Key thing to verify per the RFC:** *"the 'logged in (restricted)' state only affects access, not which component renders — the viewer always renders regardless of auth state."* This is exactly the assumption `useIIIFProbeService`/`useShowClickthrough` encode in Phase D's tests — manual testing should confirm the real cookie/probe round-trip matches that assumption in practice.

### Edge cases (manual, cross-referenced against automated coverage)
- **No manifest** — error displays gracefully, no JS errors. *Not automated.*
- **JS disabled** — `NoScriptImage` renders, OCR accessible via view-source, page not broken. *Not automated* (progressive-enhancement path).
- **Empty canvases** — *partially automated*: Phase B covers `hasNonImagesOrOriginals`/`getFileTypeLabel` with empty/undefined canvases at the function level; the full-page empty-manifest render is still manual.
- **Missing image services** — fallback rendering, no broken images. *Not automated* at the component level.
- **Invalid canvas number** (`?canvas=999`) — redirects or errors, no crash. *Not automated.*
- **Canvas without `imageServiceId`** — renders, zoom hidden, no console errors. *Not automated.*

### Browser matrix (manual only, unchanged by this work)
Chrome/Edge, Firefox, Safari macOS, Mobile Safari iOS, Mobile Chrome Android — core nav, zoom, fullscreen, downloads, touch gestures per RFC wording.

### Performance (manual only)
Large manifest (100+ canvases) loads within ~3s with smooth nav/thumbnail loading.

### Explicitly deferred (not applicable to this issue)
- "Comparison Testing (Legacy vs Refactored)" and React DevTools Profiler before/after — these require the refactor's feature flag to exist, so they belong to the implementation phases (RFC 06–13), not this characterisation issue.

### Known automated-test gaps (cross-reference, for completeness)
- `useIIIFProbeService` retry/fallback path (non-200 × 5 → falls back to true) — untested; fake-timers fix identified but not added.
- Untested pure utils: `groupRanges`, the auth-transformer layer, metadata/label helpers.
- `Infinity`/`NaN` console noise from react-window in `IIIFViewer.test.tsx` — cosmetic, jsdom-only artefact, left as-is.