### PR TITLE
Make jest-dom matchers available globally in TypeScript

### DIFF
--- a/config/jest-dom.d.ts
+++ b/config/jest-dom.d.ts
@@ -1,0 +1,4 @@
+// This file makes @testing-library/jest-dom matchers available globally
+// in all test files without requiring explicit imports.
+// The library is imported in common/test/setupTests.ts which runs before all tests.
+import '@testing-library/jest-dom';

--- a/config/tsconfig-base.json
+++ b/config/tsconfig-base.json
@@ -16,5 +16,5 @@
     "target": "es6"
   },
   "exclude": ["/**/node_modules"],
-  "include": ["/**/*.ts", "/**/*.tsx", "global.d.ts", "png.d.ts"]
+  "include": ["/**/*.ts", "/**/*.tsx", "global.d.ts", "png.d.ts", "jest-dom.d.ts"]
 }

--- a/content/webapp/views/components/CardGrid/CardGrid.test.tsx
+++ b/content/webapp/views/components/CardGrid/CardGrid.test.tsx
@@ -3,7 +3,6 @@ import { placeHolderImage } from '@weco/content/services/prismic/transformers/im
 import { MultiContent } from '@weco/content/types/multi-content';
 
 import CardGrid from '.';
-import '@testing-library/jest-dom';
 
 describe('CardGrid', () => {
   // This could be moved into fixture directory if used in more places


### PR DESCRIPTION
## What does this change?

**Problem:**
TypeScript and VSCode don't recognise `@testing-library/jest-dom` matchers in test files, showing type errors on assertions like `toHaveTextContent`, `toBeInTheDocument`, etc. While the matchers work at runtime (the library is imported in `common/test/setupTests.ts` for content webapp and `identity/webapp/test/jest-setup.ts` for identity), TypeScript can't see the extended matcher types without an explicit import in each test file.

This creates a poor developer experience with red squiggly lines throughout test files and forces developers to add `import '@testing-library/jest-dom'` to every test file just for type checking, even though the runtime import is already handled globally.

**Why this change is needed:**
- Removes visual noise and false errors in test files
- Prevents developers from adding redundant imports just to satisfy TypeScript
- Improves consistency across the codebase
- Makes the global setup actually work as intended for both runtime and types

**How it solves it:**
Creates a dedicated type declaration file (`config/jest-dom.d.ts`) that imports the jest-dom types globally. This file is included in the base TypeScript config so all test files automatically have access to the matcher types without needing individual imports. The runtime behaviour is unchanged - setup files still import the library to actually extend Jest's matchers.

**Changes:**
- Created `config/jest-dom.d.ts` - Type declaration that makes jest-dom matchers available globally
- Updated `config/tsconfig-base.json` - Added `jest-dom.d.ts` to the include array
- Removed redundant import from `content/webapp/views/components/CardGrid/CardGrid.test.tsx` (was only there for types)

**Note on alternatives:**
Other approaches were considered (adding to `types` in tsconfig, using triple-slash directives, etc.) but this solution is explicit, doesn't pollute other type declarations, and doesn't interfere with TypeScript's default type inclusion behaviour.

## How to test

**Before this change:**
Opening a test file like `content/webapp/views/components/CardGrid/CardGrid.test.tsx` would show TypeScript errors on lines using jest-dom matchers (e.g., `expect(element).toHaveTextContent('text')`).

**After this change:**
1. Open `content/webapp/test/fixtures/iiif/render.test.tsx` - no TypeScript errors should appear. **you might need to restart VSCode to see this**.
2. Hover over `.toHaveTextContent` in the test assertions - VSCode should show the full type definition
3. Try removing an import of `'@testing-library/jest-dom'` from a test file - no errors should appear
4. Run `yarn test` from root - all tests should pass as before (runtime behaviour unchanged)

## Have we considered potential risks?

**Very low risk.** This is purely a TypeScript configuration change for development time.
