### PR TITLE
Add 'Explore more' link to tenderness-and-rage exhibition

### DIFF
--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -2,6 +2,7 @@ import * as prismic from '@prismicio/client';
 import { SliceZone } from '@prismicio/react';
 import styled from 'styled-components';
 
+import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { ExhibitionsDocumentDataOnwardJourneysSlice } from '@weco/common/prismicio-types';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 import {
@@ -28,6 +29,7 @@ const ExhibitionCollectionsContent = ({
   onwardJourneys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>;
   isTendernessAndRageExhibition: boolean;
 }) => {
+  const { isTendernessAndRageKiosk } = useKiosk();
   const { verticalVideos } = useFeatureFlags();
 
   const shouldDisplayCardListings = onwardJourneys.some(
@@ -74,7 +76,7 @@ const ExhibitionCollectionsContent = ({
         }}
       />
 
-      {isTendernessAndRageExhibition && (
+      {isTendernessAndRageExhibition && isTendernessAndRageKiosk && (
         <ContaineredLayout gridSizes={gridSize12()}>
           <Space
             $v={{

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -4,9 +4,13 @@ import styled from 'styled-components';
 
 import { ExhibitionsDocumentDataOnwardJourneysSlice } from '@weco/common/prismicio-types';
 import { useFeatureFlags } from '@weco/common/server-data/Context';
-import { gridSize12 } from '@weco/common/views/components/Layout';
+import {
+  ContaineredLayout,
+  gridSize12,
+} from '@weco/common/views/components/Layout';
 import Space from '@weco/common/views/components/styled/Space';
 import { components } from '@weco/common/views/slices';
+import MoreLink from '@weco/content/views/components/MoreLink';
 
 export const Wrapper = styled(Space).attrs({
   $v: { size: 'xl', properties: ['padding-top', 'padding-bottom'] },
@@ -16,9 +20,13 @@ export const Wrapper = styled(Space).attrs({
 `;
 
 const ExhibitionCollectionsContent = ({
+  exhibitionUid,
   onwardJourneys,
+  isTendernessAndRageExhibition,
 }: {
+  exhibitionUid: string;
   onwardJourneys: prismic.SliceZone<ExhibitionsDocumentDataOnwardJourneysSlice>;
+  isTendernessAndRageExhibition: boolean;
 }) => {
   const { verticalVideos } = useFeatureFlags();
 
@@ -65,6 +73,27 @@ const ExhibitionCollectionsContent = ({
           itemsHaveTransparentBackground: true,
         }}
       />
+
+      {isTendernessAndRageExhibition && (
+        <ContaineredLayout gridSizes={gridSize12()}>
+          <Space
+            $v={{
+              size: 'xl',
+              properties: ['padding-top'],
+            }}
+          >
+            <MoreLink
+              colors={{
+                border: 'accent.green',
+                background: 'transparent',
+                text: 'accent.green',
+              }}
+              url={`/exhibitions/${exhibitionUid}/explore-more`}
+              name="Explore more"
+            />
+          </Space>
+        </ContaineredLayout>
+      )}
     </Wrapper>
   );
 };

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Collections.tsx
@@ -1,5 +1,6 @@
 import * as prismic from '@prismicio/client';
 import { SliceZone } from '@prismicio/react';
+import { useTheme } from 'styled-components';
 import styled from 'styled-components';
 
 import { useKiosk } from '@weco/common/contexts/KioskContext';
@@ -31,6 +32,7 @@ const ExhibitionCollectionsContent = ({
 }) => {
   const { isTendernessAndRageKiosk } = useKiosk();
   const { verticalVideos } = useFeatureFlags();
+  const theme = useTheme();
 
   const shouldDisplayCardListings = onwardJourneys.some(
     (slice: prismic.Slice) =>
@@ -85,11 +87,7 @@ const ExhibitionCollectionsContent = ({
             }}
           >
             <MoreLink
-              colors={{
-                border: 'accent.green',
-                background: 'transparent',
-                text: 'accent.green',
-              }}
+              colors={theme.buttonColors.greenTransparentGreen}
               url={`/exhibitions/${exhibitionUid}/explore-more`}
               name="Explore more"
             />

--- a/content/webapp/views/pages/exhibitions/exhibition/index.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/index.tsx
@@ -134,6 +134,8 @@ const ExhibitionPage: NextPage<Props> = ({
       {exhibitionAndCollection && (
         <ExhibitionCollectionsContent
           onwardJourneys={exhibition.untransformedOnwardJourneys}
+          exhibitionUid={exhibition.uid}
+          isTendernessAndRageExhibition={isTendernessAndRageExhibition}
         />
       )}
     </PageLayout>


### PR DESCRIPTION
- For #13214

## What does this change?

Adds an 'Explore more' `MoreLink` button to (only) the tenderness-and-rage exhibition page. 

## How to test

- Turn on a Tenderness and rage kiosk mode
- Scroll to the end of the tenderness and rage exhibition page
- Click the 'Explore more' button (link) and check you are taken to `/exhibitions/tenderness-and-rage/explore-more`

## Have we considered potential risks?

I didn't want to make a new toggle so used the existing kiosk mode. This removes the newsletter signup section, so the UI won't exactly match what's in the designs until we're not using this toggle (but you get the idea, and the spacing etc. won't change).
