### PR TITLE
Set automatic JSX runtime in shared Babel preset

### DIFF
--- a/common/babel.js
+++ b/common/babel.js
@@ -1,5 +1,7 @@
 module.exports = function () {
-  const presets = ['next/babel'];
+  const presets = [
+    ['next/babel', { 'preset-react': { runtime: 'automatic' } }],
+  ];
   const plugins = [
     [
       'babel-plugin-styled-components',


### PR DESCRIPTION
## What does this change?

Jest invokes `next/babel` directly (no webpack caller), so it fell back to the classic runtime and logged React's "outdated JSX transform" warning in every test that renders JSX. The production build already uses the automatic runtime via webpack; this change makes Jest match it, removing the console warnings when we run tests.

## How to test

- `yarn workspace @weco/content test:watch:fast iiif`
- no warnings about "outdated JSX transform" in the console


## Have we considered potential risks?

n/a
