### PR TITLE
IVR Type Audit (part 2)

### DIFF
--- a/content/webapp/contexts/ItemViewerContext/index.tsx
+++ b/content/webapp/contexts/ItemViewerContext/index.tsx
@@ -58,7 +58,7 @@ export type ItemViewerContextProps = {
   hasOnlyRenderableImages: boolean;
 };
 
-export const results = {
+export const results: SearchResults = {
   '@context': '',
   '@id': '',
   '@type': 'sc:AnnotationList',

--- a/content/webapp/services/iiif/types/image/v2/index.ts
+++ b/content/webapp/services/iiif/types/image/v2/index.ts
@@ -1,21 +1,33 @@
+// The info.json document for a IIIF Image API v2 image:
+// https://iiif.io/api/image/2.1/#image-information
+// @iiif/presentation-3 covers the Presentation API only: its ImageService2
+// type describes the service description embedded in a manifest (which has
+// an @type property that info.json lacks), so we define the response
+// document ourselves. Wellcome images always include their dimensions.
 export type IIIFImage = {
   '@context': 'http://iiif.io/api/image/2/context.json';
   '@id': string;
   protocol: 'http://iiif.io/api/image';
   width: number;
   height: number;
-  tiles: {
+  tiles?: {
     width: number;
-    height: number;
+    height?: number;
     scaleFactors: number[];
   }[];
-  sizes: {
+  sizes?: {
     width: number;
     height: number;
   }[];
-  profile: {
-    formats: string[];
-    qualities: string[];
-    supports: string[];
-  }[];
+  profile: (
+    | string
+    | {
+        formats?: string[];
+        qualities?: string[];
+        supports?: string[];
+        maxWidth?: number;
+        maxHeight?: number;
+        maxArea?: number;
+      }
+  )[];
 };

--- a/content/webapp/services/iiif/types/image/v2/index.ts
+++ b/content/webapp/services/iiif/types/image/v2/index.ts
@@ -1,9 +1,13 @@
-// The info.json document for a IIIF Image API v2 image:
+// Models the response from a IIIF Image API v2 info.json endpoint.
 // https://iiif.io/api/image/2.1/#image-information
-// @iiif/presentation-3 covers the Presentation API only: its ImageService2
-// type describes the service description embedded in a manifest (which has
-// an @type property that info.json lacks), so we define the response
-// document ourselves. Wellcome images always include their dimensions.
+//
+// When you fetch an image service URL with /info.json, you get technical metadata
+// about the image (dimensions, tile sizes, etc.). This is different from the brief
+// service reference that appears inside a manifest's `service` property.
+//
+// The @iiif/presentation-3 library only types the Presentation API (manifests),
+// not the Image API responses, so we define this type ourselves.
+// Wellcome images always include their dimensions.
 export type IIIFImage = {
   '@context': 'http://iiif.io/api/image/2/context.json';
   '@id': string;

--- a/content/webapp/services/iiif/types/search/v3/index.ts
+++ b/content/webapp/services/iiif/types/search/v3/index.ts
@@ -1,3 +1,8 @@
+// The IIIF Content Search response for a manifest's search service:
+// https://iiif.io/api/search/1.0/#response
+// @iiif/presentation-3 has a SearchServiceSearchResponse type, but it types
+// resource and on loosely (any) and omits the within.total and startIndex
+// properties we rely on, so we keep our own definition.
 export type SearchResults = {
   '@context': string;
   '@id': string;

--- a/content/webapp/types/manifest.ts
+++ b/content/webapp/types/manifest.ts
@@ -2,7 +2,6 @@ import type {
   ChoiceBody,
   CollectionItems,
   ContentResource,
-  InternationalString,
   Manifest,
   MetadataItem,
   Range,
@@ -30,12 +29,6 @@ export type ServiceWithMetadata = Service & {
 import type { TransformedAuthService } from '@weco/content/utils/iiif/v3';
 
 export type ThumbnailImage = { url: string; width: number };
-
-export type Original = {
-  originalFile: string | undefined;
-  label: InternationalString | null | undefined;
-  format: string | undefined;
-};
 
 export type TransformedCanvas = {
   id: string;
@@ -100,3 +93,14 @@ export type CustomSpecificationBehaviors =
 export type CustomContentResource = ContentResource & {
   behavior: 'original';
 } & { type?: string; format?: string };
+
+// Some of our ContentResources can have a type of 'Audio':
+// https://iiif.wellcomecollection.org/presentation/v3/b17276342
+// However, the IIIF Presentation API spec only has a type of 'Sound'
+// so we add 'Audio' to the type here.
+export type IIIFItemProps =
+  | (Omit<ContentResource, 'type'> & {
+      type: ContentResource['type'] | 'Audio';
+    })
+  | CustomContentResource
+  | ChoiceBody;

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -30,12 +30,12 @@ import {
   CustomContentResource,
   CustomSpecificationBehaviors,
   DownloadOption,
+  IIIFItemProps,
   ItemsStatus,
   ManifestAccessRequirement,
   ServiceWithMetadata,
   TransformedCanvas,
 } from '@weco/content/types/manifest';
-import { IIIFItemProps } from '@weco/content/views/pages/works/work/IIIFItem';
 
 import { getOriginal, getThumbnailImage } from './canvas';
 

--- a/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/IIIFItem.test.tsx
@@ -5,10 +5,10 @@ import {
   createMockCanvas,
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
-import { TransformedCanvas } from '@weco/content/types/manifest';
+import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import { TransformedAuthService } from '@weco/content/utils/iiif/v3';
 
-import IIIFItem, { IIIFItemProps } from './index';
+import IIIFItem from './index';
 
 type RenderItemArgs = {
   item: IIIFItemProps;

--- a/content/webapp/views/pages/works/work/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFItem/index.tsx
@@ -34,10 +34,7 @@ import useSkipInitialEffect from '@weco/content/hooks/useSkipInitialEffect';
 import { fetchCanvasOcr } from '@weco/content/services/iiif/fetch/canvasOcr';
 import { transformCanvasOcr } from '@weco/content/services/iiif/transformers/canvasOcr';
 import { missingAltTextMessage } from '@weco/content/services/wellcome/catalogue/works';
-import {
-  CustomContentResource,
-  TransformedCanvas,
-} from '@weco/content/types/manifest';
+import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 import { hasRestrictedItem } from '@weco/content/utils/iiif/v3';
 import {
@@ -213,16 +210,6 @@ const IIIFImage: FunctionComponent<{
   }
 };
 
-// Some of our ContentResources can have a type of 'Audio':
-// https://iiif.wellcomecollection.org/presentation/v3/b17276342
-// However, the IIIF Presentation API spec only has a type of 'Sound'
-// so we add 'Audio' to the type here.
-export type IIIFItemProps =
-  | (Omit<ContentResource, 'type'> & {
-      type: ContentResource['type'] | 'Audio';
-    })
-  | CustomContentResource
-  | ChoiceBody;
 type ItemProps = {
   canvas: TransformedCanvas;
   item: IIIFItemProps;

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFCanvasThumbnail.tsx
@@ -9,13 +9,12 @@ import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import Icon from '@weco/common/views/components/Icon';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
-import { TransformedCanvas } from '@weco/content/types/manifest';
+import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import {
   hasRestrictedItem,
   isChoiceBody,
   isPDFCanvas,
 } from '@weco/content/utils/iiif/v3';
-import { IIIFItemProps } from '@weco/content/views/pages/works/work/IIIFItem';
 
 import IIIFViewerImage from './IIIFViewerImage';
 import Padlock from './Padlock';

--- a/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/IIIFViewerImage.tsx
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
+import { IIIFImage } from '@weco/content/services/iiif/types/image/v2';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 async function getImageMax(url: string): Promise<number> {
   try {
     const infoUrl = convertRequestUriToInfoUri(url);
     const resp = await fetch(infoUrl);
-    const info: { profile?: (string | { maxWidth?: number })[] } =
-      await resp.json();
+    const info: Partial<IIIFImage> = await resp.json();
     // N.B property is called maxWidth, but it is actually the max allowed for the longest side, see https://wellcome.slack.com/archives/CBT40CMKQ/p1702897884100559
     const max =
       info.profile?.find(


### PR DESCRIPTION
- For #12982

## What does this change?

Second half of the Phase 0 type audit for the item viewer (RFC 086),
following on from #13278. Where that PR made the ItemViewer/IIIF
scope type-check under `tsc --strict`, this one is the spec-validation
and de-duplication pass the audit also called for: checking our custom
IIIF types against the official `@iiif/presentation-3` types and against
each other, removing anything unnecessary, and centralising what's left.

**Centralised `IIIFItemProps`**
- Moved from the `IIIFItem` component file into `types/manifest.ts`,
  alongside the other manifest content types. It was already being
  imported by `utils/iiif/v3` and `IIIFCanvasThumbnail`, which meant a
  utils module was importing a type from a views file — now everything
  imports it from `types/`, matching the audit's centralisation
  principle

**Removed a duplicate/dead type**
- `Original` in `types/manifest.ts` was exported but never imported
  anywhere; `TransformedCanvas.original` actually uses
  `CustomContentResource[]`. Deleted, along with the now-orphaned
  `InternationalString` import

**Corrected `IIIFImage` against the real spec**
- Its `profile` field claimed to be an array of `{formats, qualities,
  supports}` objects, but a real Image API v2 `info.json` profile mixes
  a compliance-URI string with an object that can also carry
  `maxWidth`/`maxHeight`/`maxArea` (this is exactly the field
  `IIIFViewerImage.getImageMax` reads). Fixed the type to match the
  spec, made `tiles`/`sizes` optional per spec, and pointed
  `getImageMax` at the shared type instead of the inline one-off type
  added in the previous PR

**Documented two deliberate non-matches with official types**
- `IIIFImage` isn't a duplicate of the library's `ImageService2`: that
  type describes the service description embedded in a *manifest*
  (which requires `@type`), not an Image API `info.json` response,
  which `@iiif/presentation-3` doesn't cover at all
- `SearchResults` isn't a duplicate of the library's
  `SearchServiceSearchResponse`: that type declares `resource`/`on` as
  `any` and omits `within.total`/`startIndex`, both of which we rely on
- Both now have a comment recording why we keep our own definition, so
  a future reader doesn't rediscover this from scratch

Also gave `ItemViewerContext`'s default `results` value an explicit
`SearchResults` annotation rather than relying on inference.

One item from the audit's Definition of Done is still open: whether to
add `strict` (or `noImplicitAny`) to the shared `tsconfig-base`. That's
a repo-wide decision (296/435 errors elsewhere as of this PR) rather
than something scoped to the item viewer, so I'll raise it separately
for discussion rather than bundle it here.

## How to test

- `yarn tsc` passes across all workspaces
- `npx tsc --noEmit -p content/webapp --strict 2>&1 | grep -iE "iiif|item-viewer|ItemViewerContext"` returns nothing (the viewer scope stays strict-clean)
- `yarn test:content` passes (447 tests)
- Manual check on this branch: open a digitised work with an image-only manifest, and confirm thumbnails, zoom and download links behave as on prod (exercises `getImageMax` and the `IIIFImage`-typed `info.json` parsing)

## Have we considered potential risks?

This PR is entirely type-level: relocating a type, deleting an unused
one, tightening/correcting an existing one, and adding two comments. No
production logic changes except:

- `getImageMax` now reads `info.profile` through the corrected
  `IIIFImage` type instead of an ad hoc inline type. The runtime logic
  (find the profile entry with `maxWidth`, default to 1000) is
  unchanged; only the type checking of that logic is now honest about
  `profile` entries sometimes being plain strings
- `IIIFItemProps` moved to a new module path. It's exported from
  `types/manifest.ts` now rather than the `IIIFItem` component; I
  checked there are no remaining imports from the old location

Nothing in this PR touches the runtime behaviour of manifest
transformation, canvas rendering, search, or downloads — it's the type
layer underneath.