### PR TITLE
Remove `exhibitionAndCollection` toggle

### DIFF
--- a/content/webapp/views/pages/exhibitions/exhibition/index.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/index.tsx
@@ -5,7 +5,6 @@ import {
   ExhibitionHighlightToursDocument,
   ExhibitionTextsDocument,
 } from '@weco/common/prismicio-types';
-import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { createPrismicLink } from '@weco/common/views/components/ApiToolbar';
 import { JsonLdObj } from '@weco/common/views/components/JsonLd';
@@ -50,8 +49,6 @@ const ExhibitionPage: NextPage<Props> = ({
   const [aboutThisExhibitionContent, setAboutThisExhibitionContent] = useState<
     AboutThisExhibitionContent[]
   >([]);
-
-  const { exhibitionAndCollection } = useFeatureFlags();
 
   useEffect(() => {
     let isMounted = true;
@@ -125,19 +122,15 @@ const ExhibitionPage: NextPage<Props> = ({
           accessResourceLinks={accessResourceLinks}
           exhibitionTexts={exhibitionTexts}
           exhibitionHighlightTours={exhibitionHighlightTours}
-          shouldHideRelatedStories={
-            !!(exhibitionAndCollection && isTendernessAndRageExhibition)
-          }
+          shouldHideRelatedStories={isTendernessAndRageExhibition}
         />
       )}
 
-      {exhibitionAndCollection && (
-        <ExhibitionCollectionsContent
-          onwardJourneys={exhibition.untransformedOnwardJourneys}
-          exhibitionUid={exhibition.uid}
-          isTendernessAndRageExhibition={isTendernessAndRageExhibition}
-        />
-      )}
+      <ExhibitionCollectionsContent
+        onwardJourneys={exhibition.untransformedOnwardJourneys}
+        exhibitionUid={exhibition.uid}
+        isTendernessAndRageExhibition={isTendernessAndRageExhibition}
+      />
     </PageLayout>
   );
 };

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -138,13 +138,6 @@ const toggleConfig = {
       type: 'experimental',
     },
     {
-      id: 'exhibitionAndCollection',
-      title: 'Exhibition pages and Collection content',
-      initialValue: false,
-      description: 'Adds Collection content to Exhibition pages.',
-      type: 'experimental',
-    },
-    {
       id: 'verticalVideos',
       title: 'Vertical videos',
       initialValue: false,


### PR DESCRIPTION
- For #13276

## What does this change?

The toggle has been live for 5 weeks, we're happy to make its code official.


## How to test

Can you still see the new section in https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage when running locally?

## Have we considered potential risks?
N/A