### PR TITLE
change navigation label

### DIFF
--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -252,7 +252,7 @@ export const KioskNavigation: FunctionComponent<Props> = memo(
     } else if (pageType === 'story') {
       label = 'Related stories';
     } else if (navigation?.listName === 'includedWorks') {
-      label = 'Included works';
+      label = 'Works in this exhibition';
     } else {
       label = 'Related works';
     }


### PR DESCRIPTION
- For #13263

## What does this change?

uses the correct label in the kiosk navigation for 'Works in this exhibition'

## How to test

- with kiosk mode enabled
- visit the [T & R landing page](https://wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- click one of the items in the 'Works in this exhibition' section
- the kiosk nav should display 'Works in this exhibition'

## Have we considered potential risks?

None really