### PR TITLE
fix sub-pixel rendering issue

### DIFF
--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -21,9 +21,9 @@ const KioskNavigationWrapper = styled(Space).attrs({
   className: typography('body', 'md', 'regular'),
   as: 'nav',
 })`
-  height: ${props => props.theme.kioskNavigationHeight}px;
+  height: ${props => props.theme.kioskNavigationHeight + 1}px;
   position: fixed;
-  bottom: 0;
+  bottom: -1px; /* fix for sub-pixel rendering issues */
   left: 0;
   right: 0;
   background: ${props => props.theme.color('neutral.700')};


### PR DESCRIPTION
- For #13264

## What does this change?

Positions the kiosk navigation -1px from the bottom of the screen to prevent a gap that can appear below it.

We were seeing this on the iPad when zoomed in 1.25x

Common fix for sub-pixel rendering issues

## How to test

- enable kiosk mode
- check the [navigation bar still looks ok on desktop](https://www-dev.wellcomecollection.org/works/d2mxjdkb)
- I think we'll need to deploy and confirm it fixes the issue on the iPad (it works in browserstack)

## Have we considered potential risks?
