### PR TITLE
Hide underline on hover

### DIFF
--- a/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
+++ b/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
@@ -44,6 +44,10 @@ export const TranscriptButton = styled.button.attrs({
   background: transparent;
   color: ${props => props.theme.color('white')};
   text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
 `;
 
 export const VideoDialog = styled.dialog`


### PR DESCRIPTION
- For #13101 

## What does this change?

Hides the link underline when you hover the show/hide transcript link

<img width="308" height="192" alt="hover" src="https://github.com/user-attachments/assets/310a7e4c-8d41-4530-a6fd-bde1c2b1d975" />


## How to test

I added a video to the Prismic stage Tenderness and rage exhibition page. If you think it's necessary you can test there.


## Have we considered potential risks?

n/a