### PR TITLE
Make video titles black on iOS

### DIFF
--- a/common/views/components/PortraitVideoEmbed/index.tsx
+++ b/common/views/components/PortraitVideoEmbed/index.tsx
@@ -25,6 +25,9 @@ const CardButton = styled.button`
   cursor: pointer;
   text-align: left;
   background: none;
+
+  /* Prevent iOS from making titles blue */
+  color: inherit;
 `;
 
 const PosterContainer = styled.span`


### PR DESCRIPTION
- For #13101

## What does this change?

Specifies a colour (inherit) to stop normalize's `-webkit-appearance: button` making the titles blue.

__Before__
<img width="339" height="412" alt="Screenshot 2026-07-20 at 17 26 52" src="https://github.com/user-attachments/assets/1649ccd0-3ee6-455f-a9b3-4e2f22882995" />

__After__
<img width="360" height="421" alt="Screenshot 2026-07-20 at 17 26 31" src="https://github.com/user-attachments/assets/69a0a5d8-2104-4c1f-b39a-002a59cdde22" />


## How to test

- Turn on the vertical video and Prismic stage toggles
- Visit the page in the iOS Simulator

## Have we considered potential risks?

n/a