### PR TITLE
Allow clipboard-write in iframe (fix YouTube shorts link UI)

### DIFF
--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -198,7 +198,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               ref={iframeRef}
               title={activeItem?.title || 'Video'}
               allowFullScreen={true}
-              allow="autoplay; picture-in-picture"
+              allow="autoplay; picture-in-picture; clipboard-write;"
               src={videoSrc}
             />
           )}

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -198,7 +198,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               ref={iframeRef}
               title={activeItem?.title || 'Video'}
               allowFullScreen={true}
-              allow="autoplay; picture-in-picture; clipboard-write;"
+              allow={`autoplay; picture-in-picture${activeItem?.videoProvider === 'YouTube' ? '; clipboard-write' : ''}`}
               src={videoSrc}
             />
           )}


### PR DESCRIPTION
- For #13101 

## What does this change?

Allows `clipboard-write` within the YouTube shorts embed iframe, which allows clicking the link in the UI to successfully save the video's url to the clipboard.

__Before__

<img width="431" height="120" alt="Screenshot 2026-07-21 at 09 12 39" src="https://github.com/user-attachments/assets/1561c864-cb1a-40a2-8321-1a0760374db3" />


__After__
<img width="539" height="270" alt="image" src="https://github.com/user-attachments/assets/bf0dfcc0-7dbe-4b6f-8e00-68a1c10dbf90" />


## How to test
__note:__ you'll have to be tethered to a phone or on a vpn to make YouTube shorts work if you're in the office (or maybe not if you test in Cardigan instead? [PortraitVideoList](http://localhost:9001/?path=/story/components-media-portraitvideoembedlist--basic))

- Turn on the Prismic stage toggle
- Visit the [Tenderness and rage exhibition page](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage)
- Click on a vertical video, then click on the link icon bottom left of the UI
- It should say 'Link copied to clipboard'

## Have we considered potential risks?

n/a