### PR TITLE
Use similar prev/next style as eslewhere

### DIFF
--- a/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
+++ b/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
@@ -6,7 +6,7 @@ import Space from '@weco/common/views/components/styled/Space';
 export const DialogControls = styled.span`
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   flex-shrink: 0;
 `;
 
@@ -15,8 +15,12 @@ export const NavGroup = styled.span`
   align-items: center;
 `;
 
-export const DialogButton = styled.button`
+export const DialogButton = styled.button.attrs({
+  className: typography('body', 'xs', 'regular'),
+})`
   display: flex;
+  flex-direction: column;
+  line-height: 1;
   align-items: center;
   justify-content: center;
   width: 44px;
@@ -29,6 +33,10 @@ export const DialogButton = styled.button`
   &:disabled {
     visibility: hidden;
   }
+
+  &:not(:disabled):hover {
+    text-decoration: underline;
+  }
 `;
 
 export const TranscriptButton = styled.button.attrs({
@@ -37,7 +45,6 @@ export const TranscriptButton = styled.button.attrs({
 })`
   display: flex;
   align-items: center;
-  height: 36px;
   padding: 0 8px;
   border: 0;
   cursor: pointer;
@@ -50,7 +57,9 @@ export const VideoDialog = styled.dialog`
   padding: 0;
   border: 0;
   background: ${props => props.theme.color('black')};
-  width: min(400px, calc(90dvh * 9 / 16), 90vw);
+
+  /* We subtract 44px to account for the controls (tap size) */
+  width: min(400px, calc(calc(90dvh - 44px) * 9 / 16), 90vw);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
+++ b/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
@@ -59,7 +59,7 @@ export const VideoDialog = styled.dialog`
   background: ${props => props.theme.color('black')};
 
   /* We subtract 44px to account for the controls (tap size) */
-  width: min(400px, calc(calc(90dvh - 44px) * 9 / 16), 90vw);
+  width: min(400px, calc((90dvh - 44px) * 9 / 16), 90vw);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -2,7 +2,7 @@ import * as prismic from '@prismicio/client';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 
 import useVideoEmbed, { VideoProvider } from '@weco/common/hooks/useVideoEmbed';
-import { chevron, cross } from '@weco/common/icons';
+import { arrowSmall, cross } from '@weco/common/icons';
 import { ImageType } from '@weco/common/model/image';
 import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
@@ -156,7 +156,13 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               data-gtm-trigger="video_modal_nav_left"
             >
               <span className="visually-hidden">{prevLabel}</span>
-              <Icon icon={chevron} rotate={90} iconColor="white" />
+              <Icon
+                icon={arrowSmall}
+                rotate={180}
+                iconColor="white"
+                sizeOverride="width: 20px; height: 20px;"
+              />
+              <span aria-hidden="true">Prev</span>
             </DialogButton>
             <DialogButton
               type="button"
@@ -165,7 +171,12 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               data-gtm-trigger="video_modal_nav_right"
             >
               <span className="visually-hidden">{nextLabel}</span>
-              <Icon icon={chevron} rotate={270} iconColor="white" />
+              <Icon
+                icon={arrowSmall}
+                iconColor="white"
+                sizeOverride="width: 20px; height: 20px;"
+              />
+              <span aria-hidden="true">Next</span>
             </DialogButton>
           </NavGroup>
           <NavGroup>


### PR DESCRIPTION
- For #13101

## What does this change?

Uses the prev/next button style we have for e.g. ScrollContainers. The tap areas are 44px square.

Also fixed a bug where the video height was clipped on larger screens because we weren't accounting for the (44x44) controls above.

<img width="497" height="336" alt="image" src="https://github.com/user-attachments/assets/4cdaf700-7f5f-4850-81bf-3372b3b0e4e7" />



## How to test

- Check the [PortraitVideoList in Cardigan](http://localhost:9001/?path=/story/components-media-portraitvideoembedlist--basic)

## Have we considered potential risks?

Should we be parameterising 44px e.g. in the theme somewhere?
