### PR TITLE
Update local development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,17 @@ API environment is specified in the following order of precedence:
 1. `NEXT_PUBLIC_API_ENV_OVERRIDE` is set, then all APIs are set to the value of `NEXT_PUBLIC_API_ENV_OVERRIDE`
 1. `NEXT_PUBLIC_CONTENT_API_ENV_OVERRIDE`, `NEXT_PUBLIC_CONCEPTS_API_ENV_OVERRIDE`, or `NEXT_PUBLIC_CATALOGUE_API_ENV_OVERRIDE` are set, then the respective API is set to the value of the environment variable.
 
+For example, to test the front-end against a locally running catalogue API (see [running the catalogue API locally](https://github.com/wellcomecollection/catalogue-api/blob/main/docs/developers.md), which listens on `localhost:8080`), set only this in `./content/webapp/.env`:
+
+```
+NEXT_PUBLIC_CATALOGUE_API_ENV_OVERRIDE="dev"
+```
+
+Then run `yarn content` (which serves on `http://localhost:3000`). Only catalogue requests are routed via nginx at `https://api-dev.wellcomecollection.org` to your local API; content and concepts requests continue to use prod.
+
 #### Using www-dev.wellcomecollection.org
 
-Adding the local API confguration allows you to use the `www-dev.wellcomecollection.org` domain to access the website on your local machine.
+Adding the local API configuration allows you to use the `www-dev.wellcomecollection.org` domain to access the website on your local machine.
 
 This allows content and identity to behave correctly when running locally, as paths between the two apps are relative to the domain.
 

--- a/scripts/configure-local-apis/README.md
+++ b/scripts/configure-local-apis/README.md
@@ -7,10 +7,10 @@ the developers of that project!
 
 ## Usage
 
-Run the `configure-local-apis.sh` script in the parent directory.
+Run the `configure-local-apis.sh` script in the parent directory, or `yarn config-local-apis` from the root of the repository.
 
 You can view the nginx configuration files in [weco-local.conf](./weco-local.conf), 
-it depends on thelocal APIs to be started successfully, and use the specified ports.
+it depends on the local APIs to be started successfully, and use the specified ports.
 
 - Catalogue Search, Works & Images API: http://localhost:8080
 - Catalogue Items API: http://localhost:8081

--- a/scripts/configure-local-apis/README.md
+++ b/scripts/configure-local-apis/README.md
@@ -9,8 +9,8 @@ the developers of that project!
 
 Run the `configure-local-apis.sh` script in the parent directory, or `yarn config-local-apis` from the root of the repository.
 
-You can view the nginx configuration files in [weco-local.conf](./weco-local.conf), 
-it depends on the local APIs to be started successfully, and use the specified ports.
+You can view the nginx configuration files in [weco-local.conf](./weco-local.conf).
+It depends on the local APIs being started successfully and using the specified ports.
 
 - Catalogue Search, Works & Images API: http://localhost:8080
 - Catalogue Items API: http://localhost:8081

--- a/toggles/README.md
+++ b/toggles/README.md
@@ -63,6 +63,13 @@ if (serverData.toggles.someFeatureFlag.value) {
 The `serverData.toggles` object is also passed to services that need it
 (e.g. catalogue API clients).
 
+**Note for local development:** server-side toggle resolution
+(`common/server-data/toggles.ts`) validates toggle cookies against the deployed
+[toggles JSON](https://toggles.wellcomecollection.org/toggles.json), even when the
+webapp is running locally. A toggle that only exists in `toggles/webapp/toggles.ts`
+will not resolve from its cookie until the toggles package has been deployed with
+`yarn deploy`.
+
 
 ## Deployment
 


### PR DESCRIPTION
## What does this change?

Updates the local development docs based on a setup verified end-to-end today.

- `README.md`: adds a worked example for pointing only the catalogue API at a local instance. It sets `NEXT_PUBLIC_CATALOGUE_API_ENV_OVERRIDE="dev"` in `content/webapp/.env`, runs `yarn content` (serving on `http://localhost:3000`), and explains that only catalogue requests are routed via nginx at `api-dev.wellcomecollection.org` to the local API on port 8080, while content and concepts requests keep hitting prod. Also fixes a "confguration" typo.
- `scripts/configure-local-apis/README.md`: notes that the nginx config can be applied with `yarn config-local-apis` from the repo root as an alternative to running `configure-local-apis.sh` directly. Also fixes a "thelocal" typo.
- `toggles/README.md`: adds a note that server-side toggle resolution (`common/server-data/toggles.ts`) validates toggle cookies against the deployed `toggles.json`, even when the webapp runs locally. A toggle that only exists in `toggles/webapp/toggles.ts` will not resolve from its cookie until the toggles package has been deployed with `yarn deploy`.


Part of wellcomecollection/platform#6421: these docs cover the local setup used to verify the catalogue pipeline preview toggle.
## How to test

This is a docs-only change, so there is nothing to deploy or run to verify the behaviour of the site. To sanity-check the docs themselves:

- Read the three changed files and confirm the instructions read clearly.
- Optionally follow the new catalogue-only example: set `NEXT_PUBLIC_CATALOGUE_API_ENV_OVERRIDE="dev"` in `content/webapp/.env`, run the local API and nginx config, run `yarn content`, and confirm catalogue requests go to the local API on port 8080 while content and concepts still use prod.

## Have we considered potential risks?

Low risk. The change only touches Markdown documentation and does not alter any application code, configuration, or infrastructure. The steps described were verified end-to-end today.