### PR TITLE
Kiosk design tweaks

### DIFF
--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -113,7 +113,6 @@ const navLinkStyles = `
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
   min-width: 44px;
   min-height: 44px;
 `;

--- a/common/views/components/KioskNavigation/index.tsx
+++ b/common/views/components/KioskNavigation/index.tsx
@@ -121,6 +121,7 @@ const NavLink = styled(Link)`
   ${navLinkStyles}
   color: inherit;
   text-decoration: none;
+  line-height: 1;
 
   &:hover {
     text-decoration: underline;

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
@@ -7,7 +7,7 @@ export const ScrollButtonsContainer = styled(Space)<{
   $hasContent?: boolean;
   $scrollButtonsAfter?: boolean;
 }>`
-  gap: ${props => props.theme.spacingUnits['100']};
+  gap: ${props => props.theme.spacingUnits['300']};
   display: flex;
   justify-content: ${props =>
     props.$hasContent ? 'space-between' : 'flex-end'};

--- a/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
+++ b/content/webapp/views/components/ScrollContainer/ScrollContainer.styles.tsx
@@ -189,7 +189,7 @@ export const ScrollShim = styled.li.attrs({
 `;
 
 export const CopyContainer = styled.div`
-  > *:last-child {
+  :last-child {
     margin-bottom: 0;
   }
 `;

--- a/content/webapp/views/components/ScrollContainer/index.tsx
+++ b/content/webapp/views/components/ScrollContainer/index.tsx
@@ -92,7 +92,7 @@ const ScrollContainer: FunctionComponent<Props> = ({
       <ConditionalWrapper
         condition={!scrollButtonsAfter || !!CopyContent}
         wrapper={children => (
-          <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
+          <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
             {children}
           </Space>
         )}

--- a/content/webapp/views/pages/exhibitions/explore-more.tsx
+++ b/content/webapp/views/pages/exhibitions/explore-more.tsx
@@ -106,19 +106,16 @@ const ExploreMorePage: NextPage<Props> = ({
       <SpacingSection>
         <ContaineredLayout gridSizes={gridSize12()}>
           <SectionHeader title="Related works from the collection" />
-          <Space $v={{ size: 'lg', properties: ['margin-top'] }}>
-            <p>
+          <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+            <Space as="p" $v={{ size: 'lg', properties: ['margin-bottom'] }}>
               Explore a selection of related works from our collection,
               exploring HIV, activism and intimacy.
-            </p>
+            </Space>
           </Space>
         </ContaineredLayout>
         {workGroups.map(group =>
           group.works.length > 0 ? (
-            <Space
-              key={group.heading}
-              $v={{ size: 'xl', properties: ['margin-top'] }}
-            >
+            <div key={group.heading}>
               <ScrollContainer
                 hasWorkCards={true}
                 CopyContent={
@@ -142,7 +139,7 @@ const ExploreMorePage: NextPage<Props> = ({
                   </ListItem>
                 ))}
               </ScrollContainer>
-            </Space>
+            </div>
           ) : null
         )}
       </SpacingSection>
@@ -150,17 +147,22 @@ const ExploreMorePage: NextPage<Props> = ({
         <BeigeSection>
           <ContaineredLayout gridSizes={gridSize12()}>
             <SectionHeader title="Works in this exhibition" />
-            <Space $v={{ size: 'lg', properties: ['margin-top'] }}>
-              <p>Find the items on display in our online catalogue.</p>
-            </Space>
           </ContaineredLayout>
-          <ScrollContainer gridSizes={gridSize12()} useShim={true}>
-            {exhibitionWorks.map(work => (
-              <ListItem key={work.id} $usesShim>
-                <RelatedWorksCard variant="default" work={work} />
-              </ListItem>
-            ))}
-          </ScrollContainer>
+          <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+            <ScrollContainer
+              gridSizes={gridSize12()}
+              useShim={true}
+              CopyContent={
+                <p>Find the items on display in our online catalogue.</p>
+              }
+            >
+              {exhibitionWorks.map(work => (
+                <ListItem key={work.id} $usesShim>
+                  <RelatedWorksCard variant="default" work={work} />
+                </ListItem>
+              ))}
+            </ScrollContainer>
+          </Space>
         </BeigeSection>
       )}
     </PageLayout>


### PR DESCRIPTION
- For #13625

## What does this change?

Fixes(ish) the design issues highlighted in #13625 following QA of the T&R explore more landing page.

**N.B.**
- text spacing (this is not quite resolved - but good enough I think). I'm using the design tokens specified in the figma file, but they give larger spaces than the issue is asking for. We have no value that would give a 24px gap, I went for consistency for all the headers using the values we have.
- prev/next arrow alignment - changed a selector to use last-child more generically rather than as direct descendant of the `CopyContainer`. I think this is safe enough and the way we have to include the CopyContent on the explore more page meant it appears in a nested div, so the styles weren't applying
- A couple of other spacing tweaks will have knock on effects anywhere that the ScrollContainer is used.
For example on a concept page:

Before:
<img width="1149" height="451" alt="Screenshot 2026-07-21 at 13 42 55" src="https://github.com/user-attachments/assets/28fb697a-28a9-4685-93d2-28c3a2422da8" />

After:
<img width="1222" height="431" alt="Screenshot 2026-07-21 at 13 42 43" src="https://github.com/user-attachments/assets/21ee5fc7-e294-483d-a8ae-0497105e1f4b" />

larger gap between text/controls and images

## How to test

- enable a [T&R kiosk mode](https://dash.wellcomecollection.org/toggles/#modes)
- visit the [explore-more page for T&R](https://www-dev.wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more)
- does it look right now?

## Have we considered potential risks?

It has changed some styles everywhere we use the ScrollContainer - but it is consistent