### PR TITLE
Move PortraitVideoList controls below video

### DIFF
--- a/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
+++ b/common/views/components/PortraitVideoEmbed/PortraitVideoDialog.styles.tsx
@@ -50,7 +50,9 @@ export const VideoDialog = styled.dialog`
   padding: 0;
   border: 0;
   background: ${props => props.theme.color('black')};
-  width: min(400px, calc(90dvh * 9 / 16), 90vw);
+
+  /* We subtract 44px to account for the controls (tap size) */
+  width: min(400px, calc((90dvh - 44px) * 9 / 16), 90vw);
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -147,6 +147,27 @@ const PortraitVideoList: FunctionComponent<Props> = ({
         aria-label={activeItem?.title || 'Video'}
         onClick={e => e.target === dialogRef.current && closeDialog()}
       >
+        <DialogVideoContainer>
+          {activeIndex !== null && videoSrc && (
+            <VideoIframe
+              key={activeIndex}
+              ref={iframeRef}
+              title={activeItem?.title || 'Video'}
+              allowFullScreen={true}
+              allow={`autoplay; picture-in-picture${activeItem?.videoProvider === 'YouTube' ? '; clipboard-write' : ''}`}
+              src={videoSrc}
+            />
+          )}
+          {activeItem?.transcript && (
+            <TranscriptOverlay
+              id={uid}
+              $hidden={!transcriptOpen}
+              aria-hidden={!transcriptOpen}
+            >
+              <PrismicHtmlBlock html={activeItem.transcript} />
+            </TranscriptOverlay>
+          )}
+        </DialogVideoContainer>
         <DialogControls>
           <NavGroup>
             <DialogButton
@@ -190,28 +211,6 @@ const PortraitVideoList: FunctionComponent<Props> = ({
             </DialogButton>
           </NavGroup>
         </DialogControls>
-
-        <DialogVideoContainer>
-          {activeIndex !== null && videoSrc && (
-            <VideoIframe
-              key={activeIndex}
-              ref={iframeRef}
-              title={activeItem?.title || 'Video'}
-              allowFullScreen={true}
-              allow={`autoplay; picture-in-picture${activeItem?.videoProvider === 'YouTube' ? '; clipboard-write' : ''}`}
-              src={videoSrc}
-            />
-          )}
-          {activeItem?.transcript && (
-            <TranscriptOverlay
-              id={uid}
-              $hidden={!transcriptOpen}
-              aria-hidden={!transcriptOpen}
-            >
-              <PrismicHtmlBlock html={activeItem.transcript} />
-            </TranscriptOverlay>
-          )}
-        </DialogVideoContainer>
       </VideoDialog>
     </div>
   );

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -198,7 +198,7 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               ref={iframeRef}
               title={activeItem?.title || 'Video'}
               allowFullScreen={true}
-              allow="autoplay; picture-in-picture"
+              allow={`autoplay; picture-in-picture${activeItem?.videoProvider === 'YouTube' ? '; clipboard-write' : ''}`}
               src={videoSrc}
             />
           )}


### PR DESCRIPTION
- For #13101

## What does this change?

Moves the controls (prev/next, transcript, close) from the top to the bottom of the portrait videos

<img width="405" height="674" alt="Screenshot 2026-07-21 at 14 22 04" src="https://github.com/user-attachments/assets/91ce87b0-15b5-4864-a629-a8de892f3b27" />


## How to test

- Look at the [PortraitVideoList in Cardigan](http://localhost:9001/?path=/story/components-media-portraitvideoembedlist--basic)
- Click on a Video and check the controls render at the bottom and they still work

## Have we considered potential risks?

The close button is still the first element to receive focus once the video is triggered even though the controls are now below the video. I _think_ this is the correct behaviour. Accessing the video controls requires shift-tabbing, which is in keeping with the visual order of the page, so I think this is correct too.