### PR TITLE
Add to AGENTS.md, add CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,11 @@
 
 **These guidelines are for active development and coding tasks.** Shared coding standards and PR review guidelines are in [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
-Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions) are in [.github/copilot-instructions.md](.github/copilot-instructions.md) — don't duplicate them here. The sections below cover agent-specific operational guidance.
+Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions):
+
+@.github/copilot-instructions.md
+
+The sections below cover agent-specific operational guidance.
 
 ## Working Style
 
@@ -23,11 +27,17 @@ Write casually and keep explanations clear. Don't use emojis or bold text in res
 ### Running apps locally
 ```bash
 yarn install
-yarn content    # runs content webapp
+yarn content    # runs content webapp, http://localhost:3000
 yarn identity   # runs identity webapp
+yarn cardigan   # runs the design system
+yarn dash       # runs the internal dashboard (yarn workspace @weco/dash run dev)
 ```
 
-Both apps can run together: `(yarn content & yarn identity)`
+Both apps can run together: `(yarn content & yarn identity)`. Both need matching `NEXT_PUBLIC_API_ENV_OVERRIDE` values in their `.env` files.
+
+Run `yarn config-local-apis` to configure nginx proxying so the webapps can hit local dev APIs (see [README.md](./README.md#running-the-app-with-local-apis) for the full override precedence rules).
+
+To deploy a local build straight to staging, bypassing CI (coordinate with the team first, and restore afterwards): `yarn deploy-dev content` / `yarn deploy-dev restore content`.
 
 ### Type checking
 ```bash
@@ -36,7 +46,17 @@ yarn tsc        # from root - checks TypeScript across all packages
 
 ### Testing
 ```bash
-yarn test       # runs Jest tests
+yarn test:common          # jest in common/
+yarn test:content         # jest in content/webapp
+yarn test:identity        # jest in identity/webapp
+yarn test:all:unit        # all three of the above
+yarn test:playwright        # e2e against staging
+yarn test:playwright:mobile # e2e against staging, mobile viewport
+```
+
+To run a single test file, `cd` into the relevant workspace (e.g. `content/webapp` or `common`) and run:
+```bash
+yarn test path/to/File.test.ts
 ```
 
 ### Documentation
@@ -47,6 +67,67 @@ Key documentation files:
 - [common/README.md](./common/README.md) - About shared code structure, data directory, Prismic conventions
 - [docs/git-hooks.md](./docs/git-hooks.md) - Git hooks with Husky (pre-commit linting)
 - [docs/](./docs/) - Additional feature-specific documentation
+
+## Architecture
+
+Yarn Workspaces monorepo. Main workspaces:
+
+- `common/` — shared code (`@weco/common`): components, hooks, services, utils, types, and the Prismic model (`customtypes/`, `views/slices/`) generated via SliceMachine. Also owns the koa-middleware and server-data pipeline used by both webapps.
+- `content/webapp/` — the main public site (`@weco/content`): stories, exhibitions, events, catalogue/works, search, concepts, guides. Next.js app with a custom Koa server (`app.ts`).
+- `identity/webapp/` — account management (`@weco/identity`): login, registration, library membership.
+- `toggles/webapp/` — feature flag / A-B test definitions, compiled and deployed to S3, served at `toggles.wellcomecollection.org` and displayed on the toggles dashboard.
+- `dash/webapp/` — internal dashboard, including the toggles UI.
+- `cardigan/` — the design system.
+- `cache/` — CloudFront / Lambda@Edge config, including the A/B test cohort assignment (`cache/edge_lambdas/src/toggler.ts`).
+- `deploy/` — deployment tooling (`yarn deploy-dev`).
+- `infrastructure/` — Terraform for the experience AWS account.
+- `prismic-model/` — shared Prismic type definitions.
+
+### Server architecture (content & identity)
+
+Both webapps run Next.js behind a custom Koa server (see `content/webapp/app.ts`):
+- `require('@weco/common/services/apm/initApm')(...)` must be the first thing loaded (APM instrumentation).
+- Koa middleware chain: `apmErrorMiddleware` then `withCachedValues` (from `common/koa-middleware`), which currently composes `withPrismicPreviewStatus` — this is where request-scoped data (like Prismic preview state) gets attached before Next.js handles the request.
+- `initServerData()` (`common/server-data`) runs once at boot and is the source of the `serverData` object (including `serverData.toggles`) available in `getServerSideProps`.
+- Routing is case-sensitive (`sensitive: true` on the Koa router) — deliberate, because Prismic generates near-identical document IDs differing only in case.
+- `/rss` is served directly by this Koa server (backed by `rss.wellcomecollection.org` via CloudFront) rather than through a Next.js page.
+
+### Toggles (feature flags, A/B tests & modes)
+
+Three categories, all defined in `toggles/webapp/toggles.ts`:
+- **Feature flags** (`experimental` / `permanent` / `stage`) — boolean, with a `defaultValue`. Add one by appending to `featureFlags` with `initialValue: false`, then `yarn deploy` from `toggles/webapp` to publish to S3/the dashboard.
+- **A/B tests** — cohort assignment happens in the Lambda@Edge layer (`cache/edge_lambdas/src/toggler.ts`), not in the webapp.
+- **Modes** — like a feature flag but the value is a selected option string rather than a boolean, activated via a cookie holding the chosen option's `id`. Defined in the `modes` array (e.g. `kioskMode` for Reading Room / Tenderness & Rage devices, `cataloguePipeline` for routing catalogue API queries to a specific Elasticsearch cluster via an `elasticCluster` param).
+
+Access patterns:
+- Client-side: `useFeatureFlags()` / `useABTest()` / `useModes()` from `@weco/common/server-data/Context`.
+- Server-side: `serverData.toggles.someFlag.value` (or `serverData.toggles.modes.someMode`) inside `getServerSideProps`; the same `serverData.toggles` object is threaded into API clients (catalogue, etc.) that need toggle- or mode-gated behaviour.
+- Server-side toggle *cookie* resolution (`common/server-data/toggles.ts`) validates against the deployed `toggles.wellcomecollection.org/toggles.json` — a flag or mode added locally to `toggles.ts` won't resolve from its cookie until the toggles package has actually been deployed.
+
+### API environment overrides (local dev against real APIs)
+
+Which environment (`prod`/`stage`/`dev`) each backend API is hit from, precedence high to low:
+1. `toggles?.stagingApi` unset → everything is `prod`.
+2. `toggles?.stagingApi` true → everything is `stage`.
+3. `NEXT_PUBLIC_API_ENV_OVERRIDE` → applies to content, concepts, and catalogue APIs together.
+4. Per-API overrides: `NEXT_PUBLIC_CONTENT_API_ENV_OVERRIDE`, `NEXT_PUBLIC_CONCEPTS_API_ENV_OVERRIDE`, `NEXT_PUBLIC_CATALOGUE_API_ENV_OVERRIDE`.
+
+### Prismic integration
+
+Content is authored in Prismic. Key layers, all under `content/webapp/services/prismic/`:
+- `fetch/` — Prismic client fetch helpers, `fetch-links.ts` for GraphQuery fetch-link configuration.
+- `transformers/` — convert raw Prismic documents into the app's view models.
+- `events.ts` — event-specific Prismic queries/logic.
+
+`common/customtypes` and `common/views/slices` are the SliceMachine-managed Prismic model (custom types and slices); regenerate/edit these via SliceMachine (`yarn slicemachine`), not by hand, when adding fields. See the "Future API ID naming" conventions in `.github/copilot-instructions.md` before adding new custom types, slices, or fields.
+
+### Catalogue / IIIF
+
+`content/webapp/services/wellcome/catalogue` talks to the Catalogue API (works, images). `content/webapp/services/iiif` fetches and transforms IIIF manifests for viewing digitised items.
+
+### CI / deployment
+
+Buildkite pipelines live in `.buildkite/` (`pipeline.yml` main, `pipeline.deployment.yml`, `pipeline.e2e-universal.yml`). To reproduce a CI build step locally, run the matching `docker compose` service (see [README.md](./README.md#running-ci-steps-locally) for the full walkthrough of mounting AWS credentials and using the `experience-ci` role).
 
 ## Server vs Client Code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **These guidelines are for active development and coding tasks.** Shared coding standards and PR review guidelines are in [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
-Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions):
+Guidelines for AI assistants working on the Wellcome Collection codebase. Shared coding standards (naming, accessibility, duplication, workspace structure, Prismic conventions) live in [.github/copilot-instructions.md](.github/copilot-instructions.md). The line below is a Claude Code import directive, not a GitHub @-mention — it pulls that file's contents into context automatically:
 
 @.github/copilot-instructions.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,4 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+See [AGENTS.md](./AGENTS.md) for the full guidelines. The line below is a Claude Code import directive, not a GitHub @-mention — it pulls that file's contents into context automatically:
+
 @AGENTS.md


### PR DESCRIPTION
Was trying Claude Codes' `/init` function, which creates a `CLAUDE.md` file after reading through our repo. Thought it best to just modify `AGENTS.md` in the end so more models could benefit from it, but it recommended keeping `CLAUDE.md` linking to `AGENTS.md`.