### PR TITLE
IVR split viewers: tests

### DIFF
--- a/content/webapp/test/fixtures/iiif/transformed-manifest.ts
+++ b/content/webapp/test/fixtures/iiif/transformed-manifest.ts
@@ -1,3 +1,4 @@
+import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { ItemViewerQuery } from '@weco/content/types/item-viewer';
 import {
   Auth,
@@ -126,5 +127,38 @@ export function createMockManifest(
     canvases,
     canvasCount: canvases.length,
     auth,
+  };
+}
+
+// A single search hit. `on` is the canvas it falls on, with the hit's
+// coordinates as a fragment - e.g. `${canvasId}#xywh=100,200,50,60` - which is
+// what the viewer parses to position its highlight overlay.
+export function createMockSearchHit(
+  overrides: Partial<SearchResults['resources'][number]> = {}
+): SearchResults['resources'][number] {
+  return {
+    '@id': '',
+    '@type': 'oa:Annotation',
+    motivation: 'sc:painting',
+    resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
+    on: '',
+    ...overrides,
+  };
+}
+
+// The response from a manifest's content search service. Defaults to no hits;
+// pass `resources: [createMockSearchHit(...)]` for the cases that need them.
+export function createMockSearchResults(
+  overrides: Partial<SearchResults> = {}
+): SearchResults {
+  return {
+    '@context': '',
+    '@id': '',
+    '@type': 'sc:AnnotationList',
+    within: { '@type': '', total: null },
+    startIndex: 0,
+    resources: [],
+    hits: [],
+    ...overrides,
   };
 }

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
@@ -1,0 +1,351 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext';
+import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+import {
+  createMockAuth,
+  createMockCanvas,
+  createMockManifest,
+  createMockQuery,
+  createOpenPainting,
+  createRestrictedPainting,
+} from '@weco/content/test/fixtures/iiif/transformed-manifest';
+
+import MainViewer from './MainViewer';
+
+// The legacy counterpart to the refactored viewer tests. Legacy MainViewer is
+// both viewers in one component, so the two describes below mirror
+// refactored/VirtualizedImageViewer.test.tsx and
+// refactored/PaginatedItemViewer.test.tsx respectively, test for test.
+//
+// The bodies are deliberately kept identical to their refactored twins, so
+// that a diff between the files shows only what the split actually changed.
+// Unlike those files we don't mock useFeatureFlags, so useItemViewerContext
+// resolves to the legacy context.
+//
+// Not mirrored: refactored/MainViewer.test.tsx, which asserts the router picks
+// the right child component. Legacy has no child components to pick between -
+// it branches internally, which the two describes here cover between them.
+
+// jsdom doesn't implement IntersectionObserver, which the image item's
+// scroll-to-url-update behaviour relies on via useOnScreen.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds = [];
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+  takeRecords = jest.fn(() => []);
+}
+window.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+// The FixedSizeList's outer element. Legacy renders it inside
+// MainViewerContainer, so it's one level down rather than at the root.
+const getScrollContainer = (container: HTMLElement) =>
+  container.querySelector('[data-testid="main-viewer"] > div')!;
+
+const createVideoCanvas = (id = 'https://example.com/video.mp4') =>
+  createMockCanvas({
+    painting: [{ id, type: 'Video', format: 'video/mp4' }] as never,
+  });
+
+describe('MainViewer (legacy)', () => {
+  // One test below swaps in fake timers. Restore real ones unconditionally, so
+  // a failed assertion can't leave the rest of the file running under them.
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('when the manifest has only renderable images', () => {
+    const renderViewer = (contextProps: Partial<ItemViewerContextProps> = {}) =>
+      renderWithContext(<MainViewer />, {
+        contextProps: { hasOnlyRenderableImages: true, ...contextProps },
+      });
+
+    it('renders the fixed-list scroll container sized to the main area', () => {
+      const { container } = renderViewer();
+
+      expect(getScrollContainer(container)).toHaveStyle({
+        width: '1000px',
+        height: '500px',
+      });
+    });
+
+    it('renders the virtualized image items for the canvases in view', () => {
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({ painting: [createOpenPainting()] }),
+            createMockCanvas({ painting: [createOpenPainting()] }),
+          ],
+        }),
+      });
+
+      // Both canvases fall within the FixedSizeList's rendered/overscan range
+      // given the default mainAreaHeight/itemSize, so both images are present.
+      const images = screen.getAllByRole('img');
+      expect(images).toHaveLength(2);
+      expect(images[0]).toHaveAttribute(
+        'src',
+        'https://example.com/image/open'
+      );
+    });
+
+    it('scrolls to the current canvas position on mount, accounting for landscape aspect ratio', () => {
+      const { container } = renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              width: 1000,
+              height: 1000,
+              painting: [createOpenPainting()],
+            }),
+            // Landscape: scrollViewer centres the shorter rendered image within
+            // the square FixedSizeList row instead of scrolling to its top.
+            createMockCanvas({
+              width: 2000,
+              height: 1000,
+              painting: [createOpenPainting()],
+            }),
+          ],
+        }),
+        query: createMockQuery({ canvas: 2 }),
+      });
+
+      // The scroll happens on mount via the effect on `canvas`, since the query
+      // defaults to shouldScrollToCanvas - not via the debounced onItemsRendered.
+      // mainAreaWidth/itemSize default to 1000, mainAreaHeight to 500.
+      // renderedHeight = 1000 * (1000/2000) * 0.8 = 400
+      // heightOfPreviousItems = 1 * 1000 = 1000
+      // distanceToScroll = 1000 + (1000 - 400) / 2 = 1300
+      expect(getScrollContainer(container).scrollTop).toBe(1300);
+    });
+
+    it('hides controls while scrolling and restores them once scrolling settles', () => {
+      jest.useFakeTimers();
+      const setShowControls = jest.fn();
+
+      const { container } = renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas({ painting: [createOpenPainting()] })],
+        }),
+        setShowControls,
+      });
+
+      act(() => {
+        fireEvent.scroll(getScrollContainer(container), {
+          target: { scrollTop: 100 },
+        });
+      });
+      expect(setShowControls).toHaveBeenCalledWith(false);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(setShowControls).toHaveBeenCalledWith(true);
+    });
+
+    it('adds top margin to the first item when it is restricted, to clear the restricted-access banner', () => {
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({ painting: [createRestrictedPainting()] }),
+          ],
+        }),
+      });
+
+      expect(screen.getByTestId('image-item')).toHaveStyle({
+        marginTop: '2em',
+      });
+    });
+
+    it('renders a search-hit highlight overlay for a matching canvas', async () => {
+      const canvasId =
+        'https://iiif.wellcomecollection.org/presentation/v3/b00000000/canvases/b00000000_0001.jp2';
+      const imageId =
+        'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2';
+
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              id: canvasId,
+              // Needs a real ImageService2 item (not the plain <img> fallback
+              // that createOpenPainting gives us) - only the ImageViewer path
+              // measures and reports back the image position the overlay needs.
+              painting: [
+                {
+                  id: imageId,
+                  type: 'Image',
+                  service: [{ '@id': imageId, '@type': 'ImageService2' }],
+                } as never,
+              ],
+            }),
+          ],
+        }),
+        searchResults: {
+          '@context': '',
+          '@id': '',
+          '@type': 'sc:AnnotationList',
+          within: { '@type': '', total: null },
+          startIndex: 0,
+          resources: [
+            {
+              '@id': '',
+              '@type': 'oa:Annotation',
+              motivation: 'sc:painting',
+              resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
+              on: `${canvasId}#xywh=100,200,50,60`,
+            },
+          ],
+          hits: [],
+        },
+      });
+
+      // The overlay only appears once the image has reported its measured
+      // position back up, which happens in an effect after the initial render.
+      await waitFor(() =>
+        expect(screen.getByTestId('search-term-highlight')).toBeInTheDocument()
+      );
+    });
+  });
+
+  describe('when the manifest has non-image or born-digital items', () => {
+    const renderViewer = (contextProps: Partial<ItemViewerContextProps> = {}) =>
+      renderWithContext(<MainViewer />, {
+        contextProps: { hasOnlyRenderableImages: false, ...contextProps },
+      });
+
+    it('renders the current item', () => {
+      const { container } = renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [createVideoCanvas()],
+        }),
+      });
+
+      expect(
+        container.querySelector('[data-component="video-player"]')
+      ).toBeInTheDocument();
+    });
+
+    it('hides the fullscreen control, since the paginated viewer never supports it', () => {
+      const setShowFullscreenControl = jest.fn();
+
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [createVideoCanvas()],
+        }),
+        setShowFullscreenControl,
+      });
+
+      expect(setShowFullscreenControl).toHaveBeenCalledWith(false);
+    });
+
+    it('renders the item for the canvas number associated with the query', () => {
+      const { container } = renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createVideoCanvas('https://example.com/video-1.mp4'),
+            createVideoCanvas('https://example.com/video-2.mp4'),
+          ],
+        }),
+        query: createMockQuery({ canvas: 2 }),
+      });
+
+      expect(container.querySelector('source')).toHaveAttribute(
+        'src',
+        'https://example.com/video-2.mp4'
+      );
+    });
+
+    it('renders a PDF item from the canvas originals', () => {
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              original: [
+                {
+                  id: 'https://example.com/doc.pdf',
+                  type: 'Text',
+                  format: 'application/pdf',
+                  behavior: 'original',
+                },
+              ] as never,
+            }),
+          ],
+        }),
+      });
+
+      expect(screen.getByRole('link', { name: /open/i })).toBeInTheDocument();
+    });
+
+    it('renders a download link for a born-digital archive item', () => {
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              painting: [
+                { id: 'https://example.com/placeholder', type: 'Image' },
+              ] as never,
+              original: [
+                {
+                  id: 'https://example.com/file.docx',
+                  format: 'application/msword',
+                  behavior: 'original',
+                },
+              ] as never,
+            }),
+          ],
+        }),
+      });
+
+      expect(screen.getByRole('link', { name: /download/i })).toHaveAttribute(
+        'href',
+        'https://example.com/file.docx'
+      );
+    });
+
+    it('passes the manifest access service through to restricted items', () => {
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              painting: [
+                createRestrictedPainting({
+                  id: 'https://example.com/doc.pdf',
+                  type: 'Text',
+                  format: 'application/pdf',
+                }),
+              ],
+            }),
+          ],
+          auth: createMockAuth({
+            externalAccessService: {
+              id: 'https://example.com/access',
+              label: 'Restricted access notice',
+            },
+          }),
+        }),
+      });
+
+      expect(
+        screen.getByRole('heading', { name: 'Restricted access notice' })
+      ).toBeInTheDocument();
+    });
+
+    it('renders nothing when the current canvas cannot be resolved', () => {
+      renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas()],
+        }),
+        query: createMockQuery({ canvas: 99 }),
+      });
+
+      // Legacy always renders MainViewerContainer, so unlike the refactored
+      // viewer the container itself remains - it just has nothing in it.
+      expect(screen.getByTestId('main-viewer')).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
@@ -7,6 +7,8 @@ import {
   createMockCanvas,
   createMockManifest,
   createMockQuery,
+  createMockSearchHit,
+  createMockSearchResults,
   createOpenPainting,
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
@@ -116,10 +118,78 @@ describe('MainViewer (legacy)', () => {
 
       // The scroll happens on mount via the effect on `canvas`, since the query
       // defaults to shouldScrollToCanvas - not via the debounced onItemsRendered.
+      //
+      // scrollViewer isn't exported, so its maths is asserted through the DOM:
+      // FixedSizeList.scrollTo() writes scrollTop on its outer element, and jsdom
+      // records that despite never laying anything out. If react-window ever stops
+      // driving scroll position imperatively, this fails loudly rather than
+      // quietly passing.
+      //
       // mainAreaWidth/itemSize default to 1000, mainAreaHeight to 500.
       // renderedHeight = 1000 * (1000/2000) * 0.8 = 400
       // heightOfPreviousItems = 1 * 1000 = 1000
       // distanceToScroll = 1000 + (1000 - 400) / 2 = 1300
+      expect(getScrollContainer(container).scrollTop).toBe(1300);
+    });
+
+    it('scrolls to the top of the current canvas on mount when it is portrait', () => {
+      const { container } = renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              width: 1000,
+              height: 1400,
+              painting: [createOpenPainting()],
+            }),
+            createMockCanvas({
+              width: 1000,
+              height: 1400,
+              painting: [createOpenPainting()],
+            }),
+          ],
+        }),
+        query: createMockQuery({ canvas: 2 }),
+      });
+
+      // Portrait canvases skip the centring maths above entirely: scrollViewer
+      // calls scrollToItem(1, 'start'), putting the top of the second item at the
+      // top of the viewport - 1 * itemSize = 1000.
+      expect(getScrollContainer(container).scrollTop).toBe(1000);
+    });
+
+    it('skips the canvas-change scroll when shouldScrollToCanvas is false', () => {
+      jest.useFakeTimers();
+
+      const { container } = renderViewer({
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({
+              width: 2000,
+              height: 1000,
+              painting: [createOpenPainting()],
+            }),
+            createMockCanvas({
+              width: 2000,
+              height: 1000,
+              painting: [createOpenPainting()],
+            }),
+          ],
+        }),
+        query: createMockQuery({ canvas: 2, shouldScrollToCanvas: false }),
+      });
+
+      // The flag is set when the canvas changed *because* the viewer was
+      // scrolled, so scrolling again would fight the user. It suppresses the
+      // effect on `canvas`.
+      expect(getScrollContainer(container).scrollTop).toBe(0);
+
+      // It does not suppress the first-render scroll behind onItemsRendered,
+      // though - that path doesn't consult the flag, so the viewer still jumps
+      // once the 500ms debounce elapses. Pinned here as current behaviour rather
+      // than endorsed: see the note on the PR.
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
       expect(getScrollContainer(container).scrollTop).toBe(1300);
     });
 
@@ -185,23 +255,11 @@ describe('MainViewer (legacy)', () => {
             }),
           ],
         }),
-        searchResults: {
-          '@context': '',
-          '@id': '',
-          '@type': 'sc:AnnotationList',
-          within: { '@type': '', total: null },
-          startIndex: 0,
+        searchResults: createMockSearchResults({
           resources: [
-            {
-              '@id': '',
-              '@type': 'oa:Annotation',
-              motivation: 'sc:painting',
-              resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
-              on: `${canvasId}#xywh=100,200,50,60`,
-            },
+            createMockSearchHit({ on: `${canvasId}#xywh=100,200,50,60` }),
           ],
-          hits: [],
-        },
+        }),
       });
 
       // The overlay only appears once the image has reported its measured

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
@@ -186,7 +186,7 @@ describe('MainViewer (legacy)', () => {
       // It does not suppress the first-render scroll behind onItemsRendered,
       // though - that path doesn't consult the flag, so the viewer still jumps
       // once the 500ms debounce elapses. Pinned here as current behaviour rather
-      // than endorsed: see the note on the PR.
+      // than endorsed.
       act(() => {
         jest.advanceTimersByTime(500);
       });

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.tsx
@@ -283,6 +283,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
               return (
                 <SearchTermHighlight
                   key={i}
+                  data-testid="search-term-highlight"
                   $top={item.overlayTop}
                   $left={item.overlayLeft}
                   $width={item.highlight.w}
@@ -297,6 +298,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
               return (
                 <ItemWrapper
                   key={item.type + item.id}
+                  data-testid="image-item"
                   $firstItemIsRestricted={firstItemIsRestricted}
                 >
                   <IIIFItem

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/MainViewer.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+
+import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+
+import MainViewer from './MainViewer';
+
+// The refactored components read from ItemViewerContextRefactored via the
+// useItemViewerContext hook, which checks the feature flag. Mock it so the
+// hook returns the refactored context values.
+jest.mock('@weco/common/server-data/Context', () => ({
+  ...jest.requireActual('@weco/common/server-data/Context'),
+  useFeatureFlags: () => ({ itemViewerRefactor: true }),
+}));
+
+// MainViewer is a pure router, so its own tests only need to assert it picks
+// the right child - the children's own behaviour is covered by their own tests.
+jest.mock('./VirtualizedImageViewer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="virtualized-image-viewer" />,
+}));
+
+jest.mock('./PaginatedItemViewer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="paginated-item-viewer" />,
+}));
+
+const renderMainViewer = (hasOnlyRenderableImages: boolean) =>
+  renderWithContext(<MainViewer />, {
+    contextProps: { hasOnlyRenderableImages },
+    useRefactoredContext: true,
+  });
+
+describe('MainViewer', () => {
+  it('renders VirtualizedImageViewer when the manifest has only renderable images', () => {
+    renderMainViewer(true);
+
+    expect(screen.getByTestId('virtualized-image-viewer')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('paginated-item-viewer')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders PaginatedItemViewer when the manifest has non-image or born-digital items', () => {
+    renderMainViewer(false);
+
+    expect(screen.getByTestId('paginated-item-viewer')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('virtualized-image-viewer')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/MainViewer.test.tsx
@@ -48,4 +48,16 @@ describe('MainViewer', () => {
       screen.queryByTestId('virtualized-image-viewer')
     ).not.toBeInTheDocument();
   });
+
+  it('wraps whichever child renders in the main-viewer container', () => {
+    // MainViewer owns MainViewerContainer/data-testid="main-viewer" itself
+    // now, rather than each child duplicating it - this is the one place
+    // that ownership is exercised.
+    renderMainViewer(true);
+
+    const mainViewer = screen.getByTestId('main-viewer');
+    expect(mainViewer).toContainElement(
+      screen.getByTestId('virtualized-image-viewer')
+    );
+  });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/MainViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/MainViewer.tsx
@@ -21,7 +21,10 @@ const MainViewerContainer = styled.div<{ $useFixedList: boolean }>`
 const MainViewer: FunctionComponent = () => {
   const { hasOnlyRenderableImages } = useItemViewerContext();
   return (
-    <MainViewerContainer $useFixedList={!hasOnlyRenderableImages}>
+    <MainViewerContainer
+      $useFixedList={!hasOnlyRenderableImages}
+      data-testid="main-viewer"
+    >
       {hasOnlyRenderableImages ? (
         <VirtualizedImageViewer />
       ) : (

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -1,0 +1,52 @@
+import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+import {
+  createMockCanvas,
+  createMockManifest,
+} from '@weco/content/test/fixtures/iiif/transformed-manifest';
+
+import PaginatedItemViewer from './PaginatedItemViewer';
+
+// The refactored components read from ItemViewerContextRefactored via the
+// useItemViewerContext hook, which checks the feature flag. Mock it so the
+// hook returns the refactored context values.
+jest.mock('@weco/common/server-data/Context', () => ({
+  ...jest.requireActual('@weco/common/server-data/Context'),
+  useFeatureFlags: () => ({ itemViewerRefactor: true }),
+}));
+
+const renderViewer = (setShowFullscreenControl = jest.fn()) => {
+  const videoCanvas = createMockCanvas({
+    painting: [
+      {
+        id: 'https://example.com/video.mp4',
+        type: 'Video',
+        format: 'video/mp4',
+      },
+    ] as never,
+  });
+
+  return renderWithContext(<PaginatedItemViewer />, {
+    contextProps: {
+      transformedManifest: createMockManifest({ canvases: [videoCanvas] }),
+      setShowFullscreenControl,
+    },
+    useRefactoredContext: true,
+  });
+};
+
+describe('PaginatedItemViewer', () => {
+  it('renders the current item', () => {
+    const { container } = renderViewer();
+
+    expect(
+      container.querySelector('[data-component="video-player"]')
+    ).toBeInTheDocument();
+  });
+
+  it('hides the fullscreen control, since the paginated viewer never supports it', () => {
+    const setShowFullscreenControl = jest.fn();
+    renderViewer(setShowFullscreenControl);
+
+    expect(setShowFullscreenControl).toHaveBeenCalledWith(false);
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -176,7 +176,10 @@ describe('PaginatedItemViewer', () => {
   });
 
   it('renders nothing when the current canvas cannot be resolved', () => {
-    renderWithContext(<PaginatedItemViewer />, {
+    // PaginatedItemViewer no longer owns a wrapping container element (that
+    // now lives in the MainViewer router), so an empty render is a bare
+    // fragment - nothing to query for, just an empty container.
+    const { container } = renderWithContext(<PaginatedItemViewer />, {
       contextProps: {
         transformedManifest: createMockManifest({
           canvases: [createMockCanvas()],
@@ -187,6 +190,6 @@ describe('PaginatedItemViewer', () => {
       useRefactoredContext: true,
     });
 
-    expect(screen.getByTestId('main-viewer')).toBeEmptyDOMElement();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -1,7 +1,12 @@
+import { screen } from '@testing-library/react';
+
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
+  createMockAuth,
   createMockCanvas,
   createMockManifest,
+  createMockQuery,
+  createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
 
 import PaginatedItemViewer from './PaginatedItemViewer';
@@ -48,5 +53,140 @@ describe('PaginatedItemViewer', () => {
     renderViewer(setShowFullscreenControl);
 
     expect(setShowFullscreenControl).toHaveBeenCalledWith(false);
+  });
+
+  it('shows the item for the current canvas when paginating to a later canvas', () => {
+    const canvases = [
+      createMockCanvas({
+        painting: [
+          {
+            id: 'https://example.com/video-1.mp4',
+            type: 'Video',
+            format: 'video/mp4',
+          },
+        ] as never,
+      }),
+      createMockCanvas({
+        painting: [
+          {
+            id: 'https://example.com/video-2.mp4',
+            type: 'Video',
+            format: 'video/mp4',
+          },
+        ] as never,
+      }),
+    ];
+
+    const { container } = renderWithContext(<PaginatedItemViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({ canvases }),
+        query: createMockQuery({ canvas: 2 }),
+        setShowFullscreenControl: jest.fn(),
+      },
+      useRefactoredContext: true,
+    });
+
+    expect(container.querySelector('source')).toHaveAttribute(
+      'src',
+      'https://example.com/video-2.mp4'
+    );
+  });
+
+  it('renders a PDF item from the canvas originals', () => {
+    const canvas = createMockCanvas({
+      original: [
+        {
+          id: 'https://example.com/doc.pdf',
+          type: 'Text',
+          format: 'application/pdf',
+          behavior: 'original',
+        },
+      ] as never,
+    });
+
+    renderWithContext(<PaginatedItemViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({ canvases: [canvas] }),
+        setShowFullscreenControl: jest.fn(),
+      },
+      useRefactoredContext: true,
+    });
+
+    expect(screen.getByRole('link', { name: /open/i })).toBeInTheDocument();
+  });
+
+  it('renders a download link for a born-digital archive item', () => {
+    const canvas = createMockCanvas({
+      painting: [
+        { id: 'https://example.com/placeholder', type: 'Image' },
+      ] as never,
+      original: [
+        {
+          id: 'https://example.com/file.docx',
+          format: 'application/msword',
+          behavior: 'original',
+        },
+      ] as never,
+    });
+
+    renderWithContext(<PaginatedItemViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({ canvases: [canvas] }),
+        setShowFullscreenControl: jest.fn(),
+      },
+      useRefactoredContext: true,
+    });
+
+    expect(screen.getByRole('link', { name: /download/i })).toHaveAttribute(
+      'href',
+      'https://example.com/file.docx'
+    );
+  });
+
+  it('passes the manifest access service through to restricted items', () => {
+    const canvas = createMockCanvas({
+      painting: [
+        createRestrictedPainting({
+          id: 'https://example.com/doc.pdf',
+          type: 'Text',
+          format: 'application/pdf',
+        }),
+      ],
+    });
+
+    renderWithContext(<PaginatedItemViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [canvas],
+          auth: createMockAuth({
+            externalAccessService: {
+              id: 'https://example.com/access',
+              label: 'Restricted access notice',
+            },
+          }),
+        }),
+        setShowFullscreenControl: jest.fn(),
+      },
+      useRefactoredContext: true,
+    });
+
+    expect(
+      screen.getByRole('heading', { name: 'Restricted access notice' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when the current canvas cannot be resolved', () => {
+    renderWithContext(<PaginatedItemViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas()],
+        }),
+        query: createMockQuery({ canvas: 99 }),
+        setShowFullscreenControl: jest.fn(),
+      },
+      useRefactoredContext: true,
+    });
+
+    expect(screen.getByTestId('main-viewer')).toBeEmptyDOMElement();
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockAuth,
@@ -19,29 +20,24 @@ jest.mock('@weco/common/server-data/Context', () => ({
   useFeatureFlags: () => ({ itemViewerRefactor: true }),
 }));
 
-const renderViewer = (setShowFullscreenControl = jest.fn()) => {
-  const videoCanvas = createMockCanvas({
-    painting: [
-      {
-        id: 'https://example.com/video.mp4',
-        type: 'Video',
-        format: 'video/mp4',
-      },
-    ] as never,
+const createVideoCanvas = (id = 'https://example.com/video.mp4') =>
+  createMockCanvas({
+    painting: [{ id, type: 'Video', format: 'video/mp4' }] as never,
   });
 
-  return renderWithContext(<PaginatedItemViewer />, {
-    contextProps: {
-      transformedManifest: createMockManifest({ canvases: [videoCanvas] }),
-      setShowFullscreenControl,
-    },
+const renderViewer = (contextProps: Partial<ItemViewerContextProps> = {}) =>
+  renderWithContext(<PaginatedItemViewer />, {
+    contextProps,
     useRefactoredContext: true,
   });
-};
 
 describe('PaginatedItemViewer', () => {
   it('renders the current item', () => {
-    const { container } = renderViewer();
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [createVideoCanvas()],
+      }),
+    });
 
     expect(
       container.querySelector('[data-component="video-player"]')
@@ -50,40 +46,26 @@ describe('PaginatedItemViewer', () => {
 
   it('hides the fullscreen control, since the paginated viewer never supports it', () => {
     const setShowFullscreenControl = jest.fn();
-    renderViewer(setShowFullscreenControl);
+
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [createVideoCanvas()],
+      }),
+      setShowFullscreenControl,
+    });
 
     expect(setShowFullscreenControl).toHaveBeenCalledWith(false);
   });
 
   it('renders the item for the canvas number associated with the query', () => {
-    const canvases = [
-      createMockCanvas({
-        painting: [
-          {
-            id: 'https://example.com/video-1.mp4',
-            type: 'Video',
-            format: 'video/mp4',
-          },
-        ] as never,
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createVideoCanvas('https://example.com/video-1.mp4'),
+          createVideoCanvas('https://example.com/video-2.mp4'),
+        ],
       }),
-      createMockCanvas({
-        painting: [
-          {
-            id: 'https://example.com/video-2.mp4',
-            type: 'Video',
-            format: 'video/mp4',
-          },
-        ] as never,
-      }),
-    ];
-
-    const { container } = renderWithContext(<PaginatedItemViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({ canvases }),
-        query: createMockQuery({ canvas: 2 }),
-        setShowFullscreenControl: jest.fn(),
-      },
-      useRefactoredContext: true,
+      query: createMockQuery({ canvas: 2 }),
     });
 
     expect(container.querySelector('source')).toHaveAttribute(
@@ -93,48 +75,44 @@ describe('PaginatedItemViewer', () => {
   });
 
   it('renders a PDF item from the canvas originals', () => {
-    const canvas = createMockCanvas({
-      original: [
-        {
-          id: 'https://example.com/doc.pdf',
-          type: 'Text',
-          format: 'application/pdf',
-          behavior: 'original',
-        },
-      ] as never,
-    });
-
-    renderWithContext(<PaginatedItemViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({ canvases: [canvas] }),
-        setShowFullscreenControl: jest.fn(),
-      },
-      useRefactoredContext: true,
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            original: [
+              {
+                id: 'https://example.com/doc.pdf',
+                type: 'Text',
+                format: 'application/pdf',
+                behavior: 'original',
+              },
+            ] as never,
+          }),
+        ],
+      }),
     });
 
     expect(screen.getByRole('link', { name: /open/i })).toBeInTheDocument();
   });
 
   it('renders a download link for a born-digital archive item', () => {
-    const canvas = createMockCanvas({
-      painting: [
-        { id: 'https://example.com/placeholder', type: 'Image' },
-      ] as never,
-      original: [
-        {
-          id: 'https://example.com/file.docx',
-          format: 'application/msword',
-          behavior: 'original',
-        },
-      ] as never,
-    });
-
-    renderWithContext(<PaginatedItemViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({ canvases: [canvas] }),
-        setShowFullscreenControl: jest.fn(),
-      },
-      useRefactoredContext: true,
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            painting: [
+              { id: 'https://example.com/placeholder', type: 'Image' },
+            ] as never,
+            original: [
+              {
+                id: 'https://example.com/file.docx',
+                format: 'application/msword',
+                behavior: 'original',
+              },
+            ] as never,
+          }),
+        ],
+      }),
     });
 
     expect(screen.getByRole('link', { name: /download/i })).toHaveAttribute(
@@ -144,30 +122,26 @@ describe('PaginatedItemViewer', () => {
   });
 
   it('passes the manifest access service through to restricted items', () => {
-    const canvas = createMockCanvas({
-      painting: [
-        createRestrictedPainting({
-          id: 'https://example.com/doc.pdf',
-          type: 'Text',
-          format: 'application/pdf',
-        }),
-      ],
-    });
-
-    renderWithContext(<PaginatedItemViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({
-          canvases: [canvas],
-          auth: createMockAuth({
-            externalAccessService: {
-              id: 'https://example.com/access',
-              label: 'Restricted access notice',
-            },
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            painting: [
+              createRestrictedPainting({
+                id: 'https://example.com/doc.pdf',
+                type: 'Text',
+                format: 'application/pdf',
+              }),
+            ],
           }),
+        ],
+        auth: createMockAuth({
+          externalAccessService: {
+            id: 'https://example.com/access',
+            label: 'Restricted access notice',
+          },
         }),
-        setShowFullscreenControl: jest.fn(),
-      },
-      useRefactoredContext: true,
+      }),
     });
 
     expect(
@@ -176,20 +150,15 @@ describe('PaginatedItemViewer', () => {
   });
 
   it('renders nothing when the current canvas cannot be resolved', () => {
-    // PaginatedItemViewer returns null when useCurrentCanvas() can't resolve
-    // a canvas (eg an out-of-range canvas query param, as below) - nothing to
-    // query for, just an empty container.
-    const { container } = renderWithContext(<PaginatedItemViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({
-          canvases: [createMockCanvas()],
-        }),
-        query: createMockQuery({ canvas: 99 }),
-        setShowFullscreenControl: jest.fn(),
-      },
-      useRefactoredContext: true,
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [createMockCanvas()],
+      }),
+      query: createMockQuery({ canvas: 99 }),
     });
 
+    // The wrapping container belongs to the MainViewer router, so returning
+    // null leaves nothing of ours in the DOM at all.
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -55,7 +55,7 @@ describe('PaginatedItemViewer', () => {
     expect(setShowFullscreenControl).toHaveBeenCalledWith(false);
   });
 
-  it('shows the item for the current canvas when paginating to a later canvas', () => {
+  it('renders the item for the canvas number associated with the query', () => {
     const canvases = [
       createMockCanvas({
         painting: [

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -176,9 +176,9 @@ describe('PaginatedItemViewer', () => {
   });
 
   it('renders nothing when the current canvas cannot be resolved', () => {
-    // PaginatedItemViewer no longer owns a wrapping container element (that
-    // now lives in the MainViewer router), so an empty render is a bare
-    // fragment - nothing to query for, just an empty container.
+    // PaginatedItemViewer returns null when useCurrentCanvas() can't resolve
+    // a canvas (eg an out-of-range canvas query param, as below) - nothing to
+    // query for, just an empty container.
     const { container } = renderWithContext(<PaginatedItemViewer />, {
       contextProps: {
         transformedManifest: createMockManifest({

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
@@ -39,26 +39,25 @@ const PaginatedItemViewer: FunctionComponent = () => {
     setShowFullscreenControl(false);
   }, [setShowFullscreenControl]);
 
-  const displayItems = currentCanvas ? getDisplayItems(currentCanvas) : [];
+  if (!currentCanvas) return null;
 
-  return displayItems.map(
-    (item, i) =>
-      currentCanvas && (
-        <ItemWrapper data-component="paginated" key={item.type + item.id}>
-          <IIIFItem
-            placeholderId={placeholderId}
-            item={item}
-            i={i}
-            canvas={currentCanvas}
-            titleOverride={`${canvas}/${canvases?.length}`}
-            exclude={[]}
-            isDark={true}
-            externalAccessService={externalAccessService}
-            showVideoTranscript={false}
-          />
-        </ItemWrapper>
-      )
-  );
+  const displayItems = getDisplayItems(currentCanvas);
+
+  return displayItems.map((item, i) => (
+    <ItemWrapper key={item.type + item.id} data-component="paginated">
+      <IIIFItem
+        placeholderId={placeholderId}
+        item={item}
+        i={i}
+        canvas={currentCanvas}
+        titleOverride={`${canvas}/${canvases?.length}`}
+        exclude={[]}
+        isDark={true}
+        externalAccessService={externalAccessService}
+        showVideoTranscript={false}
+      />
+    </ItemWrapper>
+  ));
 };
 
 export default PaginatedItemViewer;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
@@ -230,6 +230,7 @@ const SearchTermHighlights: FunctionComponent<{
           return (
             <SearchTermHighlight
               key={i}
+              data-testid="search-term-highlight"
               $top={item.overlayTop}
               $left={item.overlayLeft}
               $width={item.highlight.w}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -1,0 +1,60 @@
+import { screen } from '@testing-library/react';
+
+import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+import {
+  createMockCanvas,
+  createMockManifest,
+  createOpenPainting,
+} from '@weco/content/test/fixtures/iiif/transformed-manifest';
+import { TransformedCanvas } from '@weco/content/types/manifest';
+
+import VirtualizedImageViewer from './VirtualizedImageViewer';
+
+// The refactored components read from ItemViewerContextRefactored via the
+// useItemViewerContext hook, which checks the feature flag. Mock it so the
+// hook returns the refactored context values.
+jest.mock('@weco/common/server-data/Context', () => ({
+  ...jest.requireActual('@weco/common/server-data/Context'),
+  useFeatureFlags: () => ({ itemViewerRefactor: true }),
+}));
+
+// jsdom doesn't implement IntersectionObserver, which the image item's
+// scroll-to-url-update behaviour relies on via useOnScreen.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds = [];
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+  takeRecords = jest.fn(() => []);
+}
+window.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+const renderViewer = (canvases: TransformedCanvas[] = [createMockCanvas()]) =>
+  renderWithContext(<VirtualizedImageViewer />, {
+    contextProps: { transformedManifest: createMockManifest({ canvases }) },
+    useRefactoredContext: true,
+  });
+
+describe('VirtualizedImageViewer', () => {
+  it('renders the fixed-list main viewer container', () => {
+    renderViewer();
+
+    expect(screen.getByTestId('main-viewer')).toBeInTheDocument();
+  });
+
+  it('renders the virtualized image items for the canvases in view', () => {
+    renderViewer([
+      createMockCanvas({ painting: [createOpenPainting()] }),
+      createMockCanvas({ painting: [createOpenPainting()] }),
+    ]);
+
+    // Both canvases fall within the FixedSizeList's rendered/overscan range
+    // given the default mainAreaHeight/itemSize, so both images are present.
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(2);
+    expect(images[0]).toHaveAttribute('src', 'https://example.com/image/open');
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -1,10 +1,12 @@
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockCanvas,
   createMockManifest,
+  createMockQuery,
   createOpenPainting,
+  createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 
@@ -56,5 +58,132 @@ describe('VirtualizedImageViewer', () => {
     const images = screen.getAllByRole('img');
     expect(images).toHaveLength(2);
     expect(images[0]).toHaveAttribute('src', 'https://example.com/image/open');
+  });
+
+  it('scrolls to the current canvas position on mount, accounting for landscape aspect ratio', () => {
+    const canvases = [
+      createMockCanvas({
+        width: 1000,
+        height: 1000,
+        painting: [createOpenPainting()],
+      }),
+      // Landscape: scrollViewer centres the shorter rendered image within the
+      // square FixedSizeList row instead of scrolling straight to its top.
+      createMockCanvas({
+        width: 2000,
+        height: 1000,
+        painting: [createOpenPainting()],
+      }),
+    ];
+
+    const { container } = renderWithContext(<VirtualizedImageViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({ canvases }),
+        query: createMockQuery({ canvas: 2 }),
+      },
+      useRefactoredContext: true,
+    });
+
+    // mainAreaWidth/itemSize default to 1000, mainAreaHeight to 500.
+    // renderedHeight = 1000 * (1000/2000) * 0.8 = 400
+    // heightOfPreviousItems = 1 * 1000 = 1000
+    // distanceToScroll = 1000 + (1000 - 400) / 2 = 1300
+    const scrollContainer = container.querySelector(
+      '[data-testid="main-viewer"] > div'
+    );
+    expect(scrollContainer?.scrollTop).toBe(1300);
+  });
+
+  it('hides controls while scrolling and restores them once scrolling settles', () => {
+    jest.useFakeTimers();
+    const setShowControls = jest.fn();
+
+    const { container } = renderWithContext(<VirtualizedImageViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas({ painting: [createOpenPainting()] })],
+        }),
+        setShowControls,
+      },
+      useRefactoredContext: true,
+    });
+
+    const scrollContainer = container.querySelector(
+      '[data-testid="main-viewer"] > div'
+    )!;
+
+    act(() => {
+      fireEvent.scroll(scrollContainer, { target: { scrollTop: 100 } });
+    });
+    expect(setShowControls).toHaveBeenCalledWith(false);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(setShowControls).toHaveBeenCalledWith(true);
+
+    jest.useRealTimers();
+  });
+
+  it('adds top margin to the first item when it is restricted, to clear the restricted-access banner', () => {
+    const { container } = renderViewer([
+      createMockCanvas({ painting: [createRestrictedPainting()] }),
+    ]);
+
+    const itemWrapper = container.querySelector(
+      '[data-testid="main-viewer"] > div > div > div > div'
+    );
+    expect(itemWrapper).toHaveStyle({ marginTop: '2em' });
+  });
+
+  it('renders a search-hit highlight overlay for a matching canvas', async () => {
+    const canvasId =
+      'https://iiif.wellcomecollection.org/presentation/v3/b00000000/canvases/b00000000_0001.jp2';
+    const imageId =
+      'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2';
+    const canvas = createMockCanvas({
+      id: canvasId,
+      // Needs a real ImageService2 item (not the plain <img> fallback that
+      // createOpenPainting gives us) - only the ImageViewer path measures
+      // and reports back the image position that the overlay math needs.
+      painting: [
+        {
+          id: imageId,
+          type: 'Image',
+          service: [{ '@id': imageId, '@type': 'ImageService2' }],
+        } as never,
+      ],
+    });
+
+    const { container } = renderWithContext(<VirtualizedImageViewer />, {
+      contextProps: {
+        transformedManifest: createMockManifest({ canvases: [canvas] }),
+        searchResults: {
+          '@context': '',
+          '@id': '',
+          '@type': 'sc:AnnotationList',
+          within: { '@type': '', total: null },
+          startIndex: 0,
+          resources: [
+            {
+              '@id': '',
+              '@type': 'oa:Annotation',
+              motivation: 'sc:painting',
+              resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
+              on: `${canvasId}#xywh=100,200,50,60`,
+            },
+          ],
+          hits: [],
+        },
+      },
+      useRefactoredContext: true,
+    });
+
+    // The highlight overlay renders as an extra sibling alongside the item
+    // wrapper, once the image position effect has run.
+    const row = container.querySelector(
+      '[data-testid="main-viewer"] > div > div > div'
+    );
+    await waitFor(() => expect(row?.children).toHaveLength(2));
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -41,10 +41,15 @@ const renderViewer = (canvases: TransformedCanvas[] = [createMockCanvas()]) =>
   });
 
 describe('VirtualizedImageViewer', () => {
-  it('renders the fixed-list main viewer container', () => {
-    renderViewer();
+  it('renders the fixed-list scroll container sized to the main area', () => {
+    // The MainViewerContainer/data-testid="main-viewer" wrapper now lives in
+    // the MainViewer router, not here - see MainViewer.test.tsx for that.
+    const { container } = renderViewer();
 
-    expect(screen.getByTestId('main-viewer')).toBeInTheDocument();
+    expect(container.querySelector('div')).toHaveStyle({
+      width: '1000px',
+      height: '500px',
+    });
   });
 
   it('renders the virtualized image items for the canvases in view', () => {
@@ -88,9 +93,7 @@ describe('VirtualizedImageViewer', () => {
     // renderedHeight = 1000 * (1000/2000) * 0.8 = 400
     // heightOfPreviousItems = 1 * 1000 = 1000
     // distanceToScroll = 1000 + (1000 - 400) / 2 = 1300
-    const scrollContainer = container.querySelector(
-      '[data-testid="main-viewer"] > div'
-    );
+    const scrollContainer = container.querySelector('div');
     expect(scrollContainer?.scrollTop).toBe(1300);
   });
 
@@ -108,9 +111,7 @@ describe('VirtualizedImageViewer', () => {
       useRefactoredContext: true,
     });
 
-    const scrollContainer = container.querySelector(
-      '[data-testid="main-viewer"] > div'
-    )!;
+    const scrollContainer = container.querySelector('div')!;
 
     act(() => {
       fireEvent.scroll(scrollContainer, { target: { scrollTop: 100 } });
@@ -130,9 +131,9 @@ describe('VirtualizedImageViewer', () => {
       createMockCanvas({ painting: [createRestrictedPainting()] }),
     ]);
 
-    const itemWrapper = container.querySelector(
-      '[data-testid="main-viewer"] > div > div > div > div'
-    );
+    // RTL's own mounting div is itself a <div>, so it counts as one of the
+    // ancestor levels: container(RTL) > scroll > sizer > row > wrapper.
+    const itemWrapper = container.querySelector('div > div > div > div > div');
     expect(itemWrapper).toHaveStyle({ marginTop: '2em' });
   });
 
@@ -180,10 +181,9 @@ describe('VirtualizedImageViewer', () => {
     });
 
     // The highlight overlay renders as an extra sibling alongside the item
-    // wrapper, once the image position effect has run.
-    const row = container.querySelector(
-      '[data-testid="main-viewer"] > div > div > div'
-    );
+    // wrapper, once the image position effect has run. RTL's own mounting
+    // div counts as one ancestor level: container(RTL) > scroll > sizer > row.
+    const row = container.querySelector('div > div > div > div');
     await waitFor(() => expect(row?.children).toHaveLength(2));
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -41,6 +41,12 @@ const renderViewer = (canvases: TransformedCanvas[] = [createMockCanvas()]) =>
   });
 
 describe('VirtualizedImageViewer', () => {
+  // One test below swaps in fake timers. Restore real ones unconditionally, so
+  // a failed assertion can't leave the rest of the file running under them.
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('renders the fixed-list scroll container sized to the main area', () => {
     // The MainViewerContainer/data-testid="main-viewer" wrapper now lives in
     // the MainViewer router, not here - see MainViewer.test.tsx for that.
@@ -122,8 +128,6 @@ describe('VirtualizedImageViewer', () => {
       jest.advanceTimersByTime(500);
     });
     expect(setShowControls).toHaveBeenCalledWith(true);
-
-    jest.useRealTimers();
   });
 
   it('adds top margin to the first item when it is restricted, to clear the restricted-access banner', () => {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockCanvas,
@@ -8,7 +9,6 @@ import {
   createOpenPainting,
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
-import { TransformedCanvas } from '@weco/content/types/manifest';
 
 import VirtualizedImageViewer from './VirtualizedImageViewer';
 
@@ -34,9 +34,14 @@ class MockIntersectionObserver implements IntersectionObserver {
 window.IntersectionObserver =
   MockIntersectionObserver as unknown as typeof IntersectionObserver;
 
-const renderViewer = (canvases: TransformedCanvas[] = [createMockCanvas()]) =>
+// The FixedSizeList's outer element. This viewer renders it as its own root,
+// so it's the first div in the tree.
+const getScrollContainer = (container: HTMLElement) =>
+  container.querySelector('div')!;
+
+const renderViewer = (contextProps: Partial<ItemViewerContextProps> = {}) =>
   renderWithContext(<VirtualizedImageViewer />, {
-    contextProps: { transformedManifest: createMockManifest({ canvases }) },
+    contextProps,
     useRefactoredContext: true,
   });
 
@@ -48,21 +53,23 @@ describe('VirtualizedImageViewer', () => {
   });
 
   it('renders the fixed-list scroll container sized to the main area', () => {
-    // The MainViewerContainer/data-testid="main-viewer" wrapper now lives in
-    // the MainViewer router, not here - see MainViewer.test.tsx for that.
     const { container } = renderViewer();
 
-    expect(container.querySelector('div')).toHaveStyle({
+    expect(getScrollContainer(container)).toHaveStyle({
       width: '1000px',
       height: '500px',
     });
   });
 
   it('renders the virtualized image items for the canvases in view', () => {
-    renderViewer([
-      createMockCanvas({ painting: [createOpenPainting()] }),
-      createMockCanvas({ painting: [createOpenPainting()] }),
-    ]);
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({ painting: [createOpenPainting()] }),
+          createMockCanvas({ painting: [createOpenPainting()] }),
+        ],
+      }),
+    });
 
     // Both canvases fall within the FixedSizeList's rendered/overscan range
     // given the default mainAreaHeight/itemSize, so both images are present.
@@ -72,55 +79,50 @@ describe('VirtualizedImageViewer', () => {
   });
 
   it('scrolls to the current canvas position on mount, accounting for landscape aspect ratio', () => {
-    const canvases = [
-      createMockCanvas({
-        width: 1000,
-        height: 1000,
-        painting: [createOpenPainting()],
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            width: 1000,
+            height: 1000,
+            painting: [createOpenPainting()],
+          }),
+          // Landscape: scrollViewer centres the shorter rendered image within
+          // the square FixedSizeList row instead of scrolling to its top.
+          createMockCanvas({
+            width: 2000,
+            height: 1000,
+            painting: [createOpenPainting()],
+          }),
+        ],
       }),
-      // Landscape: scrollViewer centres the shorter rendered image within the
-      // square FixedSizeList row instead of scrolling straight to its top.
-      createMockCanvas({
-        width: 2000,
-        height: 1000,
-        painting: [createOpenPainting()],
-      }),
-    ];
-
-    const { container } = renderWithContext(<VirtualizedImageViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({ canvases }),
-        query: createMockQuery({ canvas: 2 }),
-      },
-      useRefactoredContext: true,
+      query: createMockQuery({ canvas: 2 }),
     });
 
+    // The scroll happens on mount via the effect on `canvas`, since the query
+    // defaults to shouldScrollToCanvas - not via the debounced onItemsRendered.
     // mainAreaWidth/itemSize default to 1000, mainAreaHeight to 500.
     // renderedHeight = 1000 * (1000/2000) * 0.8 = 400
     // heightOfPreviousItems = 1 * 1000 = 1000
     // distanceToScroll = 1000 + (1000 - 400) / 2 = 1300
-    const scrollContainer = container.querySelector('div');
-    expect(scrollContainer?.scrollTop).toBe(1300);
+    expect(getScrollContainer(container).scrollTop).toBe(1300);
   });
 
   it('hides controls while scrolling and restores them once scrolling settles', () => {
     jest.useFakeTimers();
     const setShowControls = jest.fn();
 
-    const { container } = renderWithContext(<VirtualizedImageViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({
-          canvases: [createMockCanvas({ painting: [createOpenPainting()] })],
-        }),
-        setShowControls,
-      },
-      useRefactoredContext: true,
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [createMockCanvas({ painting: [createOpenPainting()] })],
+      }),
+      setShowControls,
     });
 
-    const scrollContainer = container.querySelector('div')!;
-
     act(() => {
-      fireEvent.scroll(scrollContainer, { target: { scrollTop: 100 } });
+      fireEvent.scroll(getScrollContainer(container), {
+        target: { scrollTop: 100 },
+      });
     });
     expect(setShowControls).toHaveBeenCalledWith(false);
 
@@ -131,14 +133,15 @@ describe('VirtualizedImageViewer', () => {
   });
 
   it('adds top margin to the first item when it is restricted, to clear the restricted-access banner', () => {
-    const { container } = renderViewer([
-      createMockCanvas({ painting: [createRestrictedPainting()] }),
-    ]);
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({ painting: [createRestrictedPainting()] }),
+        ],
+      }),
+    });
 
-    // RTL's own mounting div is itself a <div>, so it counts as one of the
-    // ancestor levels: container(RTL) > scroll > sizer > row > wrapper.
-    const itemWrapper = container.querySelector('div > div > div > div > div');
-    expect(itemWrapper).toHaveStyle({ marginTop: '2em' });
+    expect(screen.getByTestId('image-item')).toHaveStyle({ marginTop: '2em' });
   });
 
   it('renders a search-hit highlight overlay for a matching canvas', async () => {
@@ -146,48 +149,48 @@ describe('VirtualizedImageViewer', () => {
       'https://iiif.wellcomecollection.org/presentation/v3/b00000000/canvases/b00000000_0001.jp2';
     const imageId =
       'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2';
-    const canvas = createMockCanvas({
-      id: canvasId,
-      // Needs a real ImageService2 item (not the plain <img> fallback that
-      // createOpenPainting gives us) - only the ImageViewer path measures
-      // and reports back the image position that the overlay math needs.
-      painting: [
-        {
-          id: imageId,
-          type: 'Image',
-          service: [{ '@id': imageId, '@type': 'ImageService2' }],
-        } as never,
-      ],
-    });
 
-    const { container } = renderWithContext(<VirtualizedImageViewer />, {
-      contextProps: {
-        transformedManifest: createMockManifest({ canvases: [canvas] }),
-        searchResults: {
-          '@context': '',
-          '@id': '',
-          '@type': 'sc:AnnotationList',
-          within: { '@type': '', total: null },
-          startIndex: 0,
-          resources: [
-            {
-              '@id': '',
-              '@type': 'oa:Annotation',
-              motivation: 'sc:painting',
-              resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
-              on: `${canvasId}#xywh=100,200,50,60`,
-            },
-          ],
-          hits: [],
-        },
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            id: canvasId,
+            // Needs a real ImageService2 item (not the plain <img> fallback
+            // that createOpenPainting gives us) - only the ImageViewer path
+            // measures and reports back the image position the overlay needs.
+            painting: [
+              {
+                id: imageId,
+                type: 'Image',
+                service: [{ '@id': imageId, '@type': 'ImageService2' }],
+              } as never,
+            ],
+          }),
+        ],
+      }),
+      searchResults: {
+        '@context': '',
+        '@id': '',
+        '@type': 'sc:AnnotationList',
+        within: { '@type': '', total: null },
+        startIndex: 0,
+        resources: [
+          {
+            '@id': '',
+            '@type': 'oa:Annotation',
+            motivation: 'sc:painting',
+            resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
+            on: `${canvasId}#xywh=100,200,50,60`,
+          },
+        ],
+        hits: [],
       },
-      useRefactoredContext: true,
     });
 
-    // The highlight overlay renders as an extra sibling alongside the item
-    // wrapper, once the image position effect has run. `react-testing-library` own mounting
-    // div counts as one ancestor level: container(RTL) > scroll > sizer > row.
-    const row = container.querySelector('div > div > div > div');
-    await waitFor(() => expect(row?.children).toHaveLength(2));
+    // The overlay only appears once the image has reported its measured
+    // position back up, which happens in an effect after the initial render.
+    await waitFor(() =>
+      expect(screen.getByTestId('search-term-highlight')).toBeInTheDocument()
+    );
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -171,7 +171,7 @@ describe('VirtualizedImageViewer', () => {
     // It does not suppress the first-render scroll behind onItemsRendered,
     // though - that path doesn't consult the flag, so the viewer still jumps
     // once the 500ms debounce elapses. Pinned here as current behaviour rather
-    // than endorsed: see the note on the PR.
+    // than endorsed.
     act(() => {
       jest.advanceTimersByTime(500);
     });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -6,6 +6,8 @@ import {
   createMockCanvas,
   createMockManifest,
   createMockQuery,
+  createMockSearchHit,
+  createMockSearchResults,
   createOpenPainting,
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
@@ -101,10 +103,78 @@ describe('VirtualizedImageViewer', () => {
 
     // The scroll happens on mount via the effect on `canvas`, since the query
     // defaults to shouldScrollToCanvas - not via the debounced onItemsRendered.
+    //
+    // scrollViewer isn't exported, so its maths is asserted through the DOM:
+    // FixedSizeList.scrollTo() writes scrollTop on its outer element, and jsdom
+    // records that despite never laying anything out. If react-window ever stops
+    // driving scroll position imperatively, this fails loudly rather than
+    // quietly passing.
+    //
     // mainAreaWidth/itemSize default to 1000, mainAreaHeight to 500.
     // renderedHeight = 1000 * (1000/2000) * 0.8 = 400
     // heightOfPreviousItems = 1 * 1000 = 1000
     // distanceToScroll = 1000 + (1000 - 400) / 2 = 1300
+    expect(getScrollContainer(container).scrollTop).toBe(1300);
+  });
+
+  it('scrolls to the top of the current canvas on mount when it is portrait', () => {
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            width: 1000,
+            height: 1400,
+            painting: [createOpenPainting()],
+          }),
+          createMockCanvas({
+            width: 1000,
+            height: 1400,
+            painting: [createOpenPainting()],
+          }),
+        ],
+      }),
+      query: createMockQuery({ canvas: 2 }),
+    });
+
+    // Portrait canvases skip the centring maths above entirely: scrollViewer
+    // calls scrollToItem(1, 'start'), putting the top of the second item at the
+    // top of the viewport - 1 * itemSize = 1000.
+    expect(getScrollContainer(container).scrollTop).toBe(1000);
+  });
+
+  it('skips the canvas-change scroll when shouldScrollToCanvas is false', () => {
+    jest.useFakeTimers();
+
+    const { container } = renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({
+            width: 2000,
+            height: 1000,
+            painting: [createOpenPainting()],
+          }),
+          createMockCanvas({
+            width: 2000,
+            height: 1000,
+            painting: [createOpenPainting()],
+          }),
+        ],
+      }),
+      query: createMockQuery({ canvas: 2, shouldScrollToCanvas: false }),
+    });
+
+    // The flag is set when the canvas changed *because* the viewer was
+    // scrolled, so scrolling again would fight the user. It suppresses the
+    // effect on `canvas`.
+    expect(getScrollContainer(container).scrollTop).toBe(0);
+
+    // It does not suppress the first-render scroll behind onItemsRendered,
+    // though - that path doesn't consult the flag, so the viewer still jumps
+    // once the 500ms debounce elapses. Pinned here as current behaviour rather
+    // than endorsed: see the note on the PR.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
     expect(getScrollContainer(container).scrollTop).toBe(1300);
   });
 
@@ -168,23 +238,11 @@ describe('VirtualizedImageViewer', () => {
           }),
         ],
       }),
-      searchResults: {
-        '@context': '',
-        '@id': '',
-        '@type': 'sc:AnnotationList',
-        within: { '@type': '', total: null },
-        startIndex: 0,
+      searchResults: createMockSearchResults({
         resources: [
-          {
-            '@id': '',
-            '@type': 'oa:Annotation',
-            motivation: 'sc:painting',
-            resource: { '@type': 'cnt:ContentAsText', chars: 'hit' },
-            on: `${canvasId}#xywh=100,200,50,60`,
-          },
+          createMockSearchHit({ on: `${canvasId}#xywh=100,200,50,60` }),
         ],
-        hits: [],
-      },
+      }),
     });
 
     // The overlay only appears once the image has reported its measured

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -185,7 +185,7 @@ describe('VirtualizedImageViewer', () => {
     });
 
     // The highlight overlay renders as an extra sibling alongside the item
-    // wrapper, once the image position effect has run. RTL's own mounting
+    // wrapper, once the image position effect has run. `react-testing-library` own mounting
     // div counts as one ancestor level: container(RTL) > scroll > sizer > row.
     const row = container.querySelector('div > div > div > div');
     await waitFor(() => expect(row?.children).toHaveLength(2));

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
@@ -72,6 +72,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
               return (
                 <ItemWrapper
                   key={item.type + item.id}
+                  data-testid="image-item"
                   $firstItemIsRestricted={!!firstItemIsRestricted}
                 >
                   <IIIFItem


### PR DESCRIPTION
For #12985

## What does this change?

Step 5 of the `MainViewer.tsx` split, following the `VirtualizedImageViewer` /
`PaginatedItemViewer` split in #13304 (since merged to `main`).

Adds unit tests for the components created by the split, plus a matching set for
the legacy implementation they were split out of.

Under `refactored/`:
- **`MainViewer.test.tsx`** (3) — mocks both child viewers as sentinels and asserts pure routing: image-only context renders `VirtualizedImageViewer`, mixed context renders `PaginatedItemViewer`.
- **`VirtualizedImageViewer.test.tsx`** (6) — the fixed-list container and virtualized image items; the initial scroll-to-canvas-on-mount maths, including the landscape-aspect-ratio centring in `scrollViewer`; scroll-driven control hiding/restoring; the `firstItemIsRestricted` margin; and the search-hit highlight overlay.
- **`PaginatedItemViewer.test.tsx`** (7) — current item rendering, the `setShowFullscreenControl(false)` effect, the canvas the query points at, a PDF-from-originals item, a born-digital download link, `externalAccessService` propagation, and the no-resolvable-canvas edge case.

Under `legacy/`:
- **`MainViewer.test.tsx`** (13) — mirrors the two files above test for test. Legacy `MainViewer` is both viewers in one component, so they sit in two describes selected by `hasOnlyRenderableImages`. The shared test bodies are line-for-line identical to their refactored twins, so a diff between the files shows only what the split actually changed.

This addresses the review point about only covering one side: the claim that the
split preserved behaviour is now checked against both implementations rather than
asserted. Two differences remain deliberately — the empty-render test asserts
against `main-viewer` in legacy and the whole container in refactored (legacy
always renders `MainViewerContainer`; the refactored viewer returns `null`), and
`refactored/MainViewer.test.tsx` has no legacy counterpart, since legacy has no
child components to route between.

The refactored tests use the established #13296 pattern: `jest.mock`
`useFeatureFlags` -> `{ itemViewerRefactor: true }` and `renderWithContext(...,
{ useRefactoredContext: true })`. The legacy file does neither, so
`useItemViewerContext` resolves to the legacy context.

### Production code changes

Small, and in service of the tests:
- `refactored/PaginatedItemViewer.tsx` now returns `null` when there's no resolvable canvas, rather than falling out of a `.map()` over an empty array with a redundant `currentCanvas &&` guard inside it. Renders identically.
- Four `data-testid` hooks (`image-item`, `search-term-highlight`) across `legacy/MainViewer.tsx`, `refactored/VirtualizedImageViewer.tsx` and `refactored/VirtualizedImageViewer.SearchHighlights.tsx`, replacing `div > div > div > div` selectors that broke as soon as the DOM shape changed.

`legacy/MainViewer.tsx` is therefore no longer untouched by this branch, as this
description previously claimed — but the two attributes carry no behaviour.

## How to test

- `yarn tsc && yarn lint && yarn test:content` all pass (578 tests, up from 549 on `main`).
- Worth knowing for review: when the legacy tests were first run against `legacy/MainViewer.tsx`, 11 of the 13 passed unmodified. The two that didn't were both DOM-shape assertions rather than behavioural ones, and both were resolved by the `data-testid` hooks above.
- No manual smoke test needed beyond what `playwright/test/view-items-refactored.test.ts` already covers.

## Have we considered potential risks?

Low risk. The only production change with any semantics is the `PaginatedItemViewer`
null return, which renders identically (`[]` and `null` both render nothing) and
is covered by a test on both sides. The `data-testid`s are inert attributes.

Two notes for reviewers:
- Both `refactored/VirtualizedImageViewer.test.tsx` and `legacy/MainViewer.test.tsx` add a local `IntersectionObserver` stub, since jsdom doesn't implement it and these are the first tests to mount a canvas with real `painting` content through the image-scroll-to-url-update path.
- The legacy tests are duplication with a known expiry: they should be deleted in the same commit that deletes `legacy/`. Worth treating that as deliberate and time-boxed rather than something to reconcile later.
