### PR TITLE
Add shareable copy-links for modes on the toggles dashboard

### DIFF
--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.CopyLinkIcon.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.CopyLinkIcon.tsx
@@ -79,10 +79,11 @@ const CopiedBadge = styled.span`
   }
 `;
 
-export type CopyLinkIconProps = { toggleId: string; title: string } & (
-  | { modeValue?: undefined }
-  | { modeValue: string }
-);
+export type CopyLinkIconProps = {
+  toggleId: string;
+  title: string;
+  modeValue?: string;
+};
 
 const CopyLinkIcon: FunctionComponent<CopyLinkIconProps> = props => {
   const { title, modeValue } = props;

--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.CopyLinkIcon.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.CopyLinkIcon.tsx
@@ -3,9 +3,18 @@ import styled from 'styled-components';
 
 import { tokens } from '@weco/dash/views/themes/tokens';
 
-const copyEnableLink = async (toggleId: string): Promise<void> => {
-  const url = `${window.location.origin}${window.location.pathname}?enableToggle=${encodeURIComponent(
-    toggleId
+const buildQuery = (props: CopyLinkIconProps): string => {
+  if (props.modeValue !== undefined) {
+    return `enableMode=${encodeURIComponent(
+      props.toggleId
+    )}&modeValue=${encodeURIComponent(props.modeValue)}`;
+  }
+  return `enableToggle=${encodeURIComponent(props.toggleId)}`;
+};
+
+const copyEnableLink = async (props: CopyLinkIconProps): Promise<void> => {
+  const url = `${window.location.origin}${window.location.pathname}?${buildQuery(
+    props
   )}`;
   await navigator.clipboard.writeText(url);
 };
@@ -33,12 +42,18 @@ const IconButton = styled.button`
 `;
 
 const CopiedBadge = styled.span`
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  pointer-events: none;
+  white-space: nowrap;
   font-size: ${tokens.typography.fontSize.small};
   color: ${tokens.colors.success.text};
   background: ${tokens.colors.success.light};
   padding: 2px 6px;
   border-radius: 10px;
-  margin-left: ${tokens.spacing.xs};
   animation: fade-in-out 2s ease forwards;
 
   @media (prefers-reduced-motion: reduce) {
@@ -64,26 +79,42 @@ const CopiedBadge = styled.span`
   }
 `;
 
-export type CopyLinkIconProps = { toggleId: string; title: string };
+export type CopyLinkIconProps = { toggleId: string; title: string } & (
+  | { modeValue?: undefined }
+  | { modeValue: string }
+);
 
-const CopyLinkIcon: FunctionComponent<CopyLinkIconProps> = ({
-  toggleId,
-  title,
-}) => {
+const CopyLinkIcon: FunctionComponent<CopyLinkIconProps> = props => {
+  const { title, modeValue } = props;
   const [copied, setCopied] = useState(false);
+  const isMode = modeValue !== undefined;
 
   const onCopy = async () => {
-    await copyEnableLink(toggleId);
+    await copyEnableLink(props);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
   return (
-    <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        position: 'relative',
+      }}
+    >
       <IconButton
         type="button"
-        aria-label={`Copy link to enable toggle ${title}`}
-        title="Click to copy a link that enables this toggle"
+        aria-label={
+          isMode
+            ? `Copy link to set mode ${title}`
+            : `Copy link to enable toggle ${title}`
+        }
+        title={
+          isMode
+            ? 'Click to copy a link that sets this mode'
+            : 'Click to copy a link that enables this toggle'
+        }
         onClick={onCopy}
       >
         <svg

--- a/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.CopyLinkIcon.tsx
+++ b/dash/webapp/views/pages/toggles/ListOfToggles/ListOfToggles.CopyLinkIcon.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { tokens } from '@weco/dash/views/themes/tokens';
@@ -88,11 +88,25 @@ const CopyLinkIcon: FunctionComponent<CopyLinkIconProps> = props => {
   const { title, modeValue } = props;
   const [copied, setCopied] = useState(false);
   const isMode = modeValue !== undefined;
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const onCopy = async () => {
     await copyEnableLink(props);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => setCopied(false), 2000);
   };
 
   return (

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -36,7 +36,8 @@ const GENERAL_FEATURE_FLAG_IDS = ['apiToolbar', 'conceptsSearch'];
 
 const TogglesPage: FunctionComponent = () => {
   const router = useRouter();
-  const { enableToggle, disableToggle, resetToggles } = router.query;
+  const { enableToggle, disableToggle, resetToggles, enableMode, modeValue } =
+    router.query;
   const [message, setMessage] = useState<{
     text: string;
     isError?: boolean;
@@ -152,6 +153,38 @@ const TogglesPage: FunctionComponent = () => {
     [featureFlags]
   );
 
+  const handleMode = useCallback(
+    (modeId: string, optionId: string) => {
+      const mode = modes.find(m => m.id === modeId);
+      if (!mode) {
+        setMessage({
+          text: `Mode "${modeId}" does not exist.`,
+          isError: true,
+        });
+        return;
+      }
+      const optionExists = mode.options.some(opt => opt.id === optionId);
+      if (!optionExists) {
+        setMessage({
+          text: `Mode "${modeId}" has no option "${optionId}".`,
+          isError: true,
+        });
+        return;
+      }
+      setCookieCustom(modeId, optionId);
+      setModeStates(prev => ({
+        ...prev,
+        [modeId]: optionId,
+      }));
+      setMessage({
+        text: `Mode "${mode.title}" has been set to "${optionId}".`,
+        isError: false,
+        isEnabled: true,
+      });
+    },
+    [modes]
+  );
+
   const reset = useCallback(
     () =>
       setToggleStates(prev => {
@@ -193,12 +226,17 @@ const TogglesPage: FunctionComponent = () => {
       handleFeatureFlag(enableToggle as string, 'enable');
     } else if (disableToggle) {
       handleFeatureFlag(disableToggle as string, 'disable');
+    } else if (enableMode) {
+      handleMode(enableMode as string, (modeValue as string) ?? '');
     }
   }, [
     enableToggle,
     disableToggle,
     resetToggles,
+    enableMode,
+    modeValue,
     handleFeatureFlag,
+    handleMode,
     reset,
     featureFlags,
   ]);

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -163,6 +163,13 @@ const TogglesPage: FunctionComponent = () => {
         });
         return;
       }
+      if (!optionId) {
+        setMessage({
+          text: `Mode "${modeId}" requires a modeValue.`,
+          isError: true,
+        });
+        return;
+      }
       const optionExists = mode.options.some(opt => opt.id === optionId);
       if (!optionExists) {
         setMessage({

--- a/dash/webapp/views/pages/toggles/index.tsx
+++ b/dash/webapp/views/pages/toggles/index.tsx
@@ -170,8 +170,8 @@ const TogglesPage: FunctionComponent = () => {
         });
         return;
       }
-      const optionExists = mode.options.some(opt => opt.id === optionId);
-      if (!optionExists) {
+      const option = mode.options.find(opt => opt.id === optionId);
+      if (!option) {
         setMessage({
           text: `Mode "${modeId}" has no option "${optionId}".`,
           isError: true,
@@ -184,7 +184,7 @@ const TogglesPage: FunctionComponent = () => {
         [modeId]: optionId,
       }));
       setMessage({
-        text: `Mode "${mode.title}" has been set to "${optionId}".`,
+        text: `Mode "${mode.title}" has been set to "${option.label}".`,
         isError: false,
         isEnabled: true,
       });
@@ -221,7 +221,7 @@ const TogglesPage: FunctionComponent = () => {
   }, [abTests]);
 
   useEffect(() => {
-    if (featureFlags.length === 0) return;
+    if (featureFlags.length === 0 && modes.length === 0) return;
 
     if (resetToggles !== undefined) {
       reset();
@@ -246,6 +246,7 @@ const TogglesPage: FunctionComponent = () => {
     handleMode,
     reset,
     featureFlags,
+    modes,
   ]);
 
   const filterFeatureFlags = (flagList: FeatureFlag[]) => {

--- a/dash/webapp/views/pages/toggles/toggles.Modes.tsx
+++ b/dash/webapp/views/pages/toggles/toggles.Modes.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { tokens } from '@weco/dash/views/themes/tokens';
 import { ModeDefinition } from '@weco/toggles';
 
+import CopyLinkIcon from './ListOfToggles/ListOfToggles.CopyLinkIcon';
 import { deleteCookieCustom, setCookieCustom } from './toggles.helpers';
 import {
   ResetButton,
@@ -17,6 +18,13 @@ import {
 const ModeSelect = styled.select`
   padding: 6px;
   max-width: 300px;
+`;
+
+const ModeControlRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${tokens.spacing.xs};
 `;
 
 type ModesProps = {
@@ -46,11 +54,16 @@ const Modes: FunctionComponent<ModesProps> = ({
           <span aria-hidden="true">#</span>
         </a>
       </h2>
-      {Object.keys(modeStates).length > 0 && (
-        <ResetButton onClick={onReset} aria-label="Reset all modes to off">
-          Reset all modes
-        </ResetButton>
-      )}
+      <ResetButton
+        onClick={onReset}
+        aria-label="Reset all modes to off"
+        disabled={Object.keys(modeStates).length === 0}
+        style={{
+          visibility: Object.keys(modeStates).length > 0 ? 'visible' : 'hidden',
+        }}
+      >
+        Reset all modes
+      </ResetButton>
     </div>
     <p style={{ marginTop: 0, color: tokens.colors.text.secondary }}>
       Modes carry structured data beyond a simple on/off, they might represent
@@ -84,34 +97,47 @@ const Modes: FunctionComponent<ModesProps> = ({
                 </ToggleInfo>
 
                 <ToggleControls>
-                  <ModeSelect
-                    aria-labelledby={`mode-${mode.id}`}
-                    value={currentValue}
-                    onChange={e => {
-                      const value = e.target.value;
-                      if (value) {
-                        setModeStates(prev => ({
-                          ...prev,
-                          [mode.id]: value,
-                        }));
-                        setCookieCustom(mode.id, value);
-                      } else {
-                        setModeStates(prev => {
-                          const next = { ...prev };
-                          delete next[mode.id];
-                          return next;
-                        });
-                        deleteCookieCustom(mode.id);
-                      }
-                    }}
-                  >
-                    <option value="">— Off —</option>
-                    {mode.options.map(opt => (
-                      <option key={opt.id} value={opt.id}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </ModeSelect>
+                  <ModeControlRow>
+                    <span
+                      style={{
+                        visibility: currentValue ? 'visible' : 'hidden',
+                      }}
+                    >
+                      <CopyLinkIcon
+                        toggleId={mode.id}
+                        title={mode.title}
+                        modeValue={currentValue}
+                      />
+                    </span>
+                    <ModeSelect
+                      aria-labelledby={`mode-${mode.id}`}
+                      value={currentValue}
+                      onChange={e => {
+                        const value = e.target.value;
+                        if (value) {
+                          setModeStates(prev => ({
+                            ...prev,
+                            [mode.id]: value,
+                          }));
+                          setCookieCustom(mode.id, value);
+                        } else {
+                          setModeStates(prev => {
+                            const next = { ...prev };
+                            delete next[mode.id];
+                            return next;
+                          });
+                          deleteCookieCustom(mode.id);
+                        }
+                      }}
+                    >
+                      <option value="">— Off —</option>
+                      {mode.options.map(opt => (
+                        <option key={opt.id} value={opt.id}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </ModeSelect>
+                  </ModeControlRow>
                 </ToggleControls>
               </ToggleRow>
             </ToggleListItem>


### PR DESCRIPTION
## What does this change?

Feature flags on the toggles dashboard already have a per-row "copy link" that produces a shareable `?enableToggle=<id>` URL; opening it sets the `toggle_<id>` cookie for whoever follows the link. Modes had no equivalent. This adds one.

A mode's cookie value is the id of a selected option rather than a boolean, so a shareable mode link has to carry both the mode id and the chosen option id. Mode rows now render a copy-link button beside the dropdown that builds `?enableMode=<modeId>&modeValue=<optionId>`. Following that link validates both ids against the loaded modes and, if they check out, sets the same `toggle_<modeId>` cookie the live site already reads, so the mode carries through to production.

The copy-link component is shared, so it was generalised to accept an optional `modeValue` and keeps its existing `?enableToggle=` behaviour untouched when that's absent.

It also fixes three layout shifts in the modes section:
- The "Copied!" confirmation is now a floating tooltip above the icon instead of inline, so showing it no longer widens the row (feature-flag copy links get this too).
- The mode copy-link button reserves its space and toggles `visibility`, so it appears only once an option is selected without nudging the dropdown.
- "Reset all modes" got the same reserve-space treatment (and is `disabled` while hidden), rather than popping into existence on first selection and pushing rows down.

Scope was kept to the dashboard copy-link. No changes to `common/`, `toggles/webapp/`, the edge lambda, or the main-site `?toggle=` query params.

## How to test

From the `dash/webapp` folder, run `yarn dev` and open `/toggles#modes`.

- Under `cataloguePipeline`, pick an option. The copy-link icon appears only once an option is selected, and the dropdown does not move.
- Click copy: the clipboard holds `…/toggles?enableMode=cataloguePipeline&modeValue=axiell-collections-testing` and a floating "Copied!" badge shows with no layout shift.
- Open that link in a fresh browser: the dropdown shows the option, a success message appears, and `toggle_cataloguePipeline` is set to the option id.
- Tamper checks: `?enableMode=doesNotExist&modeValue=x` and `?enableMode=cataloguePipeline&modeValue=bogus` each show an error and set no cookie.
- Regression: `?enableToggle=apiToolbar` still sets `toggle_apiToolbar=true`.

Verified end to end with a headless Chromium (Playwright) script; `tsc` and `eslint` are clean for the dash package. Two pre-existing, unrelated `tsc` errors in `identity/webapp` (`@auth0/nextjs-auth0` exports) are not touched here.

## Have we considered potential risks?

Low. Dashboard-only internal tool, no new dependencies, no server or `common/` changes. The link handler validates both the mode id and option id against the deployed toggles config before setting any cookie, so a malformed or malicious link cannot set an arbitrary cookie value.

Accessibility trade-off worth noting: hidden buttons use `visibility: hidden` (kept out of the tab order and screen-reader tree until usable) rather than being unmounted.
