### PR TITLE
Add render-only toggle override via ?toggleOverride query param

### DIFF
--- a/common/server-data/index.ts
+++ b/common/server-data/index.ts
@@ -21,7 +21,10 @@ import { getAllConsentStates } from '@weco/common/services/app/civic-uk';
 import { Toggles, TogglesResp } from '@weco/toggles';
 
 import prismicHandler from './prismic';
-import togglesHandler, { getTogglesFromContext } from './toggles';
+import togglesHandler, {
+  getTogglesFromContext,
+  parseToggleOverrides,
+} from './toggles';
 import { ServerData } from './types';
 
 export type Handler<DefaultData, FetchedData> = {
@@ -148,10 +151,16 @@ export const getServerData = async (
   const enableToggle: string | undefined =
     typeof toggle === 'string' ? toggle : undefined;
 
+  // Support ?toggleOverride=id:value,id:value to override toggle state for this
+  // render only, without writing any cookie. Lets two browser tabs render the
+  // same page with different toggle states side by side.
+  const overrides = parseToggleOverrides(context.query.toggleOverride);
+
   // Resolve toggle values from the cached config + user's cookies
   const { featureFlags, tests, modes } = getTogglesFromContext(
     togglesResp,
-    context
+    context,
+    overrides
   );
 
   // If a valid toggle was requested via query param, set a cookie and enable it

--- a/common/server-data/toggles.test.ts
+++ b/common/server-data/toggles.test.ts
@@ -5,7 +5,11 @@ import { IncomingMessage } from 'http';
 
 import { TogglesResp } from '@weco/toggles';
 
-import { Context, getTogglesFromContext } from './toggles';
+import {
+  Context,
+  getTogglesFromContext,
+  parseToggleOverrides,
+} from './toggles';
 
 function createContext(
   cookies?: Record<string, string>,
@@ -286,5 +290,168 @@ describe('getTogglesFromContext', () => {
 
       expect((result.modes as Record<string, unknown>).kioskMode).toBeNull();
     });
+  });
+
+  describe('toggleOverride', () => {
+    const modeDefinition = {
+      id: 'kioskMode',
+      title: 'Kiosk Mode',
+      description: 'Select which iPad this kiosk is running on',
+      options: [
+        { id: 'ipad-1', label: 'iPad 1' },
+        { id: 'ipad-2', label: 'iPad 2' },
+      ],
+    };
+
+    it('overrides a feature flag to true regardless of cookie/default', () => {
+      const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
+        featureFlags: [stagingApiFlag], // defaultValue false
+      };
+
+      const result = getTogglesFromContext(togglesResp, createContext(), {
+        stagingApi: 'true',
+      });
+
+      expect(result.featureFlags.stagingApi).toBe(true);
+    });
+
+    it('overrides a feature flag to false, beating a "true" cookie', () => {
+      const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
+        featureFlags: [thematicBrowsingFlag], // defaultValue true
+      };
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_thematicBrowsing: 'true' }),
+        { thematicBrowsing: 'false' }
+      );
+
+      expect(result.featureFlags.thematicBrowsing).toBe(false);
+    });
+
+    it('ignores a feature flag override that is not "true"/"false"', () => {
+      const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
+        featureFlags: [thematicBrowsingFlag], // defaultValue true
+      };
+
+      const result = getTogglesFromContext(togglesResp, createContext(), {
+        thematicBrowsing: 'banana',
+      });
+
+      // Falls back to defaultValue
+      expect(result.featureFlags.thematicBrowsing).toBe(true);
+    });
+
+    it('overrides an A/B test value', () => {
+      const togglesResp = {
+        ...defaultTogglesResp,
+        tests: [
+          { id: 'sampleTest', title: 'Sample', type: 'test', range: [0, 100] },
+        ],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(togglesResp, createContext(), {
+        sampleTest: 'false',
+      });
+
+      expect((result.tests as Record<string, unknown>).sampleTest).toBe(false);
+    });
+
+    it('overrides a mode to a valid option, beating the cookie', () => {
+      const togglesResp = {
+        ...defaultTogglesResp,
+        modes: [modeDefinition],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_kioskMode: 'ipad-1' }),
+        { kioskMode: 'ipad-2' }
+      );
+
+      expect((result.modes as Record<string, unknown>).kioskMode).toBe(
+        'ipad-2'
+      );
+    });
+
+    it('ignores a mode override that is not a valid option', () => {
+      const togglesResp = {
+        ...defaultTogglesResp,
+        modes: [modeDefinition],
+      } as unknown as TogglesResp;
+
+      const result = getTogglesFromContext(
+        togglesResp,
+        createContext({ toggle_kioskMode: 'ipad-1' }),
+        { kioskMode: 'not-an-ipad' }
+      );
+
+      // Falls back to the cookie value
+      expect((result.modes as Record<string, unknown>).kioskMode).toBe(
+        'ipad-1'
+      );
+    });
+
+    it('ignores an override for an unknown toggle id', () => {
+      const togglesResp: TogglesResp = {
+        ...defaultTogglesResp,
+        featureFlags: [stagingApiFlag],
+      };
+
+      const result = getTogglesFromContext(togglesResp, createContext(), {
+        nonExistentToggle: 'true',
+      });
+
+      expect(result.featureFlags.stagingApi).toBe(false);
+      expect(
+        (result.featureFlags as Record<string, unknown>).nonExistentToggle
+      ).toBeUndefined();
+    });
+  });
+});
+
+describe('parseToggleOverrides', () => {
+  it('returns an empty object for undefined', () => {
+    expect(parseToggleOverrides(undefined)).toEqual({});
+  });
+
+  it('parses a single id:value pair', () => {
+    expect(parseToggleOverrides('apiToolbar:true')).toEqual({
+      apiToolbar: 'true',
+    });
+  });
+
+  it('parses multiple comma-separated pairs', () => {
+    expect(
+      parseToggleOverrides('apiToolbar:true,cataloguePipeline:axiell')
+    ).toEqual({ apiToolbar: 'true', cataloguePipeline: 'axiell' });
+  });
+
+  it('trims whitespace around ids and values', () => {
+    expect(parseToggleOverrides(' apiToolbar : true ')).toEqual({
+      apiToolbar: 'true',
+    });
+  });
+
+  it('joins an array value before parsing', () => {
+    expect(parseToggleOverrides(['a:true', 'b:false'])).toEqual({
+      a: 'true',
+      b: 'false',
+    });
+  });
+
+  it('skips malformed pairs with no separator', () => {
+    expect(parseToggleOverrides('apiToolbar,cataloguePipeline:axiell')).toEqual(
+      {
+        cataloguePipeline: 'axiell',
+      }
+    );
+  });
+
+  it('keeps an empty value (validation happens later)', () => {
+    expect(parseToggleOverrides('kioskMode:')).toEqual({ kioskMode: '' });
   });
 });

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -72,7 +72,9 @@ export function parseToggleOverrides(
       if (id) acc[id] = val;
       return acc;
     },
-    {} as Record<string, string>
+    // Null-prototype map: the keys come from a user-controlled query param, so
+    // avoid any chance of a crafted id (e.g. `__proto__`) touching the prototype.
+    Object.create(null) as Record<string, string>
   );
 }
 

--- a/common/server-data/toggles.ts
+++ b/common/server-data/toggles.ts
@@ -54,13 +54,39 @@ export type Context = {
 };
 
 /**
+ * Parse a `?toggleOverride=id:value,id:value` query param into a map of raw
+ * string values. Used to override toggle state for a single render without
+ * writing any cookie (see getTogglesFromContext). Malformed pairs are skipped.
+ */
+export function parseToggleOverrides(
+  raw: string | string[] | undefined
+): Record<string, string> {
+  const value = Array.isArray(raw) ? raw.join(',') : raw;
+  if (!value) return {};
+  return value.split(',').reduce(
+    (acc, pair) => {
+      const separatorIndex = pair.indexOf(':');
+      if (separatorIndex === -1) return acc;
+      const id = pair.slice(0, separatorIndex).trim();
+      const val = pair.slice(separatorIndex + 1).trim();
+      if (id) acc[id] = val;
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+
+/**
  * normally parsing like this should happen in `_app.parseServerDataToAppData`
  * but we need the `req` from the `context` for cookies which we don't
  * have in `_app` - so it lives here
  */
 export function getTogglesFromContext(
   togglesResp: TogglesResp,
-  context: Context
+  context: Context,
+  // Render-only overrides from `?toggleOverride=` (see parseToggleOverrides).
+  // These take precedence over cookies for this render and are never persisted.
+  overrides: Record<string, string> = {}
 ): Toggles {
   const isStage = context.req.headers.host?.startsWith('www-stage');
   const allCookies = getCookies(context);
@@ -69,18 +95,23 @@ export function getTogglesFromContext(
     .filter(toggle => {
       return !(!isStage && toggle.type === 'stage');
     })
-    .reduce(
-      (acc, toggle) => ({
-        ...acc,
-        [toggle.id]:
-          allCookies[`toggle_${toggle.id}`] === 'true'
-            ? true
-            : toggle.defaultValue,
-      }),
-      {} as FeatureFlags
-    );
+    .reduce((acc, toggle) => {
+      const override = overrides[toggle.id];
+      const value =
+        override === 'true'
+          ? true
+          : override === 'false'
+            ? false
+            : allCookies[`toggle_${toggle.id}`] === 'true'
+              ? true
+              : toggle.defaultValue;
+      return { ...acc, [toggle.id]: value };
+    }, {} as FeatureFlags);
   const tests = togglesResp.tests.reduce((acc, test) => {
     function testToggleValue(Id: string): boolean | undefined {
+      const override = overrides[Id];
+      if (override === 'true') return true;
+      if (override === 'false') return false;
       const cookieValue = allCookies[`toggle_${Id}`];
       switch (cookieValue) {
         case 'true':
@@ -99,6 +130,13 @@ export function getTogglesFromContext(
 
   const modesList = togglesResp.modes ?? [];
   const modes = modesList.reduce((acc, mode) => {
+    const override = overrides[mode.id];
+    if (
+      typeof override === 'string' &&
+      mode.options.some(opt => opt.id === override)
+    ) {
+      return { ...acc, [mode.id]: override };
+    }
     const cookieValue = allCookies[`toggle_${mode.id}`];
     const isValid =
       typeof cookieValue === 'string' &&


### PR DESCRIPTION
## What does this change?

Adds a cookie-free way to override toggle state for a single page render, via a new `?toggleOverride=id:value,id:value` query param (for example `?toggleOverride=apiToolbar:true` or `?toggleOverride=cataloguePipeline:axiell-collections-testing`).

The existing cookie-based `?toggle=` mechanism can't do this. Toggle cookies are scoped to `.wellcomecollection.org` and so shared across every tab in the browser, which makes it impossible to view two toggle states of the same page side by side. Toggle state is resolved server-side and provided entirely through SSR, so overriding resolution for one render flows through the whole page.

- Overrides take precedence over cookies for that render only and never write a `Set-Cookie`. The existing `?toggle=` handler is left exactly as-is.
- Feature flags and A/B tests accept only `true`/`false`; modes must match one of the mode's option ids. Anything invalid, or aimed at an unknown toggle id, is ignored and falls back to normal cookie/default resolution.

This will enable comparisons like this:

<img width="1728" height="1080" alt="Screenshot 2026-07-23 at 17 17 41" src="https://github.com/user-attachments/assets/63bc07d1-1ca2-43be-8195-6dd2ccb2f2ce" />

Known limitations, both acceptable for the intended visual-comparison use:

- A few toggles are read directly from cookies rather than resolved `serverData.toggles` (the Prismic content-source switch, kiosk consent, the kiosk cookie-banner seed, and analytics reporting). Those will not respond to `?toggleOverride=`. Ordinary feature flags, A/B tests, and modes like `cataloguePipeline` do.
- The override applies to the SSR render only. Next API routes that re-resolve toggles from cookies do not see it, so a page rendered with an override can still fetch data at the non-overridden toggle state. Threading the override through client-side fetches would defeat the cookie-free design, so it is deliberately out of scope.

Intended to help with verifying: https://github.com/wellcomecollection/platform/issues/6445

## How to test

Run the content app locally against the prod APIs (`NEXT_PUBLIC_API_ENV_OVERRIDE=prod` for the run; the repo default is stage), then:

- Open `/search/works?query=diebold` and `/search/works?query=diebold&toggleOverride=apiToolbar:true` in two tabs. The second shows the API debug toolbar, the first does not.
- Confirm the override writes no `toggle_*` cookie (DevTools > Application > Cookies), whereas `?toggle=apiToolbar` does. That is what keeps the two tabs independent.
- A mode example: `/works/<id>?toggleOverride=cataloguePipeline:axiell-collections-testing` versus the plain URL.
- Invalid or unknown ids/values are ignored: the page renders at defaults with no error.

Verified locally: the override flips the serialised toggle state and writes no cookie, while `?toggle=` still writes its cookie. `common` unit tests pass (28/28), eslint clean, and `common` and `content` type-check clean under root `yarn tsc`.

## Have we considered potential risks?

Low overall. Server-side only, no new dependencies, no infra change, existing `?toggle=` behaviour untouched.

<details>
<summary>CloudFront/CDN behaviour, verified against the Terraform in <code>cache/</code></summary>

- The prod origin-request policy `host-query-and-toggles` forwards all query strings to the origin (`query_string_behavior = "all"`), so `toggleOverride` reaches the app and is not stripped, the same path `?toggle=` uses.
- The prod app routes use the `weco-apps` cache policy, whose `query_string_behavior = "allExcept"` deny-list contains only `shouldScrollToCanvas`, `wellcomeImagesUrl`, and the `utm_*` params. `toggleOverride` is therefore part of the cache key. So a URL carrying `?toggleOverride=` is a distinct cache entry from the canonical no-param URL and from other override values: an override can never change what a normal visitor sees on the plain URL, and two override values do not collide. The response is cacheable and shared per URL+param (deterministic by URL, not per-session), which is the desired behaviour for a shareable comparison link.
- Minor caveat: each distinct override value creates its own cache entry, so heavy or automated use fragments the cache slightly, the same as any non-denylisted query param. Not a concern for occasional comparison use.
</details>

The param is deliberately allowed on prod: it is render-only and strictly less powerful than the existing `?toggle=`, which already persists a cookie on prod.
