### PR TITLE
Centralise and update `next.config.js`

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -10,8 +10,8 @@ Of particular interest:
 
 ## Bundle analysis
 Previously stored in S3 and displayed on dash.wellcomecollection.org, you can still run it locally.
-It currently only is set-up for `content/`, as it's using the `next/next.config.js`. Other repos could be made to use it.
+It's available for any app using the shared `next/next.config.js` (currently `content/` and `identity/`).
 Example of how to use:
-1. `cd content/webapp`
+1. `cd content/webapp` (or `identity/webapp`)
 2. `BUNDLE_ANALYZE=true yarn build`
-3. It'll render new files, you're probably interested in the one at: `/content/webapp/.dist/content.client.test.html`.
+3. It'll render new files, you're probably interested in the one at: `/content/webapp/.dist/content.client.test.html` (or `/identity/webapp/.dist/identity.client.test.html`).

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -4,13 +4,8 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const apmConfig = require('../services/apm/apmConfig');
 
-const defaultConfigOptions = {
-  applicationName: 'test',
-  lintBuilds: false, // TODO: fix linting errors
-};
-
 const createConfig =
-  (options = defaultConfigOptions) =>
+  options =>
   (phase, { defaultConfig }) => {
     const prodSubdomain = process.env.PROD_SUBDOMAIN || '';
     const buildHash = process.env.BUILD_HASH || 'test';
@@ -30,8 +25,10 @@ const createConfig =
 
       images: options.images || {},
 
-      // Only identity sets this, to mount itself at wellcomecollection.org/account
-      // instead of its own subdomain.
+      // Every URL in this app gets this prefix added in front, e.g. '/account'
+      // means a page at /search is actually served at /account/search. Only
+      // identity sets this, so it can live at wellcomecollection.org/account
+      // instead of getting its own subdomain the way content does.
       basePath: options.basePath || '',
 
       assetPrefix:
@@ -39,24 +36,36 @@ const createConfig =
           ? `https://${prodSubdomain}.wellcomecollection.org${options.basePath || ''}`
           : undefined,
 
-      // This file lives in common/next, so point tracing at the monorepo root -
-      // otherwise Next only traces dependencies from inside common/next itself.
+      // Next needs to know which files a build actually depends on, so it
+      // doesn't bundle more of the repo than necessary. This config file lives
+      // in common/next rather than in the app's own folder, so without this,
+      // Next would assume the app only needs files from inside common/next and
+      // miss everything else in the monorepo. Pointing this at the repo root
+      // fixes that.
       outputFileTracingRoot: path.join(__dirname, '../../'),
 
       publicRuntimeConfig: {
         apmConfig: apmConfig.client(`${options.applicationName}-webapp`),
       },
 
-      // Only set when an app actually needs one (currently just identity, for
-      // session/auth0 config - see identity/webapp/config.js) so apps that don't
-      // need one aren't left with an empty serverRuntimeConfig key.
+      // serverRuntimeConfig lets an app pass its own env-derived config (e.g.
+      // secrets, API hosts) into next.config.js once, then read it back
+      // anywhere in its server-side code via next/config's getConfig(). Only
+      // identity currently needs this (for session/auth0 config - see
+      // identity/webapp/config.js), so we only add the key when an app
+      // actually supplies one, rather than giving every app an empty one.
       ...(options.serverRuntimeConfig && {
         serverRuntimeConfig: options.serverRuntimeConfig,
       }),
 
       async rewrites() {
-        // An app that owns its own basePath (eg identity, mounted at /account)
-        // doesn't need this dev convenience proxy to itself.
+        // A "rewrite" serves a different URL's content without changing what
+        // the browser shows in the address bar. This one is a local dev
+        // convenience: it forwards any /account/* request to wherever the
+        // identity app is running, so you can hit /account URLs while running
+        // another app locally. An app that already owns its own basePath (eg
+        // identity, mounted at /account) doesn't need this - it's already
+        // serving those URLs itself.
         if (phase === PHASE_DEVELOPMENT_SERVER && !options.basePath) {
           return [
             {
@@ -69,14 +78,17 @@ const createConfig =
         return [...rewriteEntries];
       },
 
-      // Per-app redirect rules, e.g. identity's /account/search -> /search.
+      // Per-app redirect rules (a redirect sends the browser to a genuinely
+      // different URL, unlike the rewrites above). E.g. identity redirects
+      // /account/search to /search.
       async redirects() {
         return [...redirectEntries];
       },
 
       webpack: (config, { isServer, webpack }) => {
-        // moment-timezone ships its full historical timezone dataset by default,
-        // which is large and mostly unused. Swap in our own trimmed version.
+        // moment-timezone ships its full historical timezone dataset by
+        // default, which is large and mostly unused. Swap in our own trimmed
+        // version instead, to keep the app's bundle size down.
         config.plugins.push(
           new webpack.NormalModuleReplacementPlugin(
             /moment-timezone\/data\/packed\/latest\.json/,
@@ -115,14 +127,20 @@ const createConfig =
 
       eslint: {
         ...defaultConfig.eslint,
-        // Skip eslint during `next build` unless an app opts in via lintBuilds.
-        // Repo-wide linting still runs separately via the root `yarn lint`, so
-        // this just avoids a slow, redundant second lint pass inside the build.
-        ignoreDuringBuilds: !options.lintBuilds,
+        // Don't run eslint as part of `next build` - it wouldn't do anything
+        // useful anyway: this repo's eslint setup uses a newer config format
+        // ("flat config", in the root eslint.config.js) that Next's built-in
+        // build-time linter doesn't know how to read, so turning this on
+        // would just run a check that silently finds nothing. Linting is
+        // instead enforced by a git pre-commit hook (see docs/git-hooks.md)
+        // that lints whatever files you're committing, or can be run across
+        // the whole repo manually with the root `yarn lint` command.
+        ignoreDuringBuilds: true,
       },
 
-      // common's source is untranspiled TS/JSX; each app needs Next to compile
-      // it as part of its own build rather than treating it as pre-built.
+      // common's code is plain TS/JSX, not pre-compiled. Without this, each
+      // app's build would treat common as an ordinary installed package and
+      // skip compiling it, which would break.
       transpilePackages: ['@weco/common'],
 
       // I was seeing an error in the content app:
@@ -136,18 +154,25 @@ const createConfig =
       // the error *and* uses SWC to compile styled-components, which
       // makes the build noticeably faster on my machine.
       //
-      // Still required as of Next 15 / styled-components 6: without it,
-      // styled-components' class-name hashing can differ between the server
-      // and client bundles, causing hydration mismatches. Only takes effect
-      // because SWC is forced on below (forceSwcTransforms) - if that ever
-      // gets removed, this option is silently ignored and Babel takes over.
+      // Still required as of Next 15 / styled-components 6: styled-components
+      // generates each component's CSS class name at build time, and without
+      // this option that generation can come out slightly different for the
+      // server-rendered HTML vs. the version React re-generates in the
+      // browser. React then complains they don't match ("hydration
+      // mismatch") and re-renders that part of the page from scratch. This
+      // only works because SWC (Next's fast Rust-based compiler) is forced on
+      // below - if forceSwcTransforms is ever removed, this option silently
+      // stops doing anything and Babel takes over instead.
       compiler: {
         styledComponents: true,
       },
 
-      // Pages Router only: makes sure server-only dependencies used inside API
-      // routes/getServerSideProps get traced into the production output, not
-      // just the ones imported by pages themselves.
+      // Pages Router only (this repo doesn't use the newer App Router). Code
+      // that only runs on the server - inside pages/api routes or
+      // getServerSideProps - can use server-only npm packages that the
+      // browser bundle never needs. Without this option, Next can fail to
+      // notice those packages belong in the deployed output at all, since it
+      // normally only looks at what pages import directly.
       bundlePagesRouterDependencies: true,
 
       experimental: {
@@ -165,12 +190,16 @@ const createConfig =
         //
         // Confirmed still true as of Next 15.5: removing this brings back the
         // exact "Disabled SWC..." warning above, and silently disables the
-        // compiler.styledComponents option too, since that also requires SWC.
+        // compiler.styledComponents option above too, since that also
+        // requires SWC to be active.
         forceSwcTransforms: true,
       },
 
-      // Surfaces unsafe side effects (double-invokes effects, etc) in dev only -
-      // no behaviour change in production builds.
+      // In development only, this makes React deliberately run certain code
+      // twice (e.g. component functions and effects) to help surface bugs
+      // where code accidentally relies on running exactly once, or has a side
+      // effect it shouldn't. It has no effect on production builds - real
+      // users never see the double-run.
       reactStrictMode: true,
     };
     return nextConfig;

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -23,22 +23,37 @@ const createConfig =
 
     const nextConfig = {
       ...defaultConfig,
+
       // We handle compression in the nginx sidecar
       // Are you having problems with this? Make sure CloudFront is forwarding Accept-Encoding headers to our apps!
       compress: false,
+
       images: options.images || {},
+
+      // Only identity sets this, to mount itself at wellcomecollection.org/account
+      // instead of its own subdomain.
       basePath: options.basePath || '',
+
       assetPrefix:
         isProd && prodSubdomain
           ? `https://${prodSubdomain}.wellcomecollection.org${options.basePath || ''}`
           : undefined,
+
+      // This file lives in common/next, so point tracing at the monorepo root -
+      // otherwise Next only traces dependencies from inside common/next itself.
       outputFileTracingRoot: path.join(__dirname, '../../'),
+
       publicRuntimeConfig: {
         apmConfig: apmConfig.client(`${options.applicationName}-webapp`),
       },
+
+      // Only set when an app actually needs one (currently just identity, for
+      // session/auth0 config - see identity/webapp/config.js) so apps that don't
+      // need one aren't left with an empty serverRuntimeConfig key.
       ...(options.serverRuntimeConfig && {
         serverRuntimeConfig: options.serverRuntimeConfig,
       }),
+
       async rewrites() {
         // An app that owns its own basePath (eg identity, mounted at /account)
         // doesn't need this dev convenience proxy to itself.
@@ -53,10 +68,15 @@ const createConfig =
         }
         return [...rewriteEntries];
       },
+
+      // Per-app redirect rules, e.g. identity's /account/search -> /search.
       async redirects() {
         return [...redirectEntries];
       },
+
       webpack: (config, { isServer, webpack }) => {
+        // moment-timezone ships its full historical timezone dataset by default,
+        // which is large and mostly unused. Swap in our own trimmed version.
         config.plugins.push(
           new webpack.NormalModuleReplacementPlugin(
             /moment-timezone\/data\/packed\/latest\.json/,
@@ -92,10 +112,17 @@ const createConfig =
 
         return config;
       },
+
       eslint: {
         ...defaultConfig.eslint,
+        // Skip eslint during `next build` unless an app opts in via lintBuilds.
+        // Repo-wide linting still runs separately via the root `yarn lint`, so
+        // this just avoids a slow, redundant second lint pass inside the build.
         ignoreDuringBuilds: !options.lintBuilds,
       },
+
+      // common's source is untranspiled TS/JSX; each app needs Next to compile
+      // it as part of its own build rather than treating it as pre-built.
       transpilePackages: ['@weco/common'],
 
       // I was seeing an error in the content app:
@@ -108,9 +135,19 @@ const createConfig =
       // this suggested compiler option on Stack Overflow.  It cleans up
       // the error *and* uses SWC to compile styled-components, which
       // makes the build noticeably faster on my machine.
+      //
+      // Still required as of Next 15 / styled-components 6: without it,
+      // styled-components' class-name hashing can differ between the server
+      // and client bundles, causing hydration mismatches. Only takes effect
+      // because SWC is forced on below (forceSwcTransforms) - if that ever
+      // gets removed, this option is silently ignored and Babel takes over.
       compiler: {
         styledComponents: true,
       },
+
+      // Pages Router only: makes sure server-only dependencies used inside API
+      // routes/getServerSideProps get traced into the production output, not
+      // just the ones imported by pages themselves.
       bundlePagesRouterDependencies: true,
 
       experimental: {
@@ -125,8 +162,15 @@ const createConfig =
         //
         // but we only have this config file to get our jest tests working; we don't
         // need it to build the apps themselves.
+        //
+        // Confirmed still true as of Next 15.5: removing this brings back the
+        // exact "Disabled SWC..." warning above, and silently disables the
+        // compiler.styledComponents option too, since that also requires SWC.
         forceSwcTransforms: true,
       },
+
+      // Surfaces unsafe side effects (double-invokes effects, etc) in dev only -
+      // no behaviour change in production builds.
       reactStrictMode: true,
     };
     return nextConfig;

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -12,9 +12,6 @@ const defaultConfigOptions = {
 const createConfig =
   (options = defaultConfigOptions) =>
   (phase, { defaultConfig }) => {
-    /** it would appear that defaultConfig includes some invalid property types, so this will remove them */
-    const validDefaultConfig = cleanInvalidValues(defaultConfig);
-
     const prodSubdomain = process.env.PROD_SUBDOMAIN || '';
     const buildHash = process.env.BUILD_HASH || 'test';
     const isProd = process.env.NODE_ENV === 'production';
@@ -25,7 +22,7 @@ const createConfig =
     const redirectEntries = options.redirectEntries || [];
 
     const nextConfig = {
-      ...validDefaultConfig,
+      ...defaultConfig,
       // We handle compression in the nginx sidecar
       // Are you having problems with this? Make sure CloudFront is forwarding Accept-Encoding headers to our apps!
       compress: false,
@@ -96,7 +93,7 @@ const createConfig =
         return config;
       },
       eslint: {
-        ...validDefaultConfig.eslint,
+        ...defaultConfig.eslint,
         ignoreDuringBuilds: !options.lintBuilds,
       },
       transpilePackages: ['@weco/common'],
@@ -117,8 +114,7 @@ const createConfig =
       bundlePagesRouterDependencies: true,
 
       experimental: {
-        ...validDefaultConfig.experimental,
-        mdxRs: true,
+        ...defaultConfig.experimental,
 
         // This forces Next to use the SWC compiler, which is significantly faster
         // than Babel.  By default it disables SWC with the error message:
@@ -135,31 +131,5 @@ const createConfig =
     };
     return nextConfig;
   };
-
-// TODO: check the build output without this function whenever next has an update
-/**
- * this will only be necessary until the default config is updated OR the config validator is updated.
- * how I check this? I don't know besides doing it manually
- * https://github.com/cyrilwanner/next-compose-plugins/issues/59
- */
-const cleanInvalidValues = defaultConfig => {
-  const config = { ...defaultConfig };
-
-  const invalidProperties = [
-    'webpackDevMiddleware',
-    'configOrigin',
-    'target',
-    'assetPrefix',
-    'i18n',
-  ];
-  for (let index = 0; index < invalidProperties.length; index++) {
-    const property = invalidProperties[index];
-    delete config[property];
-  }
-  delete config.amp.canonicalBase;
-  delete config.experimental.outputFileTracingRoot;
-
-  return config;
-};
 
 module.exports = { createConfig };

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -22,6 +22,7 @@ const createConfig =
     const shouldAnalyzeBundle = !!process.env.BUNDLE_ANALYZE;
 
     const rewriteEntries = options.rewriteEntries || [];
+    const redirectEntries = options.redirectEntries || [];
 
     const nextConfig = {
       ...validDefaultConfig,
@@ -32,14 +33,19 @@ const createConfig =
       basePath: options.basePath || '',
       assetPrefix:
         isProd && prodSubdomain
-          ? `https://${prodSubdomain}.wellcomecollection.org`
+          ? `https://${prodSubdomain}.wellcomecollection.org${options.basePath || ''}`
           : undefined,
       outputFileTracingRoot: path.join(__dirname, '../../'),
       publicRuntimeConfig: {
         apmConfig: apmConfig.client(`${options.applicationName}-webapp`),
       },
+      ...(options.serverRuntimeConfig && {
+        serverRuntimeConfig: options.serverRuntimeConfig,
+      }),
       async rewrites() {
-        if (phase === PHASE_DEVELOPMENT_SERVER) {
+        // An app that owns its own basePath (eg identity, mounted at /account)
+        // doesn't need this dev convenience proxy to itself.
+        if (phase === PHASE_DEVELOPMENT_SERVER && !options.basePath) {
           return [
             {
               source: '/account/:path*',
@@ -49,6 +55,9 @@ const createConfig =
           ];
         }
         return [...rewriteEntries];
+      },
+      async redirects() {
+        return [...redirectEntries];
       },
       webpack: (config, { isServer, webpack }) => {
         config.plugins.push(

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -5,8 +5,14 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const apmConfig = require('../services/apm/apmConfig');
 
 const createConfig =
-  options =>
+  (options = {}) =>
   (phase, { defaultConfig }) => {
+    if (!options.applicationName) {
+      throw new Error(
+        'createConfig requires an applicationName option, e.g. createConfig({ applicationName: "content", ... })'
+      );
+    }
+
     const prodSubdomain = process.env.PROD_SUBDOMAIN || '';
     const buildHash = process.env.BUILD_HASH || 'test';
     const isProd = process.env.NODE_ENV === 'production';

--- a/common/package.json
+++ b/common/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "@elastic/apm-rum": "^5.17.0",
-    "@next/bundle-analyzer": "^15.5.7",
     "@popperjs/core": "^2.11.8",
     "@prismicio/client": "^7.21.6",
     "@prismicio/next": "^2.3.0",

--- a/content/webapp/next.config.js
+++ b/content/webapp/next.config.js
@@ -1,10 +1,6 @@
 const { createConfig } = require('@weco/common/next/next.config');
 
-const CATALOGUE_URL = 'http://localhost:3001/catalogue';
-const localConcurrentDevelopment =
-  process.env.LOCAL_CONCURRENT_DEV_ENV === 'true';
-
-const apiRewrites = [
+const rewriteEntries = [
   {
     source: '/content/management/healthcheck',
     destination: `/api/content/management/healthcheck`,
@@ -14,24 +10,6 @@ const apiRewrites = [
     destination: `/api/newsletter-signup`,
   },
 ];
-
-const rewriteEntries = localConcurrentDevelopment
-  ? [
-      ...apiRewrites,
-      {
-        source: '/:path*',
-        destination: `/:path*`,
-      },
-      {
-        source: '/download',
-        destination: `${CATALOGUE_URL}/download`,
-      },
-      {
-        source: '/image',
-        destination: `${CATALOGUE_URL}/image`,
-      },
-    ]
-  : [...apiRewrites];
 
 module.exports = createConfig({
   applicationName: 'content',

--- a/content/webapp/next.config.js
+++ b/content/webapp/next.config.js
@@ -13,10 +13,6 @@ const apiRewrites = [
     source: '/newsletter-signup',
     destination: `/api/newsletter-signup`,
   },
-  {
-    source: '/content/management/healthcheck',
-    destination: `/api/content/management/healthcheck`,
-  },
 ];
 
 const rewriteEntries = localConcurrentDevelopment

--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -4,8 +4,14 @@ const { getConfig } = require('./config');
 
 module.exports = createConfig({
   applicationName: 'identity',
+
+  // Mounts this app at wellcomecollection.org/account rather than its own subdomain.
   basePath: '/account',
+
+  // Read back in page/api code via next/config's getConfig(), not by importing
+  // ./config directly - see the comment on serverRuntimeConfig in createConfig.
   serverRuntimeConfig: getConfig(),
+
   redirectEntries: [
     {
       // does not add /account since basePath: false is set

--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -5,16 +5,23 @@ const { getConfig } = require('./config');
 module.exports = createConfig({
   applicationName: 'identity',
 
-  // Mounts this app at wellcomecollection.org/account rather than its own subdomain.
+  // Every URL this app serves gets '/account' added in front, e.g. the page at
+  // /search is actually served at wellcomecollection.org/account/search. This
+  // is how identity lives under the main site's domain instead of getting its
+  // own subdomain.
   basePath: '/account',
 
-  // Read back in page/api code via next/config's getConfig(), not by importing
-  // ./config directly - see the comment on serverRuntimeConfig in createConfig.
+  // Passed into next.config.js here, then read back anywhere in this app's
+  // server-side code via next/config's getConfig() - not by importing
+  // ./config directly. See the serverRuntimeConfig comment in createConfig
+  // (common/next/next.config.js) for why it works this way.
   serverRuntimeConfig: getConfig(),
 
   redirectEntries: [
     {
-      // does not add /account since basePath: false is set
+      // Without `basePath: false`, Next would automatically prefix
+      // destination with '/account' too (since this app's basePath is
+      // '/account'), sending people to /account/search instead of /search.
       source: '/account/search',
       destination: '/search',
       basePath: false,

--- a/identity/webapp/next.config.js
+++ b/identity/webapp/next.config.js
@@ -1,73 +1,18 @@
-const withBundleAnalyzer = require('@next/bundle-analyzer');
-
-const apmConfig = require('@weco/common/services/apm/apmConfig');
+const { createConfig } = require('@weco/common/next/next.config');
 
 const { getConfig } = require('./config');
-const buildHash = process.env.BUILD_HASH || 'test';
-const isProd = process.env.NODE_ENV === 'production';
 
-const config = function () {
-  const prodSubdomain = process.env.PROD_SUBDOMAIN || '';
-  const basePath = '/account';
-
-  const withBundleAnalyzerConfig = withBundleAnalyzer({
-    analyzeServer: ['server', 'both'].includes(process.env.BUNDLE_ANALYZE),
-    analyzeBrowser: ['browser', 'both'].includes(process.env.BUNDLE_ANALYZE),
-    bundleAnalyzerConfig: {
-      server: {
-        analyzerMode: 'static',
-        generateStatsFile: true,
-        statsFilename: `../../.dist/server.${buildHash}.json`,
-        reportFilename: `../../.dist/server.${buildHash}.html`,
-        openAnalyzer: false,
-      },
-      browser: {
-        analyzerMode: 'static',
-        generateStatsFile: true,
-        statsFilename: `../.dist/browser.${buildHash}.json`,
-        reportFilename: `../.dist/browser.${buildHash}.html`,
-        openAnalyzer: false,
-      },
+module.exports = createConfig({
+  applicationName: 'identity',
+  basePath: '/account',
+  serverRuntimeConfig: getConfig(),
+  redirectEntries: [
+    {
+      // does not add /account since basePath: false is set
+      source: '/account/search',
+      destination: '/search',
+      basePath: false,
+      permanent: true,
     },
-  });
-
-  return {
-    assetPrefix:
-      isProd && prodSubdomain
-        ? `https://${prodSubdomain}.wellcomecollection.org${basePath}`
-        : undefined,
-    basePath,
-    // We handle compression in the nginx sidecar
-    // Are you having problems with this? Make sure CloudFront is forwarding Accept-Encoding headers to our apps!
-    compress: false,
-    publicRuntimeConfig: { apmConfig: apmConfig.client('identity-webapp') },
-    async redirects() {
-      return [
-        {
-          // does not add /docs since basePath: false is set
-          source: '/account/search',
-          destination: '/search',
-          basePath: false,
-          permanent: true,
-        },
-      ];
-    },
-    serverRuntimeConfig: getConfig(),
-    transpilePackages: ['@weco/common'],
-    webpack: (config, { isServer, webpack }) => {
-      // Exclude undici from client-side bundles
-      // undici is a Node.js-only package and should only be used server-side
-      if (!isServer) {
-        config.plugins.push(
-          new webpack.IgnorePlugin({
-            resourceRegExp: /^undici$/,
-          })
-        );
-      }
-      return config;
-    },
-    ...withBundleAnalyzerConfig,
-  };
-};
-
-module.exports = config();
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,11 +1522,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz#ef28e27c1ded1d8e5c54879a9399e7055aed1920"
   integrity sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==
 
-"@discoveryjs/json-ext@0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
-  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
-
 "@discoveryjs/json-ext@^0.6.3":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
@@ -2613,13 +2608,6 @@
   integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
   dependencies:
     "@tybys/wasm-util" "^0.10.3"
-
-"@next/bundle-analyzer@^15.5.7":
-  version "15.5.22"
-  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-15.5.22.tgz#729fc44aa08bf5efe718240733bb61df85058295"
-  integrity sha512-RH3P0yrgKpJ4+zd8l9MptFk/cI48/6JpIwjdIrdqAb4Kkp611BGudysHpOGUDPOYD8qjT+QkUjDI5QyAwEyMBA==
-  dependencies:
-    webpack-bundle-analyzer "4.10.1"
 
 "@next/env@15.5.21":
   version "15.5.21"
@@ -5231,11 +5219,6 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
-
 commander@^9.3.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
@@ -5481,11 +5464,6 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-debounce@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
-  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5705,11 +5683,6 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
-
-duplexer@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
-  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -6962,13 +6935,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-gzip-size@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
-  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
-  dependencies:
-    duplexer "^0.1.2"
-
 h3@^1.15.6:
   version "1.15.11"
   resolved "https://registry.yarnpkg.com/h3/-/h3-1.15.11.tgz#831179fc6b4bc06de8ad1077e7a5c7d63b796577"
@@ -7099,7 +7065,7 @@ html-encoding-sniffer@^6.0.0:
   dependencies:
     "@exodus/bytes" "^1.6.0"
 
-html-escaper@^2.0.0, html-escaper@^2.0.2:
+html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
@@ -7552,11 +7518,6 @@ is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
-
-is-plain-object@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
-  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -10541,15 +10502,6 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-sirv@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
-  integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
-  dependencies:
-    "@polka/url" "^1.0.0-next.24"
-    mrmime "^2.0.0"
-    totalist "^3.0.0"
-
 sirv@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.2.tgz#f775fccf10e22a40832684848d636346f41cd970"
@@ -11758,25 +11710,6 @@ webidl-conversions@^8.0.1:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz#0657e571fe6f06fcb15ca50ed1fdbcb495cd1686"
   integrity sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==
 
-webpack-bundle-analyzer@4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz#84b7473b630a7b8c21c741f81d8fe4593208b454"
-  integrity sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==
-  dependencies:
-    "@discoveryjs/json-ext" "0.5.7"
-    acorn "^8.0.4"
-    acorn-walk "^8.0.0"
-    commander "^7.2.0"
-    debounce "^1.2.1"
-    escape-string-regexp "^4.0.0"
-    gzip-size "^6.0.0"
-    html-escaper "^2.0.2"
-    is-plain-object "^5.0.0"
-    opener "^1.5.2"
-    picocolors "^1.0.0"
-    sirv "^2.0.3"
-    ws "^7.3.1"
-
 webpack-bundle-analyzer@^5.2.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-5.3.1.tgz#cc966b30f3dd7e2c63b41df1633c0928dce4b77f"
@@ -12017,11 +11950,6 @@ write-file-atomic@^7.0.1:
   integrity sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==
   dependencies:
     signal-exit "^4.0.1"
-
-ws@^7.3.1:
-  version "7.5.13"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
-  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 ws@^8.18.0, ws@^8.19.0:
   version "8.21.1"


### PR DESCRIPTION
Fell in a rabbit hole after https://github.com/wellcomecollection/wellcomecollection.org/pull/13311, seeing we were using a different bundler in `identity` than we were in common/content. So I asked Claude to look at it all and see if the config could be centralised, which then led to further clean ups of legacy config params.

I've tried to split the work in various commits for readability, so you might enjoy looking at that more than the whole thing altogether.

## What does this change?

Removed from `identity/webapp/next.config.js` and why/where it went:

| Old line | What happened |
|---|---|
| `const withBundleAnalyzer = require('@next/bundle-analyzer')` | Removed. Replaced by the `webpack-bundle-analyzer` plugin already wired into the shared config's `webpack()` callback - we had two different bundle-analyzer packages doing the same job, now just one. |
| `const apmConfig = require('@weco/common/services/apm/apmConfig')` | Removed. The shared config already does `apmConfig.client(\`${applicationName}-webapp\`)`, so passing `applicationName: 'identity'` reproduces the same `'identity-webapp'` string identity used to hardcode. |
| `const { getConfig } = require('./config')` | Kept, unchanged - genuinely identity-specific. |
| `const buildHash` / `const isProd` / `const prodSubdomain` | Removed - duplicates of lines the shared config already had. |
| `const basePath = '/account'` | Replaced by passing `basePath: '/account'` as an option to the shared config (which had an unused `basePath` option already, since content never needed one). |
| The whole `withBundleAnalyzerConfig = withBundleAnalyzer({...})` block (server/browser split, custom filenames) | Removed entirely. Replaced by the shared config's existing bundle-analyzer wiring - one `BUNDLE_ANALYZE` flag instead of `server`/`browser`/`both`, output namespaced by app name. |
| `assetPrefix` / `basePath` (returned keys) | Removed - now come from the shared config, which I extended to append `options.basePath` to `assetPrefix` so the resulting URL is identical. |
| `compress: false` | Removed - shared config already sets this, comment and all. |
| `publicRuntimeConfig: { apmConfig: ... }` | Removed - same value now produced generically by the shared config. |
| `async redirects() { ... /account/search -> /search ... }` | Kept, but relocated - this was genuinely identity-specific, so I added a `redirectEntries` option to the shared config (mirroring the existing `rewriteEntries`) and moved it there. |
| `serverRuntimeConfig: getConfig()` | Kept, but relocated - added as a new option on the shared config, only applied when an app actually supplies one. |
| `transpilePackages: ['@weco/common']` | Removed - shared config already sets this. |
| `webpack: (config, ...) => { ...undici IgnorePlugin... }` | Removed - shared config already has the identical undici exclusion (plus a moment-timezone plugin and the bundle analyzer, which identity now gets for free). |
| `module.exports = config();` | Replaced by `module.exports = createConfig({...})` - the whole custom wrapper function goes away. |

### Commit by commit

**Have identity use the shared Next config file**
The actual centralisation. `identity/webapp/next.config.js` now just calls `createConfig()` from `common/next/next.config.js` instead of reimplementing everything by hand (see table above). Had to extend `createConfig` a bit to cover identity's genuine differences - `basePath`, `serverRuntimeConfig`, and a new `redirectEntries` option - and made the dev-only `/account` proxy rewrite skip itself when an app has its own `basePath`, so identity doesn't end up proxying `/account` to itself.

**Remove now unused package**
`@next/bundle-analyzer` was identity's own bundle-analyzer integration. Now that it uses the shared config's `webpack-bundle-analyzer` setup instead, nothing in the repo needs it - removed from `common/package.json`, `yarn.lock` updated to match.

**Update README**
`common/README.md` said bundle analysis was only set up for `content/`. Not true anymore, so updated it to mention `identity/` too.

**Remove duplicate redirect**
`content/webapp/next.config.js` had the exact same `/content/management/healthcheck` rewrite listed twice. Harmless, but dead weight.

**Remove legacy params for catalogue workspace**
While in there: `content/webapp/next.config.js` still had `CATALOGUE_URL` and a `LOCAL_CONCURRENT_DEV_ENV` branch. Turns out `CATALOGUE_URL` was never a Catalogue API - it was the dev-server address of the old separate `catalogue` webapp, from back when it ran alongside content. That app got merged into content in 2023 and most of its rewrites got cleaned up then, but `/download` and `/image` (and a no-op `/:path*` -> `/:path*` rewrite) got left behind. Nothing in the repo sets `LOCAL_CONCURRENT_DEV_ENV` anymore, so the whole branch was unreachable dead code - removed.

**Remove dead next config params**
Two things in the shared config that don't actually do anything on Next 15.5.21: `experimental.mdxRs` (there's no `@next/mdx` anywhere in the repo, so it's a no-op), and the whole `cleanInvalidValues` helper - an old workaround for invalid default-config properties, dating back to a linked GitHub issue from a much older Next version. Checked it against Next 15.5.21's actual `defaultConfig` directly, and confirmed building without it at all works fine in both dev and prod for both apps.

**Add config comments and improve readability**
First pass of comments on the params in `createConfig` and identity's usage of it that didn't already have any - a lot of it wasn't self-explanatory unless you already knew Next.js config internals.

**More removal of dead code and simplifying of comments**
Removed `defaultConfigOptions`/`lintBuilds` too - dead, since both real callers always pass explicit options, and the old default (`applicationName: 'test'`) would've silently mislabelled things rather than failing loudly if it were ever hit. Also rewrote the comments pass so they're understandable without already knowing Next.js internals, and fixed one comment that overstated how linting is enforced here - there's no CI lint step, only a bypassable pre-commit hook that just covers staged files.

**Error handle if no applicationName is passed since we dont have defaults anymore**
A review comment pointed out that removing `defaultConfigOptions` meant `createConfig()` with no args, or a call missing `applicationName`, would now fail with a cryptic `Cannot read properties of undefined` (or silently produce `undefined-webapp` APM/bundle-analysis names). Fixed by defaulting `options` to `{}` and throwing an explicit error if `applicationName` is missing, so a future mistake fails loudly with a clear message instead of quietly or confusingly.

## How to test

Do tests pass?

Run it locally and try various redirects, try to break it.

## Have we considered potential risks?
Hopefully our tests cover enough ground, and manual testing should make us feel good about moving forward. We'll also test once in staging.