### PR TITLE
Fix GridViewer rendering when there's no manifest to page through

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.tsx
@@ -469,7 +469,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
                 <ViewerBottomBar />
               </BottomBar>
             )}
-            {hasOnlyRenderableImages && (
+            {hasOnlyRenderableImages && hasMultipleCanvases && (
               <ThumbnailsWrapper
                 $isActive={gridVisible}
                 $isDesktopSidebarActive={isDesktopSidebarActive}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -486,7 +486,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
                 <ViewerBottomBar />
               </BottomBar>
             )}
-            {hasOnlyRenderableImages && (
+            {hasOnlyRenderableImages && hasMultipleCanvases && (
               <ThumbnailsWrapper
                 $isActive={gridVisible}
                 $isDesktopSidebarActive={isDesktopSidebarActive}


### PR DESCRIPTION
- For #12985

## What does this change?

[This was a problem flagged in the type audit](https://github.com/wellcomecollection/wellcomecollection.org/pull/13278#discussion_r3596257816).

The narrow and straightforward fix seemed to be to make `hasOnlyRenderableImages` explicitly check that a manifest exists, rather than defaulting to an empty array that accidentally reads as "all images":

```tsx
   const hasOnlyRenderableImages =
     Boolean(transformedManifest) &&
     !hasNonImagesOrOriginals(transformedManifest?.canvases || []);
```

I tried that, but checking it in the browser exposed a problem with the fix itself: the fix removes the **Zoom in / Rotate** overlay buttons that currently show on page load.

> Why: `ImageViewerControls` (the zoom/rotate overlay) is gated purely by `hasOnlyRenderableImages` (`{!showZoomed && hasOnlyRenderableImages && <ImageViewerControls />}`). For a single-image work with no presentation manifest, that's a legitimate, working feature today. My fix makes `hasOnlyRenderableImages` require a `transformedManifest` to exist — which correctly stops the phantom `GridViewer`, but also incorrectly turns off zoom/rotate for standalone images, since `MainViewer` (which would otherwise manage that state via hover) never even mounts in this case, so `showControls` never gets set after its initial `true`.
> 
> This is exactly the coupling problem issue #12985 is about: one boolean is doing two different jobs — "does the manifest contain any non-image canvases" (relevant to `GridViewer`/pagination) and "is the currently-displayed thing an image" (relevant to zoom/rotate controls) — and `transformedManifest` existing isn't the right gate for both.
> 
> Recommendation: Leave the broader #12985 restructure as separate, deliberate work rather than doing it here — this investigation actually reinforces why: `hasOnlyRenderableImages` is overloaded across multiple components, and untangling that properly needs its own scoped effort with characterisation tests as a safety net, not something to rush alongside a bug fix.
> 
> The main tradeoff: shipping the narrow fix now means the underlying coupling (one boolean serving unrelated concerns) stays in place for a while longer, but it directly closes the reviewer's issue with minimal blast radius, which matters more given how easily the first attempt at "the obvious fix" broke something unrelated

If we decide to merge this PR, we can add the larger restructure/fix to the [follow-up ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/13273)

## How to test

I think check there is still grid view toggle [where you'd expect](https://www-dev.wellcomecollection.org/works/a227dajt/items), and not [where you wouldn't expect](https://www-dev.wellcomecollection.org/works/a2475q3n/items)

And `yarn workspace @weco/content test:watch:fast iiif` for good measure

## Have we considered potential risks?

The main risk was touching `hasOnlyRenderableImages`, since it's read in several unrelated places (zoom/rotate controls, layout grid areas, `MainViewer`'s virtualised-vs-paginated choice). This PR deliberately doesn't change that — it only adds an extra condition at the one render site that needed it, and that was verified by manually testing both a no-manifest work and a real multi-canvas manifest work in a browser