### PR TITLE
Don't forward an empty JSON body to the identity API on send-verifica…

### DIFF
--- a/identity/webapp/pages/api/users/[[...users]].ts
+++ b/identity/webapp/pages/api/users/[[...users]].ts
@@ -20,6 +20,14 @@ const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
       const { accessToken } = await auth0.getAccessToken(req, res);
       const path = `/users/${(req.query.users as string[]).join('/')}`;
 
+      // req.body is '' (not undefined) when the original request had no body
+      // at all - Next.js's parseBody falls back to text/plain and yields ''
+      // for zero bytes (see parseBody in
+      // next/dist/server/api-utils/node/parse-body.js). Treat that the same
+      // as "no body" so we don't forward a bogus JSON.stringify('') === '""'
+      // payload to the identity API.
+      const body = req.body === '' ? undefined : req.body;
+
       // GET and HEAD requests cannot have a body
       const method = req.method || 'GET';
       const remoteResponse = await identityFetchClient
@@ -27,7 +35,9 @@ const handleIdentityApiRequest: NextApiHandler = auth0.withApiAuthRequired(
           url: path,
           method,
           // Only include body for methods that support it
-          ...(method !== 'GET' && method !== 'HEAD' ? { data: req.body } : {}),
+          ...(method !== 'GET' && method !== 'HEAD' && body !== undefined
+            ? { data: body }
+            : {}),
           headers: {
             ...identityFetchClient.defaults.headers.common,
             Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
- For [#13314](https://github.com/wellcomecollection/wellcomecollection.org/issues/13314): clicking "resend verification email" in the unverified-email banner on /account displays "Something went wrong" message, and no email is sent.

## What does this change?

**Root cause:** 
- the identity API proxy at identity/webapp/pages/api/users/[[...users]].ts forwards req.body as the outgoing request body for any non-GET/HEAD method. 
- send-verification-email is called with no body at all
- Next.js's own API route body parser doesn't yield undefined for a bodyless request — it falls back to text/plain and returns '' (an empty string). 
- The empty string was then getting JSON.stringify'd into the literal two-character string "" and sent to the identity API with Content-Type: application/json, which the identity API can't parse, so it returns a 500.

N.B. Bug was introduced in [Replace axios with native Node functions #12932] since Axios's default transformRequest only calls JSON.stringify on data when it's actually an object (or Content-Type was already explicitly set to JSON) — for a plain string like '' it just passes it through as the (empty) body untouched. 

**The fix:** 
In the proxy route we now normalize req.body === '' to undefined before deciding whether to forward a body, so a genuinely empty request stays empty instead of getting wrapped into "".

## How to test
- On PROD (or main), sign in as a user with an unverified email, click "resend" in the /account banner: see "Something went wrong", no email arrives.
- On this branch, same steps: the request returns 204 and the verification email arrives.
- Check: update-email, update-password, and delete-account flows (useUpdateUser, useUpdatePassword, useRequestDelete) still work. They should be ok because they all send real, non-empty JSON bodies via the same proxy route, so should be unaffected by this change, but worth confirming manually.

## Have we considered potential risks?
Low risk. The change only alters behaviour for the specific case where req.body is exactly '' (i.e. a request sent with no body at all), which previously produced a guaranteed 500 from the identity API. No other caller of this proxy route sends an empty body, so there's no existing working behaviour this could regress.