### PR TITLE
Add brandUpdate toggle

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -152,6 +152,13 @@ const toggleConfig = {
         'Displays the refactored item viewer instead of the current one.',
       type: 'experimental',
     },
+    {
+      id: 'brandUpdate',
+      title: 'Brand update',
+      initialValue: false,
+      description: 'Shows new brand values',
+      type: 'experimental',
+    },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir
   // because they are deployed separately and consequently can't share a source of truth

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -158,7 +158,6 @@ const toggleConfig = {
       initialValue: false,
       description: 'Shows the new brand values.',
       type: 'experimental',
-    }
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir

--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -156,8 +156,9 @@ const toggleConfig = {
       id: 'brandUpdate',
       title: 'Brand update',
       initialValue: false,
-      description: 'Shows new brand values',
+      description: 'Shows the new brand values.',
       type: 'experimental',
+    }
     },
   ] as const,
   // We have to include a reference to any test toggles here as well as in the cache dir


### PR DESCRIPTION
- For #13207

## What does this change?

Adds the `brandUpdate` toggle to the repo. This has already been deployed to the [dashboard](https://dash.wellcomecollection.org/toggles/?enableToggle=brandUpdate).

## How to test

Do the words make sense?

## Have we considered potential risks?

n/a