### PR TITLE
New registration fix

### DIFF
--- a/identity/webapp/pages/api/auth/[...auth0].ts
+++ b/identity/webapp/pages/api/auth/[...auth0].ts
@@ -9,8 +9,10 @@ export default auth0.handleAuth({
     const { error } = req.query;
 
     if (error) {
-      const query = new URLSearchParams(req.url);
-      res.redirect(withBasePath(`/error?${query.toString()}`));
+      const [, queryString] = req.url.split('?');
+      res.redirect(
+        withBasePath(queryString ? `/error?${queryString}` : '/error')
+      );
       return;
     }
 

--- a/identity/webapp/pages/api/auth/[...auth0].ts
+++ b/identity/webapp/pages/api/auth/[...auth0].ts
@@ -1,4 +1,4 @@
-import auth0 from '@weco/identity/utils/auth0';
+import auth0, { identityBasePath } from '@weco/identity/utils/auth0';
 import {
   isFreshRegistration,
   logoutToSuccessUrl,
@@ -30,7 +30,10 @@ export default auth0.handleAuth({
           // page's logout->/success handling. Force that same redirect here,
           // regardless of what returnTo was requested.
           if (isFreshRegistration(session.user.family_name)) {
-            res.setHeader('Location', logoutToSuccessUrl(session.user.email));
+            res.setHeader(
+              'Location',
+              identityBasePath + logoutToSuccessUrl(session.user.email)
+            );
           }
           return session;
         },

--- a/identity/webapp/pages/api/auth/[...auth0].ts
+++ b/identity/webapp/pages/api/auth/[...auth0].ts
@@ -1,4 +1,8 @@
 import auth0 from '@weco/identity/utils/auth0';
+import {
+  isFreshRegistration,
+  logoutToSuccessUrl,
+} from '@weco/identity/utils/postRegistration';
 
 export default auth0.handleAuth({
   callback: async (req, res) => {
@@ -18,7 +22,19 @@ export default auth0.handleAuth({
     // I don't think anybody will encounter this in normal running, and I'm not
     // sure if that message could leak sensitive info.
     try {
-      return await auth0.handleCallback(req, res);
+      return await auth0.handleCallback(req, res, {
+        afterCallback: (req, res, session) => {
+          // A signup completed via a returnTo-tagged login link (e.g. from a
+          // work page) would otherwise land the user back on that page with
+          // a stale placeholder name, instead of going through the account
+          // page's logout->/success handling. Force that same redirect here,
+          // regardless of what returnTo was requested.
+          if (isFreshRegistration(session.user.family_name)) {
+            res.setHeader('Location', logoutToSuccessUrl(session.user.email));
+          }
+          return session;
+        },
+      });
     } catch (error) {
       console.warn(`Error in the Auth0 callback: ${error.message}`);
       res

--- a/identity/webapp/pages/api/auth/[...auth0].ts
+++ b/identity/webapp/pages/api/auth/[...auth0].ts
@@ -1,4 +1,4 @@
-import auth0, { identityBasePath } from '@weco/identity/utils/auth0';
+import auth0, { withBasePath } from '@weco/identity/utils/auth0';
 import {
   isFreshRegistration,
   logoutToSuccessUrl,
@@ -10,7 +10,7 @@ export default auth0.handleAuth({
 
     if (error) {
       const query = new URLSearchParams(req.url);
-      res.redirect(`/account/error?${query.toString()}`);
+      res.redirect(withBasePath(`/error?${query.toString()}`));
       return;
     }
 
@@ -32,7 +32,7 @@ export default auth0.handleAuth({
           if (isFreshRegistration(session.user.family_name)) {
             res.setHeader(
               'Location',
-              identityBasePath + logoutToSuccessUrl(session.user.email)
+              withBasePath(logoutToSuccessUrl(session.user.email))
             );
           }
           return session;

--- a/identity/webapp/pages/index.tsx
+++ b/identity/webapp/pages/index.tsx
@@ -1,5 +1,4 @@
 import { NextPage } from 'next';
-import { URLSearchParams } from 'url';
 
 import { getServerData } from '@weco/common/server-data';
 import { serialiseProps } from '@weco/common/utils/json';
@@ -8,6 +7,10 @@ import {
   ServerSidePropsOrAppError,
 } from '@weco/common/views/pages/_app';
 import auth0, { withPageAuthRequiredSSR } from '@weco/identity/utils/auth0';
+import {
+  isFreshRegistration,
+  logoutToSuccessUrl,
+} from '@weco/identity/utils/postRegistration';
 import AccountPage, {
   Props as AccountPageProps,
 } from '@weco/identity/views/pages';
@@ -57,16 +60,10 @@ export const getServerSideProps: ServerSidePropsOrAppError<Props> =
           }),
         };
 
-      if (session.user.family_name === 'Auth0_Registration_tempLastName') {
-        const successParams = new URLSearchParams();
-        successParams.append('email', session.user.email);
-
-        const params = new URLSearchParams();
-        params.append('returnTo', `/success?${successParams}`);
-
+      if (isFreshRegistration(session.user.family_name)) {
         return {
           redirect: {
-            destination: `/api/auth/logout?${params}`,
+            destination: logoutToSuccessUrl(session.user.email),
             permanent: false,
           },
         };

--- a/identity/webapp/utils/auth0.ts
+++ b/identity/webapp/utils/auth0.ts
@@ -93,6 +93,12 @@ const auth0 = initAuth0({
   },
 });
 
+// Handlers in pages/api/auth/[...auth0].ts that set res.redirect/Location
+// directly (rather than going through Next's own redirect/getServerSideProps
+// mechanisms) bypass Next's automatic basePath prefixing, so they need to
+// prepend this themselves.
+export const identityBasePath = config.identityBasePath;
+
 // Wrapping the built-in method as per https://github.com/auth0/nextjs-auth0#base-path-and-internationalized-routing
 // in order to preserve basePath
 export const withPageAuthRequiredSSR =

--- a/identity/webapp/utils/auth0.ts
+++ b/identity/webapp/utils/auth0.ts
@@ -96,8 +96,10 @@ const auth0 = initAuth0({
 // Handlers in pages/api/auth/[...auth0].ts that set res.redirect/Location
 // directly (rather than going through Next's own redirect/getServerSideProps
 // mechanisms) bypass Next's automatic basePath prefixing, so they need to
-// prepend this themselves.
-export const identityBasePath = config.identityBasePath;
+// prepend it themselves. Use this instead of prepending config.identityBasePath
+// by hand, so every such call site is consistent and easy to spot.
+export const withBasePath = (path: string): string =>
+  config.identityBasePath + path;
 
 // Wrapping the built-in method as per https://github.com/auth0/nextjs-auth0#base-path-and-internationalized-routing
 // in order to preserve basePath

--- a/identity/webapp/utils/postRegistration.ts
+++ b/identity/webapp/utils/postRegistration.ts
@@ -1,0 +1,20 @@
+import { URLSearchParams } from 'url';
+
+// A brand-new signup gets a placeholder name until Auth0 next syncs from
+// Sierra (which only happens on a fresh login). We treat this placeholder
+// as our signal that registration just completed.
+const PLACEHOLDER_LAST_NAME = 'Auth0_Registration_tempLastName';
+
+export function isFreshRegistration(familyName?: string): boolean {
+  return familyName === PLACEHOLDER_LAST_NAME;
+}
+
+export function logoutToSuccessUrl(email: string): string {
+  const successParams = new URLSearchParams();
+  successParams.append('email', email);
+
+  const params = new URLSearchParams();
+  params.append('returnTo', `/success?${successParams}`);
+
+  return `/api/auth/logout?${params}`;
+}


### PR DESCRIPTION
For #13313

## What does this change?
Fixes a bug where registering, after following the "sign in to your library account to request items" link from a work page, landed the user back on that page with a stale placeholder name in the header, instead of the sign-out -> application-received page flow that happens when registering after following the sign in link in the page header.

### Cause
The redirect-on-fresh-registration logic lived in the getServerSideProps of the account homepage (identity/webapp/pages/index.tsx). It checked whether family_name was still the Auth0 placeholder value set on brand-new signups. The "sign in to your library account to request items" link carries a returnTo value that sends the user straight back to the originating page and so bypasses that check entirely.

### Fix
Moves this check into the Auth0 callback's afterCallback, which every login passes through regardless of a returnTo value. The shared logic (isFreshRegistration, logoutToSuccessUrl) is extracted into identity/webapp/utils/postRegistration.ts so both call sites use the same code.

While testing this on www-dev, the redirect initially 404'd. The identity app is served under an /account basePath, which Next.js auto-prefixes for redirects made via getServerSideProps but not for a raw res.setHeader('Location', ...) call (which is what the new afterCallback code uses, since it isn't going through Next's router). That's now handled by a small withBasePath helper in identity/webapp/utils/auth0.ts, also used to tidy up an existing hardcoded /account/error redirect in the same file so there's one consistent way to build these raw redirects going forward.

## How to test
On PROD (or www-dev), follow a login link from a work page and register as a new user (fill in first name, last name, accept the agreement, submit). You currently land back on the work page with placeholder "AA" initials in the header.

On this branch, the same flow should sign you out and take you to the application-received (/success) page showing your registration email, matching what already happens when you register via the header login link.

## Have we considered potential risks?
Low risk - this only affects the fresh-registration redirect path, gated by checking for Auth0's placeholder family_name value, so it shouldn't affect any other login/logout flows.