### PR TITLE
Broader readability pass over refactored/IIIFViewer

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
@@ -13,7 +13,7 @@ import {
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
 
-import MainViewer from './MainViewer';
+import MainViewer, { getOverlayTopLeft, RotationValue } from './MainViewer';
 
 // The legacy counterpart to the refactored viewer tests. Legacy MainViewer is
 // both viewers in one component, so the two describes below mirror
@@ -406,4 +406,43 @@ describe('MainViewer (legacy)', () => {
       expect(screen.getByTestId('main-viewer')).toBeEmptyDOMElement();
     });
   });
+});
+
+describe('getOverlayTopLeft', () => {
+  const imageContainerRect = { top: 10, left: 20 } as unknown as DOMRect;
+  const imageRect = {
+    top: 30,
+    left: 50,
+    width: 200,
+    height: 100,
+  } as unknown as DOMRect;
+  const x = 15;
+  const y = 8;
+
+  // startTop = imageRect.top - imageContainerRect.top = 20
+  // startLeft = imageRect.left - imageContainerRect.left = 30
+  const expectedByRotation: Record<
+    RotationValue,
+    { overlayTop: number; overlayLeft: number }
+  > = {
+    0: { overlayTop: 28, overlayLeft: 45 },
+    90: { overlayTop: 35, overlayLeft: 222 },
+    180: { overlayTop: 112, overlayLeft: 215 },
+    270: { overlayTop: 105, overlayLeft: 38 },
+  };
+
+  it.each([0, 90, 180, 270] as RotationValue[])(
+    'computes the overlay position for a %d degree rotation',
+    rotation => {
+      const result = getOverlayTopLeft({
+        imageContainerRect,
+        imageRect,
+        rotation,
+        x,
+        y,
+      });
+
+      expect(result).toEqual(expectedByRotation[rotation]);
+    }
+  );
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.tsx
@@ -73,7 +73,7 @@ type SearchTermHighlightProps = {
   $rotation: number;
 };
 
-type RotationValue = 0 | 90 | 180 | 270;
+export type RotationValue = 0 | 90 | 180 | 270;
 
 const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
   background: ${props => props.theme.color('yellow')};
@@ -99,7 +99,7 @@ type ItemRendererProps = ListChildComponentProps<{
   firstItemIsRestricted?: boolean;
 }>;
 
-function getOverlayTopLeft({
+export function getOverlayTopLeft({
   imageContainerRect,
   imageRect,
   rotation,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.tsx
@@ -64,18 +64,18 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
         new URL(currentCanvas.id).pathname === new URL(resource.on).pathname
     )
   );
+  const isScrollingFast = scrollVelocity > 1;
 
   return (
     <div style={style}>
-      {scrollVelocity > 1 ? (
+      {isScrollingFast ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <LL $lighten={true} />
+          <LL $lighten />
         </div>
       ) : (
         currentCanvas && (
           <ThumbnailSpacer>
             <NextLink
-              replace={true}
               {...toWorksItemLink({
                 workId,
                 props: {
@@ -92,12 +92,13 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
                 setGridVisible(false);
               }}
               tabIndex={gridVisible ? 0 : -1}
+              replace
             >
               <IIIFCanvasThumbnail
                 canvas={currentCanvas}
                 placeholderId={placeholderId}
                 thumbNumber={arrayIndexToQueryParam(canvasIndex)}
-                highlightImage={hasSearchResults}
+                isHighlighted={hasSearchResults}
               />
             </NextLink>
           </ThumbnailSpacer>
@@ -109,7 +110,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
 
 Cell.displayName = 'Cell';
 
-const GridViewerEl = styled.div`
+const GridViewerContainer = styled.div`
   outline: none;
   position: fixed;
   top: 0;
@@ -132,12 +133,15 @@ const GridViewer: FunctionComponent = () => {
     work,
   } = useItemViewerContext();
   const { windowSize } = useAppContext();
-  const [newScrollOffset, setNewScrollOffset] = useState(0);
-  const scrollVelocity = useScrollVelocity(newScrollOffset);
+
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const scrollVelocity = useScrollVelocity(scrollOffset);
+
+  const grid = useRef<FixedSizeGrid>(null);
+
   const itemWidth = windowSize === 'zero' ? 250 : 350;
   const columnCount = Math.max(1, Math.round(mainAreaWidth / itemWidth)); // ensure at least one column is displayed
   const columnWidth = mainAreaWidth / columnCount;
-  const grid = useRef<FixedSizeGrid>(null);
   const canvases = transformedManifest?.canvases;
 
   useEffect(() => {
@@ -168,7 +172,7 @@ const GridViewer: FunctionComponent = () => {
   }, []);
 
   return (
-    <GridViewerEl tabIndex={0}>
+    <GridViewerContainer tabIndex={0}>
       <FixedSizeGrid
         columnCount={columnCount}
         columnWidth={columnWidth}
@@ -187,12 +191,12 @@ const GridViewer: FunctionComponent = () => {
           workId: work.id,
           placeholderId: transformedManifest?.placeholderId,
         }}
-        onScroll={({ scrollTop }) => setNewScrollOffset(scrollTop)}
+        onScroll={({ scrollTop }) => setScrollOffset(scrollTop)}
         ref={grid}
       >
         {Cell}
       </FixedSizeGrid>
-    </GridViewerEl>
+    </GridViewerContainer>
   );
 };
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
@@ -58,6 +58,13 @@ const ImageContainer = styled.span`
   }
 `;
 
+const IconWrapper = styled.span`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 const IIIFViewerThumbNumber = styled.span.attrs({
   className: typography('body', 'sm', 'strong'),
 })`
@@ -72,47 +79,47 @@ const IIIFViewerThumbNumber = styled.span.attrs({
   }
 `;
 
-const IconWrapper = styled.span`
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
+function getPlaceholderIcon(
+  itemType: string | undefined,
+  canvas: TransformedCanvas
+) {
+  if (itemType === 'Sound') return audio;
+  if (itemType === 'Video') return video;
+  if (isPDFCanvas(canvas)) return pdf;
+  return file;
+}
 
 type IIIFCanvasThumbnailProps = {
   canvas: TransformedCanvas;
   thumbNumber: number;
-  highlightImage?: boolean;
+  isHighlighted?: boolean;
   placeholderId?: string;
 };
 
 const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
   canvas,
   thumbNumber,
-  highlightImage,
+  isHighlighted,
   placeholderId,
 }: IIIFCanvasThumbnailProps) => {
   const [thumbnailLoaded, setThumbnailLoaded] = useState(false);
   const { userIsStaffWithRestricted } = useUserContext();
+
   const isRestricted = hasRestrictedItem(canvas);
   const urlTemplate = canvas.imageServiceId
     ? iiifImageTemplate(canvas.imageServiceId)
     : undefined;
-
   const thumbnailSrc =
     canvas?.thumbnailImage?.url ||
     (urlTemplate && urlTemplate({ size: '200,' })) ||
     placeholderId;
-
   const itemType = isChoiceBody(canvas?.painting?.[0])
     ? (canvas.painting[0].items[0] as IIIFExternalWebResource | IIIFItemProps)
         ?.type
     : canvas.painting?.[0]?.type;
-
-  const thumbnailSrcIsPlaceholder =
+  const isThumbnailSrcPlaceholder =
     thumbnailSrc?.includes('/born-digital/placeholder-thumb/') || false;
-
-  const hasIconPlaceholder = !thumbnailSrc || thumbnailSrcIsPlaceholder;
+  const shouldShowIconPlaceholder = !thumbnailSrc || isThumbnailSrcPlaceholder;
 
   return (
     <IIIFViewerThumb>
@@ -129,12 +136,11 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
 
           {!isRestricted && (
             <>
-              {!hasIconPlaceholder ? (
+              {!shouldShowIconPlaceholder ? (
                 <>
-                  {!thumbnailLoaded && <LL $small={true} $lighten={true} />}
+                  {!thumbnailLoaded && <LL $small $lighten />}
 
                   <IIIFViewerImage
-                    highlightImage={highlightImage}
                     width={canvas?.thumbnailImage?.width || 30}
                     src={thumbnailSrc}
                     srcSet=""
@@ -143,28 +149,17 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
                     loadHandler={() => {
                       setThumbnailLoaded(true);
                     }}
+                    isHighlighted={isHighlighted}
                   />
                 </>
               ) : (
-                <>
-                  {hasIconPlaceholder && (
-                    <IconWrapper>
-                      <Icon
-                        icon={
-                          itemType === 'Sound'
-                            ? audio
-                            : itemType === 'Video'
-                              ? video
-                              : isPDFCanvas(canvas)
-                                ? pdf
-                                : file
-                        }
-                        iconColor="white"
-                        sizeOverride="width: 53px; height: 53px;"
-                      />
-                    </IconWrapper>
-                  )}
-                </>
+                <IconWrapper>
+                  <Icon
+                    icon={getPlaceholderIcon(itemType, canvas)}
+                    iconColor="white"
+                    sizeOverride="width: 53px; height: 53px;"
+                  />
+                </IconWrapper>
               )}
             </>
           )}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
@@ -68,7 +68,7 @@ const MessageContainer = styled.div`
   padding: 10%;
 `;
 
-const RestrictedMessage = styled.div.attrs({})`
+const RestrictedMessage = styled.div`
   margin: 2em auto 0;
   padding: 0 2em;
 
@@ -129,22 +129,20 @@ const Choice: FunctionComponent<
     const firstItem = item.items[0];
     if (typeof firstItem !== 'string' && 'id' in firstItem) {
       return (
-        <>
-          <RenderItem
-            key={firstItem.id}
-            item={firstItem}
-            i={i}
-            canvas={canvas}
-            placeholderId={placeholderId}
-            titleOverride={titleOverride}
-            exclude={exclude}
-            itemUrl={itemUrl}
-            isDark={isDark}
-            externalAccessService={externalAccessService}
-            shouldScrollToUpdateUrl={shouldScrollToUpdateUrl}
-            showVideoTranscript={showVideoTranscript}
-          />
-        </>
+        <RenderItem
+          key={firstItem.id}
+          item={firstItem}
+          i={i}
+          canvas={canvas}
+          placeholderId={placeholderId}
+          titleOverride={titleOverride}
+          exclude={exclude}
+          itemUrl={itemUrl}
+          isDark={isDark}
+          externalAccessService={externalAccessService}
+          shouldScrollToUpdateUrl={shouldScrollToUpdateUrl}
+          showVideoTranscript={showVideoTranscript}
+        />
       );
     }
   }
@@ -227,7 +225,7 @@ type ItemProps = {
 };
 
 const PublicRestrictedMessage: FunctionComponent<{
-  externalAccessService?: import('@weco/content/utils/iiif/v3').TransformedAuthService;
+  externalAccessService?: TransformedAuthService;
 }> = ({ externalAccessService }) => {
   return (
     <MessageContainer>
@@ -299,7 +297,6 @@ const IIIFItemWrapper: FunctionComponent<{
 // Wraps IIIFItemWrapper with an intersection observer that keeps the URL in
 // sync with the visible canvas when scrolling through images in the viewer.
 // Only used for the IIIFImage case because we only scroll when all items are images
-
 const IIIFItemWrapperWithObserver: FunctionComponent<{
   shouldShowItem: boolean;
   className: string;
@@ -357,6 +354,16 @@ const IIIFItemWrapperWithObserver: FunctionComponent<{
   );
 };
 
+function getItemLabel(
+  item: IIIFItemProps,
+  canvas: TransformedCanvas
+): string | undefined {
+  if ('label' in item) {
+    return getLabelString(item.label as InternationalString);
+  }
+  return canvas.label?.trim() !== '-' ? canvas.label : undefined;
+}
+
 const IIIFItem: FunctionComponent<ItemProps> = ({
   canvas,
   item,
@@ -375,12 +382,14 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
   const { userIsStaffWithRestricted } = useUserContext();
   const isRestricted = hasRestrictedItem(canvas);
   const isProbeOk = useIIIFProbeService(canvas);
+
   // Replace "image" with "item" in description if the item is not an image
   // or if it's an image but has originals, which means the image is just a placeholder for the original item
+  const shouldRelabelImageAsItem =
+    item.type !== 'Image' ||
+    (item.type === 'Image' && canvas.original.length > 0);
   const adjustedExternalAccessService =
-    externalAccessService &&
-    (item.type !== 'Image' ||
-      (item.type === 'Image' && canvas.original.length > 0))
+    externalAccessService && shouldRelabelImageAsItem
       ? {
           ...externalAccessService,
           description: externalAccessService.description
@@ -388,14 +397,8 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             ?.replace(/\bviewed\b/gi, 'accessed'),
         }
       : externalAccessService;
-
   const shouldShowItem = isRestricted && !userIsStaffWithRestricted;
-  const itemLabel =
-    'label' in item
-      ? getLabelString(item.label as InternationalString)
-      : canvas.label?.trim() !== '-'
-        ? canvas.label
-        : undefined;
+  const itemLabel = getItemLabel(item, canvas);
 
   if (item.type === 'Choice' && !exclude.includes('Choice')) {
     return (
@@ -419,11 +422,11 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
     );
   }
 
-  if (
-    ((item.type === 'Sound' && !exclude.includes('Sound')) ||
-      (item.type === 'Audio' && !exclude.includes('Audio'))) &&
-    !!item.id
-  ) {
+  const isAudioType =
+    (item.type === 'Sound' && !exclude.includes('Sound')) ||
+    (item.type === 'Audio' && !exclude.includes('Audio'));
+
+  if (isAudioType && item.id) {
     return (
       <IIIFItemWrapper
         shouldShowItem={shouldShowItem}
@@ -450,19 +453,17 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
         isProbeOk={isProbeOk}
         externalAccessService={adjustedExternalAccessService}
       >
-        <>
-          <VideoPlayer
-            placeholderId={placeholderId}
-            video={item}
-            showDownloadOptions={true}
+        <VideoPlayer
+          placeholderId={placeholderId}
+          video={item}
+          showDownloadOptions
+        />
+        {showVideoTranscript && (
+          <VideoTranscript
+            supplementing={canvas.supplementing}
+            isDark={isDark}
           />
-          {showVideoTranscript && (
-            <VideoTranscript
-              supplementing={canvas.supplementing}
-              isDark={isDark}
-            />
-          )}
-        </>
+        )}
       </IIIFItemWrapper>
     );
   }
@@ -509,7 +510,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
                     label={itemLabel}
                     fileSize={getFileSize(canvas)}
                     format={'format' in original ? original.format : undefined}
-                    showWarning={true}
+                    showWarning
                   />
                 </IIIFItemWrapper>
               )
@@ -537,7 +538,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             isProbeOk={isProbeOk}
             externalAccessService={adjustedExternalAccessService}
             index={i}
-            removeRestrictedMessage={true}
+            removeRestrictedMessage
           >
             {imageContent}
           </IIIFItemWrapperWithObserver>
@@ -551,7 +552,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           isRestricted={isRestricted}
           isProbeOk={isProbeOk}
           externalAccessService={adjustedExternalAccessService}
-          removeRestrictedMessage={true}
+          removeRestrictedMessage
         >
           {imageContent}
         </IIIFItemWrapper>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -17,15 +17,13 @@ import {
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { searchWithinLabel } from '@weco/content/text/aria-labels';
 import { TransformedCanvas } from '@weco/content/types/manifest';
-import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
+import {
+  ItemProps,
+  toWorksItemLink,
+} from '@weco/content/views/components/ItemLink';
 import { arrayIndexToQueryParam } from '@weco/content/views/pages/works/work/work.helpers';
 
 import { thumbnailsPageSize } from './Paginators';
-
-const Highlight = styled.span`
-  background: ${props => props.theme.color('yellow')};
-  color: ${props => props.theme.color('black')};
-`;
 
 const SearchForm = styled.form`
   position: relative;
@@ -46,12 +44,22 @@ const SearchButtonWrapper = styled.div`
   }
 `;
 
+const ErrorMessage = styled(Space).attrs({
+  as: 'p',
+  $v: { size: 'sm', properties: ['margin-top'] },
+  className: typography('body', 'sm', 'regular'),
+})``;
+
 const ResultsHeader = styled(Space).attrs({
   as: 'h3',
   $v: { size: 'sm', properties: ['margin-top'] },
 })`
   border-bottom: 1px solid ${props => props.theme.color('neutral.500')};
   padding-bottom: ${props => `${props.theme.spacingUnit}px`};
+`;
+
+const ResultsList = styled.ul`
+  padding: 0;
 `;
 
 const ListItem = styled.li.attrs({
@@ -78,15 +86,10 @@ const HitData = styled(Space).attrs({
   display: block;
 `;
 
-const ResultsList = styled.ul`
-  padding: 0;
+const Highlight = styled.span`
+  background: ${props => props.theme.color('yellow')};
+  color: ${props => props.theme.color('black')};
 `;
-
-const ErrorMessage = styled(Space).attrs({
-  as: 'p',
-  $v: { size: 'sm', properties: ['margin-top'] },
-  className: typography('body', 'sm', 'regular'),
-})``;
 
 const Loading = () => (
   <div
@@ -96,7 +99,7 @@ const Loading = () => (
       height: '80px',
     }}
   >
-    <LL $small={true} $lighten={true} />
+    <LL $small $lighten />
     <span className="visually-hidden">Loading</span>
   </div>
 );
@@ -133,6 +136,25 @@ const Hit: FunctionComponent<HitProps> = ({
   );
 };
 
+// We need the matching resource for each hit to get the canvas it appears on
+function findCanvasIndexForHit(
+  hit: SearchResults['hits'][0],
+  searchResults: SearchResults | null,
+  canvases: TransformedCanvas[] | undefined
+) {
+  const matchingResources = hit.annotations
+    .map(annotation =>
+      searchResults?.resources?.find(resource => resource['@id'] === annotation)
+    )
+    .filter(Boolean)
+    .filter(resource => resource?.resource?.chars);
+
+  return canvases?.findIndex(canvas => {
+    const matchingPathname = matchingResources[0]?.on || '';
+    return new URL(matchingPathname).pathname === new URL(canvas.id).pathname;
+  });
+}
+
 const IIIFSearchWithin: FunctionComponent = () => {
   const router = useRouter();
   const theme = useTheme();
@@ -146,10 +168,15 @@ const IIIFSearchWithin: FunctionComponent = () => {
     query,
     work,
   } = useItemViewerContext();
-  const [value, setValue] = useState(query.query);
+  const [searchQuery, setSearchQuery] = useState(query.query);
   const [isLoading, setIsLoading] = useState(false);
   const [searchError, setSearchError] = useState(false);
   const { searchService, canvases } = { ...transformedManifest };
+
+  function navigateToItem(props: Partial<ItemProps>) {
+    const link = toWorksItemLink({ workId: work.id, props });
+    router.replace(link.href);
+  }
 
   function handleClearResults() {
     // Set data attribute to prevent GTM trigger from firing
@@ -157,16 +184,12 @@ const IIIFSearchWithin: FunctionComponent = () => {
       formRef.current.dataset.gtmIsClearing = 'true';
     }
 
-    const link = toWorksItemLink({
-      workId: work.id,
-      props: {
-        manifest: query.manifest,
-        canvas: query.canvas,
-        page: query.page,
-      },
+    setSearchResults(results);
+    navigateToItem({
+      manifest: query.manifest,
+      canvas: query.canvas,
+      page: query.page,
     });
-    setSearchResults && setSearchResults(results);
-    router.replace(link.href);
 
     // Remove the attribute after navigation
     if (formRef.current) {
@@ -180,23 +203,29 @@ const IIIFSearchWithin: FunctionComponent = () => {
       const searchServiceId =
         '@id' in searchService ? searchService['@id'] : searchService.id;
       try {
-        const results = await (
+        const fetchedResults = await (
           await fetch(`${searchServiceId}?q=${query.query}`)
         ).json();
         setIsLoading(false);
-        setSearchResults && setSearchResults(results);
+        setSearchResults(fetchedResults);
       } catch {
         setIsLoading(false);
         setSearchError(true);
       }
     } else {
-      setSearchResults && setSearchResults(results);
+      setSearchResults(results);
     }
   }
 
   useEffect(() => {
     getSearchResults();
   }, [query.query, query.manifest]);
+
+  const shouldShowResultsCount =
+    !isLoading &&
+    searchResults &&
+    typeof searchResults?.within?.total === 'number' &&
+    query.query;
 
   return (
     <>
@@ -206,16 +235,12 @@ const IIIFSearchWithin: FunctionComponent = () => {
         action={router.asPath}
         onSubmit={event => {
           event.preventDefault();
-          const link = toWorksItemLink({
-            workId: work.id,
-            props: {
-              canvas: query.canvas,
-              manifest: query.manifest,
-              query: value,
-              page: query.page,
-            },
+          navigateToItem({
+            canvas: query.canvas,
+            manifest: query.manifest,
+            query: searchQuery,
+            page: query.page,
           });
-          router.replace(link.href);
         }}
       >
         <input type="hidden" name="canvas" value={query.canvas} />
@@ -227,12 +252,12 @@ const IIIFSearchWithin: FunctionComponent = () => {
             label={searchWithinLabel}
             type="search"
             name="query"
-            value={value}
-            setValue={setValue}
-            required={true}
+            value={searchQuery}
+            setValue={setSearchQuery}
             ref={inputRef}
-            hasClearButton
             clearHandler={handleClearResults}
+            hasClearButton
+            required
           />
         </SearchInputWrapper>
         <SearchButtonWrapper>
@@ -240,8 +265,8 @@ const IIIFSearchWithin: FunctionComponent = () => {
             variant="ButtonSolid"
             icon={search}
             text="search within"
-            isTextHidden={true}
             colors={theme.buttonColors.yellowYellowBlack}
+            isTextHidden
           />
         </SearchButtonWrapper>
       </SearchForm>
@@ -252,38 +277,18 @@ const IIIFSearchWithin: FunctionComponent = () => {
             There has been a problem conducting the search.
           </ErrorMessage>
         )}
-        {!isLoading &&
-          searchResults &&
-          typeof searchResults?.within?.total === 'number' &&
-          query.query && (
-            <ResultsHeader aria-live="assertive">
-              {pluralize(searchResults.within.total ?? 0, 'result')}
-            </ResultsHeader>
-          )}
+        {shouldShowResultsCount && (
+          <ResultsHeader aria-live="assertive">
+            {pluralize(searchResults?.within.total ?? 0, 'result')}
+          </ResultsHeader>
+        )}
         <ResultsList>
           {searchResults?.hits?.map((hit, i) => {
-            // We need the matching resource for each hit to get the canvas it appears on
-            const matchingResources = hit.annotations
-              .map(annotation => {
-                return searchResults?.resources?.find(
-                  resource => resource['@id'] === annotation
-                );
-              })
-              .filter(Boolean)
-              .filter(resource => resource?.resource?.chars);
-            // Get the index of the canvas the hits appear on
-            const index = canvases?.findIndex(canvas => {
-              const matchingPathname = matchingResources?.[0]?.on || '';
-              return (
-                new URL(matchingPathname).pathname ===
-                new URL(canvas.id).pathname
-              );
-            });
+            const index = findCanvasIndexForHit(hit, searchResults, canvases);
             const matchingCanvas = (index && canvases?.[index]) || undefined;
             return (
               <ListItem key={i}>
                 <NextLink
-                  replace={true}
                   {...toWorksItemLink({
                     workId: work.id,
                     props: {
@@ -296,6 +301,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
                     },
                   })}
                   onClick={() => setIsMobileSidebarActive(false)}
+                  replace
                 >
                   <Hit
                     hit={hit}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -70,10 +70,13 @@ const ZoomedImage = dynamic(() => import('./ZoomedImage'), {
   loading: LoadingComponent,
 });
 
-type GridProps = {
+type KioskDisplayProps = {
   $isFullSupportBrowser: boolean;
   $isTRKiosk?: boolean;
   $isNonTRKiosk?: boolean;
+};
+
+type GridProps = KioskDisplayProps & {
   $useFixedList?: boolean;
   $hasMultipleCanvases?: boolean;
 };
@@ -131,13 +134,12 @@ const Grid = styled.div<GridProps>`
     )}
 `;
 
-const Sidebar = styled.div<{
-  $isActiveMobile: boolean;
-  $isActiveDesktop: boolean;
-  $isFullSupportBrowser: boolean;
-  $isTRKiosk?: boolean;
-  $isNonTRKiosk?: boolean;
-}>`
+const Sidebar = styled.div<
+  KioskDisplayProps & {
+    $isActiveMobile: boolean;
+    $isActiveDesktop: boolean;
+  }
+>`
   display: ${props =>
     props.$isActiveMobile || !props.$isFullSupportBrowser ? 'inherit' : 'none'};
   align-content: start;
@@ -264,11 +266,15 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     shouldScrollToCanvas = true,
     query = '',
   } = useMemo(() => fromQuery(router.query), [router.query]);
-  const [gridVisible, setGridVisible] = useState(false);
+
   const { isFullSupportBrowser } = useAppContext();
   const { isKiosk, isTendernessAndRageKiosk } = useKiosk();
+  const isNonTRKiosk = isKiosk && !isTendernessAndRageKiosk;
+
   const viewerRef = useRef<HTMLDivElement>(null);
   const mainAreaRef = useRef<HTMLDivElement>(null);
+
+  const [gridVisible, setGridVisible] = useState(false);
   const [isDesktopSidebarActive, setIsDesktopSidebarActive] = useState(true);
   const [isMobileSidebarActive, setIsMobileSidebarActive] = useState(false);
   const [showZoomed, setShowZoomed] = useState(false);
@@ -282,23 +288,21 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const [tree, setTree] = useState<UiTree>(initialTree || []);
 
   const canvasIndexById = useMemo(() => getTreeCanvasIndexById(tree), [tree]);
+
   const currentCanvas =
     transformedManifest?.canvases[queryParamToArrayIndex(canvas)];
   const mainImageService: PartialImageService = {
     '@id': currentCanvas?.imageServiceId,
   };
   // We only want to use the IIIF image location if we don't have an image service on the current canvas
-  const shouldUseIifImageLocation = !currentCanvas?.imageServiceId;
+  const shouldUseIiifImageLocation = !currentCanvas?.imageServiceId;
   const urlTemplate =
     (iiifImageLocation && iiifImageTemplate(iiifImageLocation.url)) ||
     (mainImageService['@id'] && iiifImageTemplate(mainImageService['@id'])) ||
     undefined;
   const imageUrl = urlTemplate && urlTemplate({ size: '800,' });
   const hasIiifImage = imageUrl && iiifImageLocation;
-  const hasImageService = Boolean(mainImageService['@id'] && currentCanvas);
-  const [showControls, setShowControls] = useState(
-    Boolean(hasIiifImage && !hasImageService)
-  );
+  const hasIiifImageService = Boolean(mainImageService['@id'] && currentCanvas);
   // we only render certain parts of the UI when hasOnlyRenderableImages is true
   const hasOnlyRenderableImages = !hasNonImagesOrOriginals(
     transformedManifest?.canvases || []
@@ -306,6 +310,12 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   // useFixedSizeList is true when all items are images (using FixedSizeList for virtualization)
   const useFixedSizeList = hasOnlyRenderableImages;
   const hasMultipleCanvases = (transformedManifest?.canvases?.length || 0) > 1;
+
+  // showControls' initial value depends on the derived values above, so it's
+  // declared here rather than grouped with the other state
+  const [showControls, setShowControls] = useState(
+    Boolean(hasIiifImage && !hasIiifImageService)
+  );
 
   // We need to reset the MainAreaWidth and MainAreaHeight
   // when the available space changes.
@@ -412,7 +422,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         ref={viewerRef}
         $isFullSupportBrowser={isFullSupportBrowser}
         $isTRKiosk={isTendernessAndRageKiosk}
-        $isNonTRKiosk={isKiosk && !isTendernessAndRageKiosk}
+        $isNonTRKiosk={isNonTRKiosk}
         $useFixedList={useFixedSizeList}
         $hasMultipleCanvases={hasMultipleCanvases}
       >
@@ -421,7 +431,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
           $isActiveDesktop={isDesktopSidebarActive}
           $isFullSupportBrowser={isFullSupportBrowser}
           $isTRKiosk={isTendernessAndRageKiosk}
-          $isNonTRKiosk={isKiosk && !isTendernessAndRageKiosk}
+          $isNonTRKiosk={isNonTRKiosk}
         >
           <DelayVisibility>
             <ViewerSidebar
@@ -430,15 +440,17 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             />
           </DelayVisibility>
         </Sidebar>
+
         <Topbar>
           <DelayVisibility>
             <ViewerTopBar
               iiifImageLocation={
-                shouldUseIifImageLocation ? iiifImageLocation : undefined
+                shouldUseIiifImageLocation ? iiifImageLocation : undefined
               }
             />
           </DelayVisibility>
         </Topbar>
+
         <Main
           ref={mainAreaRef}
           $isDesktopSidebarActive={isDesktopSidebarActive}
@@ -449,7 +461,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
           <DelayVisibility>
             {!showZoomed && hasOnlyRenderableImages && <ImageViewerControls />}
             {hasIiifImage &&
-              !hasImageService &&
+              !hasIiifImageService &&
               (isFullSupportBrowser || !hasOnlyRenderableImages) && (
                 <ImageViewer
                   infoUrl={iiifImageLocation.url}
@@ -464,21 +476,24 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
             {imageUrl && !isFullSupportBrowser && hasOnlyRenderableImages && (
               <NoScriptImage urlTemplate={urlTemplate} canvasOcr={canvasOcr} />
             )}
+
             {/* If we hide the MainViewer when resizing the browser, it will then rerender with the correct canvas displayed */}
-            {(hasImageService || !!currentCanvas) && !isResizing && (
+            {(hasIiifImageService || !!currentCanvas) && !isResizing && (
               <MainViewer />
             )}
           </DelayVisibility>
         </Main>
+
         {showZoomed && isFullSupportBrowser && (
           <Zoom>
             <ZoomedImage
               iiifImageLocation={
-                shouldUseIifImageLocation ? iiifImageLocation : undefined
+                shouldUseIiifImageLocation ? iiifImageLocation : undefined
               }
             />
           </Zoom>
         )}
+
         {isFullSupportBrowser && (
           <>
             {!isMobileSidebarActive && (
@@ -486,6 +501,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
                 <ViewerBottomBar />
               </BottomBar>
             )}
+
             {hasOnlyRenderableImages && (
               <ThumbnailsWrapper
                 $isActive={gridVisible}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
@@ -23,9 +23,9 @@ async function getImageMax(url: string): Promise<number> {
   }
 }
 
-const Image = styled.img<{ $highlightImage?: boolean; $zoomOnClick?: boolean }>`
+const Image = styled.img<{ $isHighlighted?: boolean; $zoomOnClick?: boolean }>`
   ${props =>
-    props.$highlightImage
+    props.$isHighlighted
       ? `filter: grayscale(100%) brightness(70%) sepia(40%) hue-rotate(-120deg) saturate(400%) contrast(1);`
       : ''}; /* the filter is used for highlighting thumbnails that contain search terms */
   cursor: ${props => (props.$zoomOnClick ? 'zoom-in' : undefined)};
@@ -45,7 +45,7 @@ type Props = {
   loadHandler?: () => void | Promise<void>;
   errorHandler?: () => void | Promise<void>;
   tabIndex?: number;
-  highlightImage?: boolean;
+  isHighlighted?: boolean;
   zoomOnClick?: boolean;
 };
 
@@ -64,7 +64,7 @@ const IIIFViewerImage = (
     loadHandler,
     errorHandler,
     tabIndex,
-    highlightImage,
+    isHighlighted,
     zoomOnClick,
   }: Props,
   ref: ForwardedRef<HTMLImageElement>
@@ -82,7 +82,7 @@ const IIIFViewerImage = (
 
   return (
     <>
-      {!hasLoaded && isFullSupportBrowser && <LL $lighten={true} />}
+      {!hasLoaded && isFullSupportBrowser && <LL $lighten />}
       <Image
         data-testid={index !== undefined ? `image-${index}` : null}
         ref={ref}
@@ -93,7 +93,7 @@ const IIIFViewerImage = (
         height={height}
         className="image"
         $zoomOnClick={zoomOnClick}
-        $highlightImage={highlightImage}
+        $isHighlighted={isHighlighted}
         onLoad={() => {
           loadHandler && loadHandler();
           setHasLoaded(true);

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewer.tsx
@@ -66,8 +66,10 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   const { isFullSupportBrowser } = useAppContext();
   const { work, errorHandler, setShowZoomed, rotatedImages } =
     useItemViewerContext();
+
   const imageWrapperRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
+
   const [imageSrc, setImageSrc] = useState(urlTemplate({ size: '640,' }));
   const [imageSrcSet, setImageSrcSet] = useState(
     imageSizes(2048)
@@ -80,11 +82,11 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
       })
       .join(',')
   );
-  const matching = rotatedImages.find(
-    canvas => queryParamToArrayIndex(canvas.canvas) === index
-  );
 
-  const rotation = matching ? matching.rotation : 0;
+  const matchingRotatedImage = rotatedImages.find(
+    image => queryParamToArrayIndex(image.canvas) === index
+  );
+  const rotation = matchingRotatedImage?.rotation || 0;
 
   function updateImagePosition() {
     const imageRect = imageRef?.current?.getBoundingClientRect();
@@ -158,7 +160,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
           updateImagePosition();
         }}
         errorHandler={errorHandler}
-        zoomOnClick={true}
+        zoomOnClick
       />
       {alt ? (
         <span className="visually-hidden" id={`image-${index + 1}`}>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewerControls.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewerControls.tsx
@@ -7,7 +7,7 @@ import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
 import { CanvasRotatedImage } from '@weco/content/types/item-viewer';
 
-const ImageViewerControlsEl = styled.div<{ $showControls?: boolean }>`
+const ImageViewerControlsWrapper = styled.div<{ $showControls?: boolean }>`
   position: absolute;
   bottom: 5%;
   right: 10%;
@@ -41,7 +41,7 @@ function updateRotatedImages({
   canvasParam: number;
 }): CanvasRotatedImage[] {
   const matchingIndex = rotatedImages.findIndex(
-    rotation => rotation.canvas === canvasParam
+    rotatedImage => rotatedImage.canvas === canvasParam
   );
   if (matchingIndex >= 0) {
     return rotatedImages.map((rotatedImage, i) => {
@@ -76,10 +76,9 @@ const ImageViewerControls: FunctionComponent = () => {
     setRotatedImages,
     setShowZoomed,
   } = useItemViewerContext();
-  const { canvas } = query;
 
   return (
-    <ImageViewerControlsEl $showControls={showControls}>
+    <ImageViewerControlsWrapper $showControls={showControls}>
       <Space
         $h={{ size: 'xs', properties: ['margin-left'] }}
         $v={{ size: 'md', properties: ['margin-bottom'] }}
@@ -105,13 +104,13 @@ const ImageViewerControls: FunctionComponent = () => {
             setRotatedImages(
               updateRotatedImages({
                 rotatedImages,
-                canvasParam: canvas,
+                canvasParam: query.canvas,
               })
             );
           }}
         />
       </Space>
-    </ImageViewerControlsEl>
+    </ImageViewerControlsWrapper>
   );
 };
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/MultipleManifestList.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/MultipleManifestList.tsx
@@ -17,37 +17,33 @@ const MultipleManifestList: FunctionComponent = () => {
   return (
     <nav>
       <List aria-label={volumesNavigationLabel}>
-        {manifests.map((manifest, i) => (
-          <Item
-            key={manifest.id}
-            $isActive={i === queryParamToArrayIndex(query.manifest)}
-          >
-            <NextLink
-              data-gtm-trigger="volumes_nav_link"
-              replace={true}
-              {...toWorksItemLink({
-                workId: work.id,
-                props: {
-                  canvas: 1,
-                  query: query.query,
-                  manifest: i + 1,
-                },
-              })}
-              aria-current={
-                i === queryParamToArrayIndex(query.manifest)
-                  ? 'page'
-                  : undefined
-              }
-              onClick={() => {
-                setIsMobileSidebarActive(false);
-              }}
-            >
-              {(manifest.label &&
-                getMultiVolumeLabel(manifest.label, work?.title || '')) ||
-                'Unknown'}
-            </NextLink>
-          </Item>
-        ))}
+        {manifests.map((manifest, i) => {
+          const isActiveManifest = i === queryParamToArrayIndex(query.manifest);
+          return (
+            <Item key={manifest.id} $isActive={isActiveManifest}>
+              <NextLink
+                data-gtm-trigger="volumes_nav_link"
+                {...toWorksItemLink({
+                  workId: work.id,
+                  props: {
+                    canvas: 1,
+                    query: query.query,
+                    manifest: i + 1,
+                  },
+                })}
+                aria-current={isActiveManifest ? 'page' : undefined}
+                onClick={() => {
+                  setIsMobileSidebarActive(false);
+                }}
+                replace
+              >
+                {(manifest.label &&
+                  getMultiVolumeLabel(manifest.label, work?.title || '')) ||
+                  'Unknown'}
+              </NextLink>
+            </Item>
+          );
+        })}
       </List>
     </nav>
   );

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
@@ -34,6 +34,7 @@ type Props = {
 export const NoScriptImage = ({ urlTemplate, canvasOcr }: Props) => {
   const { work, query, transformedManifest } = useItemViewerContext();
   const { canvases } = { ...transformedManifest };
+
   const pageSize = 4;
   const srcSet =
     urlTemplate &&
@@ -47,12 +48,12 @@ export const NoScriptImage = ({ urlTemplate, canvasOcr }: Props) => {
         .map(i => canvases?.[i])
         .filter(Boolean)
     : [];
-  const thumbnailsRequired = Boolean(navigationCanvases?.length);
+  const thumbnailsRequired = Boolean(navigationCanvases.length);
 
   return (
     <>
       <NoScriptLoadingWrapper>
-        <LL $lighten={true} />
+        <LL $lighten />
       </NoScriptLoadingWrapper>
       <DelayVisibility>
         <CanvasPaginator />

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
@@ -52,7 +52,6 @@ const PaginatedItemViewer: FunctionComponent = () => {
         titleOverride={`${query.canvas}/${canvases?.length}`}
         exclude={[]}
         externalAccessService={externalAccessService}
-        isDark
         showVideoTranscript={false}
         isDark
       />

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
@@ -28,7 +28,6 @@ const ItemWrapper = styled.div`
 const PaginatedItemViewer: FunctionComponent = () => {
   const { transformedManifest, query, setShowFullscreenControl } =
     useItemViewerContext();
-  const { canvas } = query;
   const { canvases, auth, placeholderId } = {
     ...transformedManifest,
   };
@@ -50,10 +49,10 @@ const PaginatedItemViewer: FunctionComponent = () => {
         item={item}
         i={i}
         canvas={currentCanvas}
-        titleOverride={`${canvas}/${canvases?.length}`}
+        titleOverride={`${query.canvas}/${canvases?.length}`}
         exclude={[]}
-        isDark={true}
         externalAccessService={externalAccessService}
+        isDark
         showVideoTranscript={false}
       />
     </ItemWrapper>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
@@ -6,6 +6,7 @@ import Control from '@weco/common/views/components/Control';
 import Rotator from '@weco/common/views/components/styled/Rotator';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+import { ItemViewerQuery } from '@weco/content/types/item-viewer';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 
 const PaginatorWrapper = styled.div`
@@ -90,7 +91,18 @@ const getLink = ({
     : undefined;
 };
 
-export const CanvasPaginator = () => {
+// Shared by CanvasPaginator and ThumbnailsPaginator, which only differ in
+// which query field is the current page, the page size, and whether the
+// canvas number needs translating into its containing thumbnails page.
+function usePaginatorLinks({
+  getCurrentPage,
+  pageSize,
+  getMatchingPage,
+}: {
+  getCurrentPage: (query: ItemViewerQuery) => number;
+  pageSize: number;
+  getMatchingPage?: (pageNumber: number) => number;
+}): { prevLink?: LinkProps; nextLink?: LinkProps } {
   const { work, query, transformedManifest } = useItemViewerContext();
   const { canvases } = { ...transformedManifest };
 
@@ -105,23 +117,30 @@ export const CanvasPaginator = () => {
     },
   });
 
-  const currentPage = query.canvas;
-  const pageSize = 1;
+  const currentPage = getCurrentPage(query);
   const totalPages = Math.ceil(totalResults / pageSize);
   const next = currentPage < totalPages ? currentPage + 1 : 0;
   const prev = currentPage > 1 ? currentPage - 1 : 0;
-  const matchingNextPage = Math.ceil(next / thumbnailsPageSize);
-  const matchingPreviousPage = Math.ceil(prev / thumbnailsPageSize);
 
   const prevLink = getLink({
     pageNumber: prev,
-    matchingPage: matchingPreviousPage,
+    matchingPage: getMatchingPage?.(prev),
     link,
   });
   const nextLink = getLink({
     pageNumber: next,
-    matchingPage: matchingNextPage,
+    matchingPage: getMatchingPage?.(next),
     link,
+  });
+
+  return { prevLink, nextLink };
+}
+
+export const CanvasPaginator = () => {
+  const { prevLink, nextLink } = usePaginatorLinks({
+    getCurrentPage: query => query.canvas,
+    pageSize: 1,
+    getMatchingPage: pageNumber => Math.ceil(pageNumber / thumbnailsPageSize),
   });
 
   return (
@@ -132,27 +151,10 @@ export const CanvasPaginator = () => {
 };
 
 export const ThumbnailsPaginator = () => {
-  const { work, query, transformedManifest } = useItemViewerContext();
-  const { canvases } = { ...transformedManifest };
-
-  const totalResults = canvases?.length || 1;
-  const link = toWorksItemLink({
-    workId: work.id,
-    props: {
-      canvas: query.canvas,
-      page: query.page,
-      manifest: query.manifest,
-      query: query.query,
-    },
+  const { prevLink, nextLink } = usePaginatorLinks({
+    getCurrentPage: query => query.page,
+    pageSize: thumbnailsPageSize,
   });
-
-  const currentPage = query.page;
-  const totalPages = Math.ceil(totalResults / thumbnailsPageSize);
-  const next = currentPage < totalPages ? currentPage + 1 : 0;
-  const prev = currentPage > 1 ? currentPage - 1 : 0;
-
-  const prevLink = getLink({ pageNumber: prev, link });
-  const nextLink = getLink({ pageNumber: next, link });
 
   return (
     <StyledPaginatorButtons>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
@@ -34,12 +34,12 @@ const PaginatorButtons = ({
         <Space $v={{ size: 'xs', properties: ['margin-bottom'] }}>
           <Rotator $rotate={270}>
             <Control
-              scroll={false}
-              replace={true}
               link={prevLink}
               colorScheme="light"
               icon={arrow}
               text="Previous page"
+              scroll={false}
+              replace
             />
           </Rotator>
         </Space>
@@ -48,12 +48,12 @@ const PaginatorButtons = ({
         <Space $v={{ size: 'xs', properties: ['margin-bottom'] }}>
           <Rotator $rotate={90}>
             <Control
-              scroll={false}
-              replace={true}
               link={nextLink}
               colorScheme="light"
               icon={arrow}
               text="Next page"
+              scroll={false}
+              replace
             />
           </Rotator>
         </Space>
@@ -93,6 +93,7 @@ const getLink = ({
 export const CanvasPaginator = () => {
   const { work, query, transformedManifest } = useItemViewerContext();
   const { canvases } = { ...transformedManifest };
+
   const totalResults = canvases?.length || 1;
   const link = toWorksItemLink({
     workId: work.id,
@@ -103,6 +104,7 @@ export const CanvasPaginator = () => {
       query: query.query,
     },
   });
+
   const currentPage = query.canvas;
   const pageSize = 1;
   const totalPages = Math.ceil(totalResults / pageSize);
@@ -132,6 +134,7 @@ export const CanvasPaginator = () => {
 export const ThumbnailsPaginator = () => {
   const { work, query, transformedManifest } = useItemViewerContext();
   const { canvases } = { ...transformedManifest };
+
   const totalResults = canvases?.length || 1;
   const link = toWorksItemLink({
     workId: work.id,
@@ -142,6 +145,7 @@ export const ThumbnailsPaginator = () => {
       query: query.query,
     },
   });
+
   const currentPage = query.page;
   const totalPages = Math.ceil(totalResults / thumbnailsPageSize);
   const next = currentPage < totalPages ? currentPage + 1 : 0;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
@@ -50,7 +50,6 @@ export const Thumbnails = () => {
 
   return (
     <ThumbnailsContainer
-      id="xyz"
       $isTRKiosk={isTendernessAndRageKiosk}
       $isNonTRKiosk={isKiosk && !isTendernessAndRageKiosk}
     >

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ToolbarSegmentedControl.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ToolbarSegmentedControl.tsx
@@ -61,34 +61,37 @@ const ToolbarSegmentedControl: FunctionComponent<Props> = ({
 }: Props) => {
   return (
     <List>
-      {items.map(item => (
-        <Item $isActive={activeId === item.id} key={item.id}>
-          <Button
-            onClick={item.clickHandler}
-            data-gtm-trigger={item.dataGtmTrigger}
-          >
-            <ButtonInner>
-              <Icon
-                icon={item.icon}
-                iconColor={activeId === item.id ? 'yellow' : 'neutral.600'}
-              />
-              <Space
-                $h={
-                  hideLabels
-                    ? undefined
-                    : {
-                        size: '2xs',
-                        properties: ['padding-left', 'padding-right'],
-                      }
-                }
-                className={hideLabels ? 'visually-hidden' : undefined}
-              >
-                {item.label}
-              </Space>
-            </ButtonInner>
-          </Button>
-        </Item>
-      ))}
+      {items.map(item => {
+        const isActive = activeId === item.id;
+        return (
+          <Item $isActive={isActive} key={item.id}>
+            <Button
+              onClick={item.clickHandler}
+              data-gtm-trigger={item.dataGtmTrigger}
+            >
+              <ButtonInner>
+                <Icon
+                  icon={item.icon}
+                  iconColor={isActive ? 'yellow' : 'neutral.600'}
+                />
+                <Space
+                  $h={
+                    hideLabels
+                      ? undefined
+                      : {
+                          size: '2xs',
+                          properties: ['padding-left', 'padding-right'],
+                        }
+                  }
+                  className={hideLabels ? 'visually-hidden' : undefined}
+                >
+                  {item.label}
+                </Space>
+              </ButtonInner>
+            </Button>
+          </Item>
+        );
+      })}
     </List>
   );
 };

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -1,9 +1,10 @@
 import NextLink from 'next/link';
 import { FunctionComponent } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { chevron, gridView, maximise, singlePage } from '@weco/common/icons';
+import { LinkProps } from '@weco/common/model/link-props';
 import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
@@ -23,6 +24,54 @@ const BottomBar = styled.div`
   justify-content: space-between;
 `;
 
+const NavigationBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: ${props => props.theme.spacingUnit * 2}px;
+`;
+
+const navButtonBaseStyles = css`
+  display: flex;
+  align-items: center;
+  gap: ${props => props.theme.spacingUnit}px;
+  padding: ${props => props.theme.spacingUnit}px
+    ${props => props.theme.spacingUnit * 2}px;
+  color: ${props => props.theme.color('white')};
+  background: ${props => props.theme.color('neutral.600')};
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  text-decoration: none;
+  transition: background ${props => props.theme.transitionProperties};
+`;
+
+// used for the disabled state, which isn't a real navigable link
+const NavButton = styled.a<{ $disabled?: boolean }>`
+  ${navButtonBaseStyles}
+
+  ${props =>
+    props.$disabled
+      ? `
+    opacity: 0.5;
+    cursor: not-allowed;
+  `
+      : `
+    &:hover {
+      background: ${props.theme.color('neutral.500')};
+    }
+  `}
+`;
+
+// used for the enabled state; Link renders its own single <a>, so this must
+// not be nested inside another Link-rendered anchor
+const NavLinkButton = styled(NextLink)`
+  ${navButtonBaseStyles}
+
+  &:hover {
+    background: ${props => props.theme.color('neutral.500')};
+  }
+`;
+
 const LeftZone = styled(Space).attrs({
   $v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'sm', properties: ['padding-left'] },
@@ -40,38 +89,38 @@ const RightZone = styled(Space).attrs({
   align-items: center;
 `;
 
-const NavigationBar = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  padding: ${props => props.theme.spacingUnit * 2}px;
-`;
+type CanvasNavButtonProps = {
+  link: LinkProps | null;
+  direction: 'previous' | 'next';
+};
 
-const NavButton = styled.a<{ $disabled?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: ${props => props.theme.spacingUnit}px;
-  padding: ${props => props.theme.spacingUnit}px
-    ${props => props.theme.spacingUnit * 2}px;
-  color: ${props => props.theme.color('white')};
-  background: ${props => props.theme.color('neutral.600')};
-  border-radius: ${props => props.theme.borderRadiusUnit}px;
-  text-decoration: none;
-  transition: background ${props => props.theme.transitionProperties};
+const CanvasNavButton: FunctionComponent<CanvasNavButtonProps> = ({
+  link,
+  direction,
+}) => {
+  const rotate = direction === 'previous' ? 90 : 270;
+  const content = (
+    <>
+      {direction === 'next' && <>Next</>}
+      <Icon icon={chevron} rotate={rotate} />
+      {direction === 'previous' && <>Previous</>}
+    </>
+  );
 
-  ${props =>
-    props.$disabled
-      ? `
-    opacity: 0.5;
-    cursor: not-allowed;
-  `
-      : `
-    &:hover {
-      background: ${props.theme.color('neutral.500')};
-    }
-  `}
-`;
+  if (!link) {
+    return (
+      <NavButton className={typography('body', 'md', 'regular')} $disabled>
+        {content}
+      </NavButton>
+    );
+  }
+
+  return (
+    <NavLinkButton {...link} className={typography('body', 'md', 'regular')}>
+      {content}
+    </NavLinkButton>
+  );
+};
 
 const ViewerBottomBar: FunctionComponent = () => {
   const { isEnhanced } = useAppContext();
@@ -93,105 +142,81 @@ const ViewerBottomBar: FunctionComponent = () => {
   const { canvases } = { ...transformedManifest };
   const { canvas } = query;
 
-  // Navigation logic for previous/next canvas
   const hasCompleteStructure =
     Object.keys(canvasIndexById).length === canvases?.length;
   const totalCanvases = hasCompleteStructure
     ? Object.keys(canvasIndexById).length
     : canvases?.length || 0;
+
   const hasPreviousCanvas = canvas > 1;
   const hasNextCanvas = canvas < totalCanvases;
+
   const previousCanvasLink = hasPreviousCanvas
     ? toWorksItemLink({ workId: work.id, props: { canvas: canvas - 1 } })
     : null;
   const nextCanvasLink = hasNextCanvas
     ? toWorksItemLink({ workId: work.id, props: { canvas: canvas + 1 } })
     : null;
+
   const hasMultipleCanvases = (canvases?.length || 0) > 1;
+  const shouldShowCanvasNavigation =
+    !hasOnlyRenderableImages && hasMultipleCanvases;
+  const shouldShowViewToggle =
+    !showZoomed && hasMultipleCanvases && !isMobileSidebarActive;
+  const shouldShowFullscreenButton =
+    isEnhanced && isFullscreenEnabled && showFullscreenControl;
 
   return (
     <BottomBar data-testid="bottombar">
-      {!hasOnlyRenderableImages && hasMultipleCanvases ? (
+      {shouldShowCanvasNavigation ? (
         <NavigationBar>
-          {previousCanvasLink ? (
-            <NextLink {...previousCanvasLink} passHref legacyBehavior>
-              <NavButton className={typography('body', 'md', 'regular')}>
-                <Icon icon={chevron} rotate={90} />
-                Previous
-              </NavButton>
-            </NextLink>
-          ) : (
-            <NavButton
-              $disabled
-              className={typography('body', 'md', 'regular')}
-            >
-              <Icon icon={chevron} rotate={90} />
-              Previous
-            </NavButton>
-          )}
+          <CanvasNavButton link={previousCanvasLink} direction="previous" />
+
           <span
             className={typography('body', 'md', 'regular')}
             style={{ color: 'white' }}
           >
             {canvas}/{totalCanvases}
           </span>
-          {nextCanvasLink ? (
-            <NextLink {...nextCanvasLink} passHref legacyBehavior>
-              <NavButton className={typography('body', 'md', 'regular')}>
-                Next
-                <Icon icon={chevron} rotate={270} />
-              </NavButton>
-            </NextLink>
-          ) : (
-            <NavButton
-              $disabled
-              className={typography('body', 'md', 'regular')}
-            >
-              Next
-              <Icon icon={chevron} rotate={270} />
-            </NavButton>
-          )}
+
+          <CanvasNavButton link={nextCanvasLink} direction="next" />
         </NavigationBar>
       ) : (
         <>
           <LeftZone>
-            {!showZoomed &&
-              canvases &&
-              canvases.length > 1 &&
-              !isMobileSidebarActive && (
-                <ToolbarSegmentedControl
-                  hideLabels={true}
-                  items={[
-                    {
-                      id: 'pageView',
-                      label: 'Page',
-                      icon: singlePage,
-                      dataGtmTrigger: 'item_view_page_button',
-                      clickHandler() {
-                        setGridVisible(false);
-                      },
+            {shouldShowViewToggle && (
+              <ToolbarSegmentedControl
+                items={[
+                  {
+                    id: 'pageView',
+                    label: 'Page',
+                    icon: singlePage,
+                    dataGtmTrigger: 'item_view_page_button',
+                    clickHandler() {
+                      setGridVisible(false);
                     },
-                    {
-                      id: 'gridView',
-                      label: 'Grid',
-                      icon: gridView,
-                      dataGtmTrigger: 'item_view_grid_button',
-                      clickHandler() {
-                        setGridVisible(true);
-                      },
+                  },
+                  {
+                    id: 'gridView',
+                    label: 'Grid',
+                    icon: gridView,
+                    dataGtmTrigger: 'item_view_grid_button',
+                    clickHandler() {
+                      setGridVisible(true);
                     },
-                  ]}
-                  activeId={gridVisible ? 'gridView' : 'pageView'}
-                />
-              )}
+                  },
+                ]}
+                activeId={gridVisible ? 'gridView' : 'pageView'}
+                hideLabels
+              />
+            )}
           </LeftZone>
 
-          {isEnhanced && isFullscreenEnabled && showFullscreenControl && (
+          {shouldShowFullscreenButton && (
             <RightZone>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Space $h={{ size: 'sm', properties: ['margin-right'] }}>
                   <ViewerButton
-                    $isDark
                     onClick={() => {
                       if (viewerRef?.current) {
                         if (
@@ -214,6 +239,7 @@ const ViewerBottomBar: FunctionComponent = () => {
                         }
                       }
                     }}
+                    $isDark
                   >
                     <Icon icon={maximise} />
                     <span style={{ marginLeft: '7px' }}>Full screen</span>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerSidebar.tsx
@@ -175,23 +175,20 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     setTree,
     canvasIndexById,
   } = useItemViewerContext();
-  const { canvas } = query || {};
   const { userIsStaffWithRestricted } = useUserContext();
 
   const [tabbableId, setTabbableId] = useState<string>();
-  const matchingManifest =
-    parentManifest &&
-    parentManifest.canvases.find(canvas => {
-      return !transformedManifest
-        ? false
-        : canvas.id === transformedManifest.id;
-    });
+
+  const matchingCanvas = parentManifest?.canvases.find(
+    parentCanvas => parentCanvas.id === transformedManifest?.id
+  );
 
   const manifestLabel =
-    matchingManifest?.label &&
-    getMultiVolumeLabel(matchingManifest.label, work?.title || '');
+    matchingCanvas?.label &&
+    getMultiVolumeLabel(matchingCanvas.label, work?.title || '');
 
   const { structures, searchService } = { ...transformedManifest };
+  const hasStructures = Boolean(structures && structures.length > 0);
 
   const digitalLocation: DigitalLocation | undefined =
     iiifPresentationLocation || iiifImageLocation;
@@ -210,6 +207,13 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
   const isWorkVisibleWithPermission =
     digitalLocationInfo?.accessCondition === 'restricted' &&
     userIsStaffWithRestricted;
+  // this check for `behavior === 'multi-part'` is repeated in items.tsx to
+  // avoid sending unnecessary data about parent manifests that we're not
+  // going to render. If you change the display condition here, you'll
+  // likely want to update it there also.
+  const isMultiPartWork = Boolean(
+    parentManifest && parentManifest.behavior?.[0] === 'multi-part'
+  );
 
   useEffect(() => {
     const elementToFocus = tabbableId && document.getElementById(tabbableId);
@@ -222,15 +226,17 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     <>
       {isWorkVisibleWithPermission && (
         <RestrictedMessage>
-          <RestrictedItemMessage plural={true} />
+          <RestrictedItemMessage plural />
         </RestrictedMessage>
       )}
+
       <Inner className={typography('body', 'md', 'strong')}>
         {manifestLabel && (
           <span className={typography('body', 'md', 'regular')}>
             {manifestLabel}
           </span>
         )}
+
         <h1>
           <WorkTitle title={work.title} />
         </h1>
@@ -266,7 +272,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
               $h={{ size: 'xs', properties: ['margin-left'] }}
               style={{ display: 'flex', alignItems: 'center' }}
             >
-              <Icon icon={arrow} matchText={true} iconColor="white" />
+              <Icon icon={arrow} iconColor="white" matchText />
             </Space>
           </WorkLink>
         </Space>
@@ -310,10 +316,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
             defaultOpen
           >
             <div style={{ overflow: 'auto' }}>
-              <WorksTree
-                isDarkMode={true}
-                hasStructures={Boolean(structures && structures.length > 0)}
-              >
+              <WorksTree hasStructures={hasStructures} isDarkMode>
                 <NestedList
                   currentWorkId={work.id}
                   tree={tree}
@@ -322,45 +325,36 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
                   level={1}
                   tabbableId={tabbableId}
                   setTabbableId={setTabbableId}
-                  firstItemTabbable={true}
-                  showFirstLevelGuideline={true}
-                  shouldFetchChildren={false}
-                  isDarkMode={true}
                   ItemRenderer={DownloadItemRenderer}
                   itemRendererProps={{
                     linkToCanvas: true,
                     workId: work.id,
                     canvasIndexById,
-                    currentCanvasIndex: canvas,
+                    currentCanvasIndex: query.canvas,
                     itemOnClick: () => setIsMobileSidebarActive(false),
                     canvases: transformedManifest?.canvases,
                   }}
+                  firstItemTabbable
+                  showFirstLevelGuideline
+                  shouldFetchChildren={false}
+                  isDarkMode
                 />
               </WorksTree>
             </div>
           </AccordionItem>
         )}
 
-        {Boolean(structures && structures.length > 0) &&
-          hasOnlyRenderableImages && (
-            <AccordionItem title="Contents" gtmData={{ trigger: 'contents' }}>
-              <ViewerStructures />
-            </AccordionItem>
-          )}
+        {hasStructures && hasOnlyRenderableImages && (
+          <AccordionItem title="Contents" gtmData={{ trigger: 'contents' }}>
+            <ViewerStructures />
+          </AccordionItem>
+        )}
 
-        {/*
-          Note: this check for `behavior === 'multi-part'` is repeated in items.tsx to
-          avoid sending unnecessary data about parent manifests that we're not going
-          to render.  If you change the display condition here, you'll likely want to
-          update it there also.
-        */}
-        {parentManifest &&
-          parentManifest.behavior?.[0] === 'multi-part' &&
-          parentManifest.canvases && (
-            <AccordionItem title="Volumes" gtmData={{ trigger: 'volumes' }}>
-              <MultipleManifestList />
-            </AccordionItem>
-          )}
+        {isMultiPartWork && (
+          <AccordionItem title="Volumes" gtmData={{ trigger: 'volumes' }}>
+            <MultipleManifestList />
+          </AccordionItem>
+        )}
       </Inner>
 
       {searchService && (

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerStructures.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerStructures.tsx
@@ -83,19 +83,17 @@ const Structures: FunctionComponent<Props> = ({
         const canvasIndex =
           canvases?.findIndex(canvas => canvas.id === firstCanvasInRangeId) ||
           0;
+
         const nestedRanges = range?.items?.filter(isRange) || [];
+        const isActiveRange =
+          currentCanvasIndex === arrayIndexToQueryParam(canvasIndex);
+
         return (
-          <Item
-            key={i}
-            $isActive={
-              currentCanvasIndex === arrayIndexToQueryParam(canvasIndex)
-            }
-          >
+          <Item key={i} $isActive={isActiveRange}>
             <ConditionalWrapper
-              condition={Boolean(nestedRanges.length === 0)}
+              condition={nestedRanges.length === 0}
               wrapper={children => (
                 <NextLink
-                  replace={true}
                   {...toWorksItemLink({
                     workId: work.id,
                     props: {
@@ -108,14 +106,11 @@ const Structures: FunctionComponent<Props> = ({
                     },
                   })}
                   data-gtm-trigger="contents_nav"
-                  aria-current={
-                    currentCanvasIndex === arrayIndexToQueryParam(canvasIndex)
-                      ? 'page'
-                      : undefined
-                  }
+                  aria-current={isActiveRange ? 'page' : undefined}
                   onClick={() => {
                     setIsMobileSidebarActive(false);
                   }}
+                  replace
                 >
                   {children}
                 </NextLink>
@@ -123,11 +118,11 @@ const Structures: FunctionComponent<Props> = ({
             >
               {getDisplayLabel(range.label)}
             </ConditionalWrapper>
-            {nestedRanges.map((range, i) => {
+            {nestedRanges.map((nestedRange, nestedIndex) => {
               return (
                 <Structures
-                  key={i}
-                  ranges={[range]}
+                  key={nestedIndex}
+                  ranges={[nestedRange]}
                   canvases={canvases}
                   currentCanvasIndex={currentCanvasIndex}
                   setIsMobileSidebarActive={setIsMobileSidebarActive}
@@ -147,14 +142,13 @@ const Structures: FunctionComponent<Props> = ({
 const ViewerStructures: FunctionComponent = () => {
   const { transformedManifest, setIsMobileSidebarActive, query, work } =
     useItemViewerContext();
-  const { canvas } = query;
   const { structures: ranges, canvases } = { ...transformedManifest };
 
   return (
     <Structures
       ranges={ranges || []}
       canvases={canvases || []}
-      currentCanvasIndex={canvas}
+      currentCanvasIndex={query.canvas}
       setIsMobileSidebarActive={setIsMobileSidebarActive}
       work={work}
       query={query}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -138,7 +138,7 @@ const TopBar = styled.div<{
   `}
 `;
 
-const Sidebar = styled(Space).attrs({
+const TopBarSidebarZone = styled(Space).attrs({
   $v: { size: 'xs', properties: ['padding-top', 'padding-bottom'] },
   $h: { size: 'xs', properties: ['padding-left', 'padding-right'] },
 })<{ $isZooming: boolean }>`
@@ -219,11 +219,11 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     showFullscreenControl,
     hasOnlyRenderableImages,
   } = useItemViewerContext();
-  const { canvas } = query;
-  const { canvases, rendering } = { ...transformedManifest };
-  const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const { userIsStaffWithRestricted } = useUserContext();
+
+  const { canvases, rendering } = { ...transformedManifest };
+  const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
   const imageServices = (currentCanvas?.painting
     .map(p => {
       if (isChoiceBody(p)) {
@@ -237,6 +237,13 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     .flat()
     .filter(Boolean) || []) as ImageService[];
   const isRestricted = currentCanvas && hasRestrictedItem(currentCanvas);
+  const currentPageLabel = currentCanvas?.label?.trim();
+
+  const hasMultipleCanvases = Boolean(canvases && canvases.length > 1);
+  const shouldShowViewToggle =
+    !showZoomed && hasMultipleCanvases && isFullSupportBrowser;
+  const shouldShowPageIndicator =
+    hasMultipleCanvases && !showZoomed && !isResizing;
 
   // Works can have a DigitalLocation of type iiif-presentation and/or iiif-image.
   // For a iiif-presentation DigitalLocation we get the download options from the manifest to which it points.
@@ -298,9 +305,9 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
       $isZooming={showZoomed}
       $isDesktopSidebarActive={isDesktopSidebarActive}
       $useFixedList={hasOnlyRenderableImages}
-      $hasMultipleCanvases={!!(canvases && canvases.length > 1)}
+      $hasMultipleCanvases={hasMultipleCanvases}
     >
-      <Sidebar $isZooming={showZoomed}>
+      <TopBarSidebarZone $isZooming={showZoomed}>
         {isEnhanced && !showZoomed && (
           <>
             <ViewerButton
@@ -332,53 +339,48 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
             </ViewerButton>
           </>
         )}
-      </Sidebar>
+      </TopBarSidebarZone>
+
       <Main>
         {hasOnlyRenderableImages && (
           <LeftZone className="viewer-desktop">
-            {!showZoomed &&
-              canvases &&
-              canvases.length > 1 &&
-              isFullSupportBrowser && (
-                <ToolbarSegmentedControl
-                  hideLabels={true}
-                  items={[
-                    {
-                      id: 'pageView',
-                      label: 'Page',
-                      icon: singlePage,
-                      dataGtmTrigger: 'item_view_page_button',
-                      clickHandler() {
-                        setGridVisible(false);
-                      },
+            {shouldShowViewToggle && (
+              <ToolbarSegmentedControl
+                items={[
+                  {
+                    id: 'pageView',
+                    label: 'Page',
+                    icon: singlePage,
+                    dataGtmTrigger: 'item_view_page_button',
+                    clickHandler() {
+                      setGridVisible(false);
                     },
-                    {
-                      id: 'gridView',
-                      label: 'Grid',
-                      icon: gridView,
-                      dataGtmTrigger: 'item_view_grid_button',
-                      clickHandler() {
-                        setGridVisible(true);
-                      },
+                  },
+                  {
+                    id: 'gridView',
+                    label: 'Grid',
+                    icon: gridView,
+                    dataGtmTrigger: 'item_view_grid_button',
+                    clickHandler() {
+                      setGridVisible(true);
                     },
-                  ]}
-                  activeId={gridVisible ? 'gridView' : 'pageView'}
-                />
-              )}
+                  },
+                ]}
+                activeId={gridVisible ? 'gridView' : 'pageView'}
+                hideLabels
+              />
+            )}
           </LeftZone>
         )}
+
         <MiddleZone className="viewer-desktop">
-          {canvases && canvases.length > 1 && !showZoomed && !isResizing && (
+          {shouldShowPageIndicator && (
             <>
-              <span data-testid="active-index">{`${canvas || 0}`}</span>
+              <span data-testid="active-index">{`${query.canvas || 0}`}</span>
               {`/${canvases?.length || ''}`}{' '}
-              {!(
-                canvases[queryParamToArrayIndex(canvas)]?.label?.trim() === '-'
-              ) &&
+              {currentPageLabel !== '-' &&
                 hasOnlyRenderableImages &&
-                `page ${canvases[
-                  queryParamToArrayIndex(canvas)
-                ]?.label?.trim()}`}
+                `page ${currentPageLabel}`}
             </>
           )}
         </MiddleZone>
@@ -393,8 +395,8 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                     <Download
                       ariaControlsId="itemDownloads"
                       downloadOptions={downloadOptions}
-                      useDarkControl={true}
-                      isInline={true}
+                      useDarkControl
+                      isInline
                     />
                   </Space>
                 )}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.test.tsx
@@ -1,0 +1,45 @@
+import {
+  getOverlayTopLeft,
+  RotationValue,
+} from './VirtualizedImageViewer.SearchHighlights';
+
+// Kept identical to its counterpart in legacy/MainViewer.test.tsx, so the two
+// stay in sync - this function is duplicated between the two viewers.
+describe('getOverlayTopLeft', () => {
+  const imageContainerRect = { top: 10, left: 20 } as unknown as DOMRect;
+  const imageRect = {
+    top: 30,
+    left: 50,
+    width: 200,
+    height: 100,
+  } as unknown as DOMRect;
+  const x = 15;
+  const y = 8;
+
+  // startTop = imageRect.top - imageContainerRect.top = 20
+  // startLeft = imageRect.left - imageContainerRect.left = 30
+  const expectedByRotation: Record<
+    RotationValue,
+    { overlayTop: number; overlayLeft: number }
+  > = {
+    0: { overlayTop: 28, overlayLeft: 45 },
+    90: { overlayTop: 35, overlayLeft: 222 },
+    180: { overlayTop: 112, overlayLeft: 215 },
+    270: { overlayTop: 105, overlayLeft: 38 },
+  };
+
+  it.each([0, 90, 180, 270] as RotationValue[])(
+    'computes the overlay position for a %d degree rotation',
+    rotation => {
+      const result = getOverlayTopLeft({
+        imageContainerRect,
+        imageRect,
+        rotation,
+        x,
+        y,
+      });
+
+      expect(result).toEqual(expectedByRotation[rotation]);
+    }
+  );
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
@@ -12,8 +12,8 @@ type OverlayPositionData = {
   overlayTop: number;
   overlayLeft: number;
   highlight: {
-    w: number;
-    h: number;
+    width: number;
+    height: number;
   };
   rotation: number;
 };
@@ -26,7 +26,7 @@ type SearchTermHighlightProps = {
   $rotation: number;
 };
 
-type RotationValue = 0 | 90 | 180 | 270;
+export type RotationValue = 0 | 90 | 180 | 270;
 
 const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
   background: ${props => props.theme.color('yellow')};
@@ -41,7 +41,7 @@ const SearchTermHighlight = styled.div<SearchTermHighlightProps>`
   mix-blend-mode: color;
 `;
 
-function getOverlayTopLeft({
+export function getOverlayTopLeft({
   imageContainerRect,
   imageRect,
   rotation,
@@ -63,26 +63,28 @@ function getOverlayTopLeft({
   const imageLeft = imageRect?.left || 0;
   const startTop = imageTop - imageContainerTop;
   const startLeft = imageLeft - imageContainerLeft;
-  if (rotation === 90) {
-    return {
-      overlayTop: startTop + x,
-      overlayLeft: startLeft + imageRect.width - y,
-    };
-  } else if (rotation === 180) {
-    return {
-      overlayTop: startTop + imageRect.height - y,
-      overlayLeft: startLeft + imageRect.width - x,
-    };
-  } else if (rotation === 270) {
-    return {
-      overlayTop: imageTop - imageContainerTop + imageRect.height - x,
-      overlayLeft: imageLeft - imageContainerLeft + y,
-    };
-  } else {
-    return {
-      overlayTop: imageTop - imageContainerTop + y,
-      overlayLeft: imageLeft - imageContainerLeft + x,
-    };
+
+  switch (rotation) {
+    case 90:
+      return {
+        overlayTop: startTop + x,
+        overlayLeft: startLeft + imageRect.width - y,
+      };
+    case 180:
+      return {
+        overlayTop: startTop + imageRect.height - y,
+        overlayLeft: startLeft + imageRect.width - x,
+      };
+    case 270:
+      return {
+        overlayTop: startTop + imageRect.height - x,
+        overlayLeft: startLeft + y,
+      };
+    default:
+      return {
+        overlayTop: startTop + y,
+        overlayLeft: startLeft + x,
+      };
   }
 }
 
@@ -138,16 +140,16 @@ function getPositionData({
     });
     const coordsMatch = resource.on.match(/(#xywh=)(.*)/);
     const coords = coordsMatch && coordsMatch[2].split(',');
-    const x = coords ? Math.round(Number(coords[0]) * scale) : 0;
-    const y = coords ? Math.round(Number(coords[1]) * scale) : 0;
-    const w = coords ? Math.round(Number(coords[2]) * scale) : 0;
-    const h = coords ? Math.round(Number(coords[3]) * scale) : 0;
+    const coordX = coords ? Math.round(Number(coords[0]) * scale) : 0;
+    const coordY = coords ? Math.round(Number(coords[1]) * scale) : 0;
+    const highlightWidth = coords ? Math.round(Number(coords[2]) * scale) : 0;
+    const highlightHeight = coords ? Math.round(Number(coords[3]) * scale) : 0;
     const { overlayTop, overlayLeft } = getOverlayTopLeft({
       imageContainerRect,
       imageRect,
       rotation: (matchingRotation?.rotation || 0) as RotationValue,
-      x,
-      y,
+      x: coordX,
+      y: coordY,
     });
 
     return {
@@ -155,8 +157,8 @@ function getPositionData({
       overlayTop,
       overlayLeft,
       highlight: {
-        w,
-        h,
+        width: highlightWidth,
+        height: highlightHeight,
       },
       rotation: matchingRotation?.rotation || 0,
     };
@@ -233,8 +235,8 @@ const SearchTermHighlights: FunctionComponent<{
               data-testid="search-term-highlight"
               $top={item.overlayTop}
               $left={item.overlayLeft}
-              $width={item.highlight.w}
-              $height={item.highlight.h}
+              $width={item.highlight.width}
+              $height={item.highlight.height}
               $rotation={item.rotation}
             />
           );

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
@@ -26,9 +26,9 @@ import SearchTermHighlights, {
   useSearchTermHighlights,
 } from './VirtualizedImageViewer.SearchHighlights';
 
-const ItemWrapper = styled.div<{ $firstItemIsRestricted: boolean }>`
+const ItemWrapper = styled.div<{ $isFirstItemRestricted: boolean }>`
   height: 100%;
-  ${props => (props.$firstItemIsRestricted ? 'margin-top: 2em;' : null)}
+  ${props => (props.$isFirstItemRestricted ? 'margin-top: 2em;' : null)}
 `;
 
 type ItemRendererProps = ListChildComponentProps<{
@@ -39,7 +39,7 @@ type ItemRendererProps = ListChildComponentProps<{
   externalAccessService?: TransformedAuthService;
   accessToken?: string;
   placeholderId?: string;
-  firstItemIsRestricted?: boolean;
+  isFirstItemRestricted?: boolean;
 }>;
 
 const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
@@ -48,7 +48,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     canvases,
     placeholderId,
     externalAccessService,
-    firstItemIsRestricted,
+    isFirstItemRestricted,
   } = data;
 
   const currentCanvas = canvases[index];
@@ -61,7 +61,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     <div style={style}>
       {scrollVelocity === 3 ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <LL $lighten={true} />
+          <LL $lighten />
         </div>
       ) : (
         <>
@@ -73,7 +73,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
                 <ItemWrapper
                   key={item.type + item.id}
                   data-testid="image-item"
-                  $firstItemIsRestricted={!!firstItemIsRestricted}
+                  $isFirstItemRestricted={!!isFirstItemRestricted}
                 >
                   <IIIFItem
                     placeholderId={placeholderId}
@@ -85,7 +85,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
                     setImageRect={setImageRect}
                     setImageContainerRect={setImageContainerRect}
                     externalAccessService={externalAccessService}
-                    shouldScrollToUpdateUrl={true}
+                    shouldScrollToUpdateUrl
                     showVideoTranscript={false}
                   />
                 </ItemWrapper>
@@ -151,34 +151,36 @@ const VirtualizedImageViewer: FunctionComponent = () => {
     errorHandler,
     accessToken,
   } = useItemViewerContext();
-  const { shouldScrollToCanvas, canvas } = query;
+
   const mainViewerRef = useRef<FixedSizeList>(null);
-  const [newScrollOffset, setNewScrollOffset] = useState(0);
+
+  const [viewerScrollOffset, setViewerScrollOffset] = useState(0);
   const [firstRender, setFirstRender] = useState(true);
   const firstRenderRef = useRef(firstRender);
   firstRenderRef.current = firstRender;
-  const scrollVelocity = useScrollVelocity(newScrollOffset);
+
+  const scrollVelocity = useScrollVelocity(viewerScrollOffset);
+  const currentCanvas = useCurrentCanvas();
+
   const debounceHandleOnItemsRendered = useRef(
     debounce(handleOnItemsRendered, 500)
   );
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
   const { canvases, auth, placeholderId } = {
     ...transformedManifest,
   };
-
-  const firstItemIsRestricted = canvases?.[0]
+  const isFirstItemRestricted = canvases?.[0]
     ? hasRestrictedItem(canvases[0])
     : false;
-
   const externalAccessService = auth?.externalAccessService;
-  const currentCanvas = useCurrentCanvas();
 
   // We hide the zoom and rotation controls while the user is scrolling
   function handleOnScroll({ scrollOffset }: ListOnScrollProps) {
     if (!currentCanvas?.imageServiceId) return;
     timer.current && clearTimeout(timer.current);
     setShowControls(false);
-    setNewScrollOffset(scrollOffset);
+    setViewerScrollOffset(scrollOffset);
 
     timer.current = setTimeout(() => {
       setShowControls(true);
@@ -189,7 +191,12 @@ const VirtualizedImageViewer: FunctionComponent = () => {
   function handleOnItemsRendered() {
     if (firstRenderRef.current) {
       const viewer = mainViewerRef?.current;
-      scrollViewer({ currentCanvas, canvas, viewer, mainAreaWidth });
+      scrollViewer({
+        currentCanvas,
+        canvas: query.canvas,
+        viewer,
+        mainAreaWidth,
+      });
       setFirstRender(false);
     }
   }
@@ -198,15 +205,15 @@ const VirtualizedImageViewer: FunctionComponent = () => {
   // But we don't want this to happen if the canvas changes as a result of the viewer being scrolled,
   // so ItemLink href prop can include a shouldScrollToCanvas query param on the href object to prevent this.
   useEffect(() => {
-    if (shouldScrollToCanvas) {
+    if (query.shouldScrollToCanvas) {
       scrollViewer({
         currentCanvas,
-        canvas,
+        canvas: query.canvas,
         viewer: mainViewerRef?.current,
         mainAreaWidth,
       });
     }
-  }, [canvas]);
+  }, [query.canvas]);
 
   return (
     <FixedSizeList
@@ -222,7 +229,7 @@ const VirtualizedImageViewer: FunctionComponent = () => {
         externalAccessService,
         accessToken,
         placeholderId,
-        firstItemIsRestricted,
+        isFirstItemRestricted,
       }}
       itemSize={mainAreaWidth}
       onItemsRendered={debounceHandleOnItemsRendered.current}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   KeyboardEvent,
   MutableRefObject,
+  PropsWithChildren,
   useEffect,
   useRef,
   useState,
@@ -35,7 +36,7 @@ const Controls = styled.div`
   z-index: 2;
 `;
 
-const Image = styled.div`
+const OpenSeadragonContainer = styled.div`
   height: 100%;
 `;
 
@@ -43,6 +44,14 @@ const ErrorMessage = () => (
   <div>
     <p>The image viewer is not working.</p>
   </div>
+);
+
+const ZOOM_STEP = 0.5;
+
+const ControlSpacer: FunctionComponent<PropsWithChildren> = ({ children }) => (
+  <Space as="span" $h={{ size: 'sm', properties: ['margin-left'] }}>
+    {children}
+  </Space>
 );
 
 type ZoomedImageProps = OptionalToUndefined<{
@@ -62,12 +71,16 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
     ? iiifImageLocation.url
     : convertRequestUriToInfoUri(mainImageService['@id'] || '');
   const [scriptError, setScriptError] = useState(false);
-  const [viewer, setViewer] = useState<openseadragon.Viewer | null>(null);
+  // osdViewerInstance re-renders the click handlers below with the current
+  // viewer; viewerRef tracks the same instance without triggering a
+  // re-render, so it can be read from the unmount cleanup effect
+  const [osdViewerInstance, setOsdViewerInstance] =
+    useState<openseadragon.Viewer | null>(null);
+
   const viewerRef: MutableRefObject<openseadragon.Viewer | null> = useRef(null);
-  const zoomStep = 0.5;
   const firstControl = useRef<HTMLButtonElement>(null);
   const lastControl = useRef<HTMLButtonElement>(null);
-  const zoomedImage = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const hasInitialised = useRef(false);
 
   function setupViewer(imageInfoSrc: string, viewerId: string) {
@@ -102,7 +115,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
           ],
         });
         osdViewer.addOnceHandler('tile-loaded', () => {
-          doZoomIn(osdViewer);
+          zoomBy(osdViewer, ZOOM_STEP);
         });
         osdViewer.addHandler('tile-loaded', () => {
           // Prevent NVDA arrow key events escaping the viewer (https://stackoverflow.com/a/41523306)
@@ -112,7 +125,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
             'use arrow keys to pan the image'
           );
         });
-        setViewer(osdViewer);
+        setOsdViewerInstance(osdViewer);
         viewerRef.current = osdViewer;
       })
       .catch(() => {
@@ -121,44 +134,33 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   }
 
   useEffect(() => {
-    !hasInitialised.current && setupViewer(zoomInfoUrl, 'zoomedImage');
-    lastControl?.current && lastControl.current.focus();
+    if (!hasInitialised.current) {
+      setupViewer(zoomInfoUrl, 'zoomedImage');
+    }
+    if (lastControl.current) {
+      lastControl.current.focus();
+    }
 
     return () => viewerRef.current?.destroy();
   }, []);
 
-  function doZoomIn(viewer: openseadragon.Viewer | null) {
-    if (!viewer) {
-      return;
-    }
-    const max = viewer.viewport.getMaxZoom();
-    const nextMax = viewer.viewport.getZoom() + zoomStep;
-    const newMax = nextMax <= max ? nextMax : max;
-
-    viewer.viewport.zoomTo(newMax);
-  }
-
-  function doZoomOut(viewer: openseadragon.Viewer | null) {
+  // Positive delta zooms in (clamped to the max zoom), negative zooms out
+  // (clamped to the min zoom).
+  function zoomBy(viewer: openseadragon.Viewer | null, delta: number) {
     if (!viewer) return;
-    const min = viewer.viewport.getMinZoom();
-    const nextMin = viewer.viewport.getZoom() - zoomStep;
-    const newMin = nextMin >= min ? nextMin : min;
+    const currentZoom = viewer.viewport.getZoom();
+    const clampedZoom =
+      delta > 0
+        ? Math.min(currentZoom + delta, viewer.viewport.getMaxZoom())
+        : Math.max(currentZoom + delta, viewer.viewport.getMinZoom());
 
-    viewer.viewport.zoomTo(newMin);
+    viewer.viewport.zoomTo(clampedZoom);
   }
 
-  function handleZoomIn(viewer: openseadragon.Viewer | null) {
-    if (!viewer) return;
-
-    if (viewer.isOpen()) {
-      doZoomIn(viewer);
-    }
-  }
-
-  function handleZoomOut(viewer: openseadragon.Viewer | null) {
+  function handleZoom(viewer: openseadragon.Viewer | null, delta: number) {
     if (!viewer) return;
     if (viewer.isOpen()) {
-      doZoomOut(viewer);
+      zoomBy(viewer, delta);
     }
   }
 
@@ -171,7 +173,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
     if (event.shiftKey && event.keyCode === 9) {
       event.preventDefault();
       (
-        zoomedImage?.current?.querySelector(
+        containerRef.current?.querySelector(
           '.openseadragon-canvas'
         ) as HTMLDivElement
       ).focus();
@@ -198,7 +200,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   }
 
   return (
-    <ZoomedImageContainer ref={zoomedImage} onKeyDown={handleKeyDown}>
+    <ZoomedImageContainer ref={containerRef} onKeyDown={handleKeyDown}>
       <Controls>
         <Space
           $v={{
@@ -210,62 +212,38 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
             properties: ['margin-left', 'margin-right'],
           }}
         >
-          <Space
-            as="span"
-            $h={{
-              size: 'sm',
-              properties: ['margin-left'],
-            }}
-          >
+          <ControlSpacer>
             <Control
               ref={firstControl}
               colorScheme="black-on-white"
               text="Zoom in"
               icon={plus}
               clickHandler={() => {
-                handleZoomIn(viewer);
+                handleZoom(osdViewerInstance, ZOOM_STEP);
               }}
             />
-          </Space>
-          <Space
-            as="span"
-            $h={{
-              size: 'sm',
-              properties: ['margin-left'],
-            }}
-          >
+          </ControlSpacer>
+          <ControlSpacer>
             <Control
               colorScheme="black-on-white"
               text="Zoom out"
               icon={minus}
               clickHandler={() => {
-                handleZoomOut(viewer);
+                handleZoom(osdViewerInstance, -ZOOM_STEP);
               }}
             />
-          </Space>
-          <Space
-            as="span"
-            $h={{
-              size: 'sm',
-              properties: ['margin-left'],
-            }}
-          >
+          </ControlSpacer>
+          <ControlSpacer>
             <Control
               colorScheme="black-on-white"
               text="Rotate"
               icon={rotateRight}
               clickHandler={() => {
-                handleRotate(viewer);
+                handleRotate(osdViewerInstance);
               }}
             />
-          </Space>
-          <Space
-            as="span"
-            $h={{
-              size: 'sm',
-              properties: ['margin-left'],
-            }}
-          >
+          </ControlSpacer>
+          <ControlSpacer>
             <Control
               ref={lastControl}
               colorScheme="black-on-white"
@@ -275,12 +253,12 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
                 setShowZoomed(false);
               }}
             />
-          </Space>
+          </ControlSpacer>
         </Space>
       </Controls>
-      <Image id="image-viewer-zoomedImage">
+      <OpenSeadragonContainer id="image-viewer-zoomedImage">
         {scriptError && <ErrorMessage />}
-      </Image>
+      </OpenSeadragonContainer>
     </ZoomedImageContainer>
   );
 };


### PR DESCRIPTION
For #13329

## What does this change?

A readability pass over `content/webapp/views/pages/works/work/IIIFViewer/refactored/`, alongside the item-viewer-refactor work. No behaviour change — renames, de-duplication, and simplification, guided by [RFC 086](https://github.com/wellcomecollection/docs/blob/main/rfcs/086-item-viewer-refactor/03-naming-conventions.md)'s boolean naming convention (`is`/`has`/`can`/`should`).

## Commits

1. **`ViewerBottomBar.tsx`, `ZoomedImage.tsx`, `IIIFSearchWithin.tsx`** — extracted a `CanvasNavButton` component to remove duplicated linked/disabled-state markup in the bottom bar, and dropped its leftover `legacyBehavior`/`passHref` (obsolete Next.js API, was producing invalid nested `<a>` tags). In `ZoomedImage.tsx`, renamed a `viewer` state variable that was confusingly shadowed by same-named handler parameters to `osdViewerInstance`, and consolidated `doZoomIn`/`doZoomOut` and `handleZoomIn`/`handleZoomOut` into one `zoomBy`/`handleZoom` each. In `IIIFSearchWithin.tsx`, fixed a local `results` variable shadowing an imported one, and extracted `navigateToItem`/`findCanvasIndexForHit` helpers to de-duplicate link-building logic.
2. **`VirtualizedImageViewer.SearchHighlights.tsx`** — renamed single-letter coordinate variables (`x, y, w, h`) to `coordX`/`coordY`/`highlightWidth`/`highlightHeight`, fixed two rotation branches recomputing values that were already available, and turned an `if/else if` chain into a `switch`. Added a parity test for this function against its verbatim duplicate in `legacy/MainViewer.tsx`, mirrored into both test files so the two can't silently drift.
3. **`IIIFViewer.tsx`, `ViewerSidebar.tsx`, `ViewerTopBar.tsx`** — the main viewer shell: grouped scattered hooks/state, replaced `prop={true}` with shorthand throughout, applied the naming convention. Found and fixed a real bug in `ViewerSidebar.tsx`: a redundant `parentManifest.canvases &&` clause had drifted out of sync with the equivalent check in `items.tsx`, despite a comment saying they should match.
4. **`VirtualizedImageViewer.tsx`** — same pass, kept separate as a distinct piece. Renamed `firstItemIsRestricted` to `isFirstItemRestricted`; renamed a scroll-offset state variable to `viewerScrollOffset` rather than plain `scrollOffset`, since react-window's `onScroll` callback already destructures a parameter with that name.
5. **`GridViewer.tsx`, `IIIFCanvasThumbnail.tsx`, `IIIFViewerImage.tsx`** — renamed a `highlightImage` prop to `isHighlighted` across all three. In `IIIFCanvasThumbnail.tsx`, extracted a three-way icon-selection ternary into `getPlaceholderIcon`, and removed a redundant re-check of an already-guaranteed condition.
6. **`ImageViewer.tsx`, `Paginators.tsx`, `ViewerStructures.tsx`** — renamed a misleading `canvas` callback parameter (actually a `{ canvas, rotation }` pair) to `image` in `ImageViewer.tsx`. In `ViewerStructures.tsx`, de-duplicated a condition computed twice and fixed a recursive `.map()` shadowing its own outer `range`/`i`. Also found a real (harmless) bug here: `findIndex(...) || 0` doesn't fall back as intended, since `-1` is truthy in JS — present identically in the legacy viewer too, so left unfixed to keep this PR behaviour-neutral, and raised separately.
7. **`IIIFItem/index.tsx`** — named two dense inline conditions (`shouldRelabelImageAsItem`, `isAudioType`) and extracted a label-resolution ternary into `getItemLabel`. Removed a no-op `.attrs({})`, a redundant inline `import(...)` type reference, and two unnecessary Fragment wrappers.
8. **`ImageViewerControls.tsx`, `ToolbarSegmentedControl.tsx`, `Thumbnails.tsx`, `NoScriptImage.tsx`, `PaginatedItemViewer.tsx`, `MultipleManifestList.tsx`** — smaller fixes across the remaining components: de-duplicated conditions computed twice (`ToolbarSegmentedControl.tsx`, `MultipleManifestList.tsx`), removed a dead `id="xyz"` placeholder attribute unreferenced since 2023 (`Thumbnails.tsx`), renamed the last styled component still using the vague `...El` suffix, and applied the usual boolean-shorthand/direct-`query.x`-access cleanups throughout.
9. **`Paginators.tsx`** — `CanvasPaginator` and `ThumbnailsPaginator` were near-duplicates (same context read, link construction, and next/prev logic). Extracted the shared part into a `usePaginatorLinks` hook, parameterised by which query field drives the current page, the page size, and an optional canvas-to-thumbnails-page translation — each paginator is now three lines of config.

## How to test

No behavioural change intended.
- `yarn tsc` and `yarn test:content` pass.
- Manually exercise the item viewer: search within a multi-page item, zoom/rotate/close the zoomed view, navigate canvases via the bottom bar, open the grid view and thumbnails panel (including its pagination), and check the sidebar's contents/structures links.
- Playwright's `(1) | The images can be zoomed` (`playwright/test/view-items-tests.ts`) covers the zoom control at a basic level, though it doesn't assert exact zoom values.

## Have we considered potential risks?

Low risk — internal renames, extractions, and de-duplication, verified with `tsc`/eslint and existing tests after every change. Several touched files (`GridViewer`, `IIIFCanvasThumbnail`, `ImageViewer`, `Paginators`, `ViewerStructures`) have no dedicated unit tests, so for those we relied on tracing the logic by hand and on `tsc` catching narrowing/typing regressions. The one identified bug (`ViewerStructures.tsx`'s fallback) was deliberately left unfixed to keep this PR behaviour-neutral.
