### PR TITLE
IVR: context divergence safety

### DIFF
--- a/content/webapp/contexts/ItemViewerContext/index.tsx
+++ b/content/webapp/contexts/ItemViewerContext/index.tsx
@@ -1,14 +1,22 @@
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 
 import ItemViewerContextLegacy, {
-  defaultItemViewerContext,
   ItemViewerContextProps,
-  results,
   useItemViewerContext as useLegacy,
 } from './legacy';
 import ItemViewerContextRefactored, {
+  ItemViewerContextProps as ItemViewerContextPropsRefactored,
   useItemViewerContext as useRefactored,
 } from './refactored';
+
+// This barrel exists so that both the legacy and refactored viewer trees
+// (see IIIFViewer/index.tsx for where they're switched between, per RFC 086)
+// can consume context via one import path during the item-viewer-refactor
+// migration. `legacy` is still the live implementation for anyone without
+// the `itemViewerRefactor` flag, so its context stays untouched here even as
+// `refactored`'s context is free to diverge (new fields, renamed booleans,
+// etc.) as the refactor progresses. Once legacy is fully retired, this file
+// can be deleted and consumers can import `refactored`'s context directly.
 
 // TODO: Remove after itemViewerRefactor is fully rolled out.
 declare global {
@@ -17,15 +25,12 @@ declare global {
   }
 }
 
-// Export types and defaults (same in both versions)
-export type { ItemViewerContextProps };
-export { defaultItemViewerContext, results };
-
 // Export both contexts for IIIFViewer implementations to use with .Provider
 export { ItemViewerContextLegacy, ItemViewerContextRefactored };
 
 // Hook that returns the correct context based on feature flag
-export function useItemViewerContext(): ItemViewerContextProps {
+export function useItemViewerContext():
+  ItemViewerContextProps | ItemViewerContextPropsRefactored {
   const { itemViewerRefactor } = useFeatureFlags();
   const legacyContext = useLegacy();
   const refactoredContext = useRefactored();

--- a/content/webapp/contexts/ItemViewerContext/index.tsx
+++ b/content/webapp/contexts/ItemViewerContext/index.tsx
@@ -1,7 +1,7 @@
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 
 import ItemViewerContextLegacy, {
-  ItemViewerContextProps,
+  ItemViewerContextProps as ItemViewerContextPropsLegacy,
   useItemViewerContext as useLegacy,
 } from './legacy';
 import ItemViewerContextRefactored, {
@@ -30,7 +30,7 @@ export { ItemViewerContextLegacy, ItemViewerContextRefactored };
 
 // Hook that returns the correct context based on feature flag
 export function useItemViewerContext():
-  ItemViewerContextProps | ItemViewerContextPropsRefactored {
+  ItemViewerContextPropsLegacy | ItemViewerContextPropsRefactored {
   const { itemViewerRefactor } = useFeatureFlags();
   const legacyContext = useLegacy();
   const refactoredContext = useRefactored();

--- a/content/webapp/contexts/ItemViewerContext/legacy.tsx
+++ b/content/webapp/contexts/ItemViewerContext/legacy.tsx
@@ -14,6 +14,9 @@ import { TransformedManifest } from '@weco/content/types/manifest';
 import { UiTree } from '@weco/content/views/pages/works/work/work.types';
 
 export type ItemViewerContextProps = {
+  // Discriminant for narrowing the legacy | refactored union returned by
+  // useItemViewerContext() — see ./refactored.tsx and ./index.tsx.
+  isRefactoredContext: false;
   // DATA props:
   query: ItemViewerQuery;
   work: WorkBasic & Pick<Work, 'description'>;
@@ -95,6 +98,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
 };
 
 export const defaultItemViewerContext: ItemViewerContextProps = {
+  isRefactoredContext: false,
   // DATA props:
   query,
   work,

--- a/content/webapp/contexts/ItemViewerContext/legacy.tsx
+++ b/content/webapp/contexts/ItemViewerContext/legacy.tsx
@@ -1,6 +1,9 @@
 import { createContext, RefObject, useContext } from 'react';
 
-import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
+import {
+  emptySearchResults,
+  SearchResults,
+} from '@weco/content/services/iiif/types/search/v3';
 import {
   Work,
   WorkBasic,
@@ -61,19 +64,6 @@ export type ItemViewerContextProps = {
   hasOnlyRenderableImages: boolean;
 };
 
-export const results: SearchResults = {
-  '@context': '',
-  '@id': '',
-  '@type': 'sc:AnnotationList',
-  within: {
-    '@type': '',
-    total: null,
-  },
-  startIndex: 0,
-  resources: [],
-  hits: [],
-};
-
 const query = {
   canvas: 1,
   manifest: 1,
@@ -104,7 +94,7 @@ export const defaultItemViewerContext: ItemViewerContextProps = {
   work,
   transformedManifest: undefined,
   parentManifest: undefined,
-  searchResults: results,
+  searchResults: emptySearchResults,
   setSearchResults: () => undefined,
   accessToken: undefined,
   tree: [],

--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -14,8 +14,9 @@ import { TransformedManifest } from '@weco/content/types/manifest';
 import { UiTree } from '@weco/content/views/pages/works/work/work.types';
 
 export type ItemViewerContextProps = {
-  // To remove once we move over from the itemViewerRefactor feature flag
-  isRefactoredContext: boolean;
+  // Discriminant for narrowing the legacy | refactored union returned by
+  // useItemViewerContext() — see ./legacy.tsx and ./index.tsx.
+  isRefactoredContext: true;
   // DATA props:
   query: ItemViewerQuery;
   work: WorkBasic & Pick<Work, 'description'>;

--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -14,6 +14,8 @@ import { TransformedManifest } from '@weco/content/types/manifest';
 import { UiTree } from '@weco/content/views/pages/works/work/work.types';
 
 export type ItemViewerContextProps = {
+  // To remove once we move over from the itemViewerRefactor feature flag
+  isRefactoredContext: boolean;
   // DATA props:
   query: ItemViewerQuery;
   work: WorkBasic & Pick<Work, 'description'>;
@@ -95,6 +97,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
 };
 
 export const defaultItemViewerContext: ItemViewerContextProps = {
+  isRefactoredContext: true,
   // DATA props:
   query,
   work,

--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -1,6 +1,9 @@
 import { createContext, RefObject, useContext } from 'react';
 
-import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
+import {
+  emptySearchResults,
+  SearchResults,
+} from '@weco/content/services/iiif/types/search/v3';
 import {
   Work,
   WorkBasic,
@@ -61,19 +64,6 @@ export type ItemViewerContextProps = {
   hasOnlyRenderableImages: boolean;
 };
 
-export const results: SearchResults = {
-  '@context': '',
-  '@id': '',
-  '@type': 'sc:AnnotationList',
-  within: {
-    '@type': '',
-    total: null,
-  },
-  startIndex: 0,
-  resources: [],
-  hits: [],
-};
-
 const query = {
   canvas: 1,
   manifest: 1,
@@ -104,7 +94,7 @@ export const defaultItemViewerContext: ItemViewerContextProps = {
   work,
   transformedManifest: undefined,
   parentManifest: undefined,
-  searchResults: results,
+  searchResults: emptySearchResults,
   setSearchResults: () => undefined,
   accessToken: undefined,
   tree: [],

--- a/content/webapp/hooks/useIIIFProbeService.test.tsx
+++ b/content/webapp/hooks/useIIIFProbeService.test.tsx
@@ -5,10 +5,10 @@ import UserContext, {
   defaultUserContext,
 } from '@weco/common/contexts/UserContext';
 import ItemViewerContextLegacy, {
-  defaultItemViewerContext as defaultLegacyItemViewerContext,
+  defaultItemViewerContext as defaultItemViewerContextLegacy,
 } from '@weco/content/contexts/ItemViewerContext/legacy';
 import ItemViewerContextRefactored, {
-  defaultItemViewerContext as defaultRefactoredItemViewerContext,
+  defaultItemViewerContext as defaultItemViewerContextRefactored,
 } from '@weco/content/contexts/ItemViewerContext/refactored';
 import {
   createMockCanvas,
@@ -66,13 +66,13 @@ describe.each([
       >
         {itemViewerRefactor ? (
           <ItemViewerContextRefactored.Provider
-            value={{ ...defaultRefactoredItemViewerContext, accessToken }}
+            value={{ ...defaultItemViewerContextRefactored, accessToken }}
           >
             {children}
           </ItemViewerContextRefactored.Provider>
         ) : (
           <ItemViewerContextLegacy.Provider
-            value={{ ...defaultLegacyItemViewerContext, accessToken }}
+            value={{ ...defaultItemViewerContextLegacy, accessToken }}
           >
             {children}
           </ItemViewerContextLegacy.Provider>

--- a/content/webapp/hooks/useIIIFProbeService.test.tsx
+++ b/content/webapp/hooks/useIIIFProbeService.test.tsx
@@ -6,7 +6,7 @@ import UserContext, {
 } from '@weco/common/contexts/UserContext';
 import ItemViewerContext, {
   defaultItemViewerContext,
-} from '@weco/content/contexts/ItemViewerContext';
+} from '@weco/content/contexts/ItemViewerContext/legacy';
 import {
   createMockCanvas,
   createRestrictedPainting,

--- a/content/webapp/hooks/useIIIFProbeService.test.tsx
+++ b/content/webapp/hooks/useIIIFProbeService.test.tsx
@@ -4,9 +4,12 @@ import { FunctionComponent, PropsWithChildren } from 'react';
 import UserContext, {
   defaultUserContext,
 } from '@weco/common/contexts/UserContext';
-import ItemViewerContext, {
-  defaultItemViewerContext,
+import ItemViewerContextLegacy, {
+  defaultItemViewerContext as defaultLegacyItemViewerContext,
 } from '@weco/content/contexts/ItemViewerContext/legacy';
+import ItemViewerContextRefactored, {
+  defaultItemViewerContext as defaultRefactoredItemViewerContext,
+} from '@weco/content/contexts/ItemViewerContext/refactored';
 import {
   createMockCanvas,
   createRestrictedPainting,
@@ -18,28 +21,21 @@ import useIIIFProbeService from './useIIIFProbeService';
 // unrestricted canvases, and for restricted ones only once the auth cookie is
 // confirmed via the probe service (for a logged-in staff user with a token).
 // This exercises that matrix with mocked user state and fetch.
+//
+// The hook reads accessToken via the feature-flag-aware useItemViewerContext()
+// barrel, so the whole matrix runs against both the legacy and refactored
+// context to catch either side silently no longer supplying accessToken.
+let mockItemViewerRefactor = false;
+
+jest.mock('@weco/common/server-data/Context', () => ({
+  ...jest.requireActual('@weco/common/server-data/Context'),
+  useFeatureFlags: () => ({ itemViewerRefactor: mockItemViewerRefactor }),
+}));
 
 type WrapperOptions = {
   userIsStaffWithRestricted?: boolean;
   accessToken?: string;
 };
-
-const createWrapper =
-  ({
-    userIsStaffWithRestricted = false,
-    accessToken,
-  }: WrapperOptions): FunctionComponent<PropsWithChildren> =>
-  ({ children }) => (
-    <UserContext.Provider
-      value={{ ...defaultUserContext, userIsStaffWithRestricted }}
-    >
-      <ItemViewerContext.Provider
-        value={{ ...defaultItemViewerContext, accessToken }}
-      >
-        {children}
-      </ItemViewerContext.Provider>
-    </UserContext.Provider>
-  );
 
 const restrictedCanvas = (probeServiceId?: string) =>
   createMockCanvas({ painting: [createRestrictedPainting()], probeServiceId });
@@ -51,7 +47,39 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('useIIIFProbeService', () => {
+describe.each([
+  { name: 'legacy', itemViewerRefactor: false },
+  { name: 'refactored', itemViewerRefactor: true },
+])('useIIIFProbeService ($name context)', ({ itemViewerRefactor }) => {
+  beforeEach(() => {
+    mockItemViewerRefactor = itemViewerRefactor;
+  });
+
+  const createWrapper =
+    ({
+      userIsStaffWithRestricted = false,
+      accessToken,
+    }: WrapperOptions): FunctionComponent<PropsWithChildren> =>
+    ({ children }) => (
+      <UserContext.Provider
+        value={{ ...defaultUserContext, userIsStaffWithRestricted }}
+      >
+        {itemViewerRefactor ? (
+          <ItemViewerContextRefactored.Provider
+            value={{ ...defaultRefactoredItemViewerContext, accessToken }}
+          >
+            {children}
+          </ItemViewerContextRefactored.Provider>
+        ) : (
+          <ItemViewerContextLegacy.Provider
+            value={{ ...defaultLegacyItemViewerContext, accessToken }}
+          >
+            {children}
+          </ItemViewerContextLegacy.Provider>
+        )}
+      </UserContext.Provider>
+    );
+
   it('returns true immediately for an unrestricted canvas', () => {
     const fetchMock = jest.fn();
     global.fetch = fetchMock as unknown as typeof fetch;

--- a/content/webapp/services/iiif/types/search/v3/index.ts
+++ b/content/webapp/services/iiif/types/search/v3/index.ts
@@ -30,3 +30,16 @@ export type SearchResults = {
     after: string;
   }[];
 };
+
+export const emptySearchResults: SearchResults = {
+  '@context': '',
+  '@id': '',
+  '@type': 'sc:AnnotationList',
+  within: {
+    '@type': '',
+    total: null,
+  },
+  startIndex: 0,
+  resources: [],
+  hits: [],
+};

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -113,16 +113,12 @@ export function renderWithContext(
       <AppContext.Provider value={appValue}>
         <KioskContext.Provider value={kioskValue}>
           <UserContext.Provider value={userValue}>
-            {useRefactoredContext ? (
-              <ItemViewerContextRefactored.Provider
-                value={contextValue as RefactoredItemViewerContextProps}
-              >
+            {contextValue.isRefactoredContext ? (
+              <ItemViewerContextRefactored.Provider value={contextValue}>
                 {children}
               </ItemViewerContextRefactored.Provider>
             ) : (
-              <ItemViewerContextLegacy.Provider
-                value={contextValue as LegacyItemViewerContextProps}
-              >
+              <ItemViewerContextLegacy.Provider value={contextValue}>
                 {children}
               </ItemViewerContextLegacy.Provider>
             )}

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -15,12 +15,14 @@ import UserContext, {
   UserContextProps,
 } from '@weco/common/contexts/UserContext';
 import theme from '@weco/common/views/themes/default';
-import {
-  defaultItemViewerContext,
-  ItemViewerContextLegacy,
-  ItemViewerContextProps,
-  ItemViewerContextRefactored,
-} from '@weco/content/contexts/ItemViewerContext';
+import ItemViewerContextLegacy, {
+  defaultItemViewerContext as defaultLegacyItemViewerContext,
+  ItemViewerContextProps as LegacyItemViewerContextProps,
+} from '@weco/content/contexts/ItemViewerContext/legacy';
+import ItemViewerContextRefactored, {
+  defaultItemViewerContext as defaultRefactoredItemViewerContext,
+  ItemViewerContextProps as RefactoredItemViewerContextProps,
+} from '@weco/content/contexts/ItemViewerContext/refactored';
 
 import { createMockManifest } from './transformed-manifest';
 
@@ -32,12 +34,28 @@ import { createMockManifest } from './transformed-manifest';
 // KioskContext (isKiosk, which affects PDF viewer choice and other kiosk-specific
 // behavior). `renderWithContext` wires all of these up with sensible defaults
 // so a test only has to declare the values relevant to the scenario it characterises.
+//
+// This imports legacy's and refactored's context modules directly (rather
+// than the feature-flag-aware barrel), so each Provider below is always given
+// a value matching its own shape — the two are expected to diverge as the
+// item-viewer-refactor migration progresses.
 
 export function createMockItemViewerContext(
-  overrides: Partial<ItemViewerContextProps> = {}
-): ItemViewerContextProps {
+  overrides: Partial<LegacyItemViewerContextProps> = {}
+): LegacyItemViewerContextProps {
   return {
-    ...defaultItemViewerContext,
+    ...defaultLegacyItemViewerContext,
+    // A single-image manifest is the most common baseline; override as needed.
+    transformedManifest: createMockManifest(),
+    ...overrides,
+  };
+}
+
+export function createMockRefactoredItemViewerContext(
+  overrides: Partial<RefactoredItemViewerContextProps> = {}
+): RefactoredItemViewerContextProps {
+  return {
+    ...defaultRefactoredItemViewerContext,
     // A single-image manifest is the most common baseline; override as needed.
     transformedManifest: createMockManifest(),
     ...overrides,
@@ -45,18 +63,21 @@ export function createMockItemViewerContext(
 }
 
 export type RenderWithContextOptions = {
-  contextProps?: Partial<ItemViewerContextProps>;
+  contextProps?:
+    | Partial<LegacyItemViewerContextProps>
+    | Partial<RefactoredItemViewerContextProps>;
   appContext?: Partial<AppContextProps>;
   userContext?: Partial<UserContextProps>;
   kioskContext?: Partial<KioskContextType>;
-  // When true, wraps with ItemViewerContextRefactored.Provider instead of
-  // ItemViewerContextLegacy.Provider. Use in refactored viewer tests that
-  // mock useFeatureFlags to return { itemViewerRefactor: true }.
+  // When true, wraps with ItemViewerContextRefactored.Provider (given a
+  // refactored-shaped context value) instead of ItemViewerContextLegacy.Provider.
+  // Use in refactored viewer tests that mock useFeatureFlags to return
+  // { itemViewerRefactor: true }.
   useRefactoredContext?: boolean;
 } & Omit<RenderOptions, 'wrapper'>;
 
 export type RenderWithContextResult = RenderResult & {
-  contextValue: ItemViewerContextProps;
+  contextValue: LegacyItemViewerContextProps | RefactoredItemViewerContextProps;
 };
 
 export function renderWithContext(
@@ -70,7 +91,13 @@ export function renderWithContext(
     ...renderOptions
   }: RenderWithContextOptions = {}
 ): RenderWithContextResult {
-  const contextValue = createMockItemViewerContext(contextProps);
+  const contextValue = useRefactoredContext
+    ? createMockRefactoredItemViewerContext(
+        contextProps as Partial<RefactoredItemViewerContextProps>
+      )
+    : createMockItemViewerContext(
+        contextProps as Partial<LegacyItemViewerContextProps>
+      );
   const appValue: AppContextProps = { ...appContextDefaults, ...appContext };
   const userValue: UserContextProps = {
     ...defaultUserContext,
@@ -81,18 +108,24 @@ export function renderWithContext(
     ...kioskContext,
   };
 
-  const ItemViewerContext = useRefactoredContext
-    ? ItemViewerContextRefactored
-    : ItemViewerContextLegacy;
-
   const Wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
     <ThemeProvider theme={theme}>
       <AppContext.Provider value={appValue}>
         <KioskContext.Provider value={kioskValue}>
           <UserContext.Provider value={userValue}>
-            <ItemViewerContext.Provider value={contextValue}>
-              {children}
-            </ItemViewerContext.Provider>
+            {useRefactoredContext ? (
+              <ItemViewerContextRefactored.Provider
+                value={contextValue as RefactoredItemViewerContextProps}
+              >
+                {children}
+              </ItemViewerContextRefactored.Provider>
+            ) : (
+              <ItemViewerContextLegacy.Provider
+                value={contextValue as LegacyItemViewerContextProps}
+              >
+                {children}
+              </ItemViewerContextLegacy.Provider>
+            )}
           </UserContext.Provider>
         </KioskContext.Provider>
       </AppContext.Provider>

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -16,12 +16,12 @@ import UserContext, {
 } from '@weco/common/contexts/UserContext';
 import theme from '@weco/common/views/themes/default';
 import ItemViewerContextLegacy, {
-  defaultItemViewerContext as defaultLegacyItemViewerContext,
-  ItemViewerContextProps as LegacyItemViewerContextProps,
+  defaultItemViewerContext as defaultItemViewerContextLegacy,
+  ItemViewerContextProps as ItemViewerContextPropsLegacy,
 } from '@weco/content/contexts/ItemViewerContext/legacy';
 import ItemViewerContextRefactored, {
-  defaultItemViewerContext as defaultRefactoredItemViewerContext,
-  ItemViewerContextProps as RefactoredItemViewerContextProps,
+  defaultItemViewerContext as defaultItemViewerContextRefactored,
+  ItemViewerContextProps as ItemViewerContextPropsRefactored,
 } from '@weco/content/contexts/ItemViewerContext/refactored';
 
 import { createMockManifest } from './transformed-manifest';
@@ -40,11 +40,21 @@ import { createMockManifest } from './transformed-manifest';
 // a value matching its own shape — the two are expected to diverge as the
 // item-viewer-refactor migration progresses.
 
+// isRefactoredContext is excluded from overrides: it's the discriminant that
+// decides which Provider wraps the tree below, so it must only ever come
+// from the matching default, never from a test-supplied override.
+type ItemViewerContextOverridesLegacy = Partial<
+  Omit<ItemViewerContextPropsLegacy, 'isRefactoredContext'>
+>;
+type ItemViewerContextOverridesRefactored = Partial<
+  Omit<ItemViewerContextPropsRefactored, 'isRefactoredContext'>
+>;
+
 export function createMockItemViewerContext(
-  overrides: Partial<LegacyItemViewerContextProps> = {}
-): LegacyItemViewerContextProps {
+  overrides: ItemViewerContextOverridesLegacy = {}
+): ItemViewerContextPropsLegacy {
   return {
-    ...defaultLegacyItemViewerContext,
+    ...defaultItemViewerContextLegacy,
     // A single-image manifest is the most common baseline; override as needed.
     transformedManifest: createMockManifest(),
     ...overrides,
@@ -52,10 +62,10 @@ export function createMockItemViewerContext(
 }
 
 export function createMockRefactoredItemViewerContext(
-  overrides: Partial<RefactoredItemViewerContextProps> = {}
-): RefactoredItemViewerContextProps {
+  overrides: ItemViewerContextOverridesRefactored = {}
+): ItemViewerContextPropsRefactored {
   return {
-    ...defaultRefactoredItemViewerContext,
+    ...defaultItemViewerContextRefactored,
     // A single-image manifest is the most common baseline; override as needed.
     transformedManifest: createMockManifest(),
     ...overrides,
@@ -64,8 +74,7 @@ export function createMockRefactoredItemViewerContext(
 
 export type RenderWithContextOptions = {
   contextProps?:
-    | Partial<LegacyItemViewerContextProps>
-    | Partial<RefactoredItemViewerContextProps>;
+    ItemViewerContextOverridesLegacy | ItemViewerContextOverridesRefactored;
   appContext?: Partial<AppContextProps>;
   userContext?: Partial<UserContextProps>;
   kioskContext?: Partial<KioskContextType>;
@@ -76,8 +85,19 @@ export type RenderWithContextOptions = {
   useRefactoredContext?: boolean;
 } & Omit<RenderOptions, 'wrapper'>;
 
+// Narrows contextProps to the refactored context's own shape (rather than
+// RenderWithContextOptions' generic legacy-or-refactored union), so a stale
+// field name is caught at compile time instead of being silently dropped.
+// For use in refactored viewer tests that always pass useRefactoredContext: true.
+export type RenderWithRefactoredContextOptions = Omit<
+  RenderWithContextOptions,
+  'contextProps' | 'useRefactoredContext'
+> & {
+  contextProps?: ItemViewerContextOverridesRefactored;
+};
+
 export type RenderWithContextResult = RenderResult & {
-  contextValue: LegacyItemViewerContextProps | RefactoredItemViewerContextProps;
+  contextValue: ItemViewerContextPropsLegacy | ItemViewerContextPropsRefactored;
 };
 
 export function renderWithContext(
@@ -93,10 +113,10 @@ export function renderWithContext(
 ): RenderWithContextResult {
   const contextValue = useRefactoredContext
     ? createMockRefactoredItemViewerContext(
-        contextProps as Partial<RefactoredItemViewerContextProps>
+        contextProps as ItemViewerContextOverridesRefactored
       )
     : createMockItemViewerContext(
-        contextProps as Partial<LegacyItemViewerContextProps>
+        contextProps as ItemViewerContextOverridesLegacy
       );
   const appValue: AppContextProps = { ...appContextDefaults, ...appContext };
   const userValue: UserContextProps = {

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -72,18 +72,29 @@ export function createMockRefactoredItemViewerContext(
   };
 }
 
-export type RenderWithContextOptions = {
-  contextProps?:
-    ItemViewerContextOverridesLegacy | ItemViewerContextOverridesRefactored;
+type CommonRenderWithContextOptions = {
   appContext?: Partial<AppContextProps>;
   userContext?: Partial<UserContextProps>;
   kioskContext?: Partial<KioskContextType>;
-  // When true, wraps with ItemViewerContextRefactored.Provider (given a
-  // refactored-shaped context value) instead of ItemViewerContextLegacy.Provider.
-  // Use in refactored viewer tests that mock useFeatureFlags to return
-  // { itemViewerRefactor: true }.
-  useRefactoredContext?: boolean;
 } & Omit<RenderOptions, 'wrapper'>;
+
+// A discriminated union keyed on useRefactoredContext, rather than a plain
+// boolean alongside a generic legacy-or-refactored contextProps union — so
+// contextProps is narrowed to the matching shape at every call site, with no
+// `as` casts needed here or anywhere that calls renderWithContext directly.
+export type RenderWithContextOptions =
+  | (CommonRenderWithContextOptions & {
+      useRefactoredContext?: false;
+      contextProps?: ItemViewerContextOverridesLegacy;
+    })
+  | (CommonRenderWithContextOptions & {
+      // Wraps with ItemViewerContextRefactored.Provider (given a
+      // refactored-shaped context value) instead of ItemViewerContextLegacy.Provider.
+      // Use in refactored viewer tests that mock useFeatureFlags to return
+      // { itemViewerRefactor: true }.
+      useRefactoredContext: true;
+      contextProps?: ItemViewerContextOverridesRefactored;
+    });
 
 // Narrows contextProps to the refactored context's own shape (rather than
 // RenderWithContextOptions' generic legacy-or-refactored union), so a stale
@@ -102,22 +113,22 @@ export type RenderWithContextResult = RenderResult & {
 
 export function renderWithContext(
   ui: ReactElement,
-  {
+  options: RenderWithContextOptions = {}
+): RenderWithContextResult {
+  // Narrowed via property access on `options` itself (rather than destructured
+  // copies) so contextProps' shape stays tied to useRefactoredContext's value.
+  const contextValue = options.useRefactoredContext
+    ? createMockRefactoredItemViewerContext(options.contextProps)
+    : createMockItemViewerContext(options.contextProps);
+
+  const {
     contextProps,
+    useRefactoredContext,
     appContext,
     userContext,
     kioskContext,
-    useRefactoredContext = false,
     ...renderOptions
-  }: RenderWithContextOptions = {}
-): RenderWithContextResult {
-  const contextValue = useRefactoredContext
-    ? createMockRefactoredItemViewerContext(
-        contextProps as ItemViewerContextOverridesRefactored
-      )
-    : createMockItemViewerContext(
-        contextProps as ItemViewerContextOverridesLegacy
-      );
+  } = options;
   const appValue: AppContextProps = { ...appContextDefaults, ...appContext };
   const userValue: UserContextProps = {
     ...defaultUserContext,

--- a/content/webapp/views/pages/works/work/IIIFViewer/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/index.tsx
@@ -10,6 +10,11 @@ import { IIIFViewerProps as RefactoredIIIFViewerProps } from './refactored/IIIFV
 const IIIFViewerLegacy = dynamic(() => import('./legacy'));
 const IIIFViewerRefactored = dynamic(() => import('./refactored'));
 
+// This is the switch point for the item-viewer-refactor migration (RFC 086:
+// https://github.com/wellcomecollection/docs/blob/main/rfcs/086-item-viewer-refactor/README.md).
+// `legacy/` is what all users see today; `refactored/` is being built out
+// behind the `itemViewerRefactor` feature flag. Once the refactor is fully
+// rolled out, `legacy/` (and this switch) can be deleted.
 export default function IIIFViewer(
   props: LegacyIIIFViewerProps | RefactoredIIIFViewerProps
 ) {

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFSearchWithin.tsx
@@ -10,10 +10,8 @@ import Button from '@weco/common/views/components/Buttons';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import TextInput from '@weco/common/views/components/TextInput';
-import {
-  results,
-  useItemViewerContext,
-} from '@weco/content/contexts/ItemViewerContext';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+import { results } from '@weco/content/contexts/ItemViewerContext/legacy';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { searchWithinLabel } from '@weco/content/text/aria-labels';
 import { TransformedCanvas } from '@weco/content/types/manifest';

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFSearchWithin.tsx
@@ -11,8 +11,10 @@ import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import TextInput from '@weco/common/views/components/TextInput';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
-import { results } from '@weco/content/contexts/ItemViewerContext/legacy';
-import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
+import {
+  emptySearchResults,
+  SearchResults,
+} from '@weco/content/services/iiif/types/search/v3';
 import { searchWithinLabel } from '@weco/content/text/aria-labels';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
@@ -163,7 +165,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
         page: query.page,
       },
     });
-    setSearchResults && setSearchResults(results);
+    setSearchResults && setSearchResults(emptySearchResults);
     router.replace(link.href);
 
     // Remove the attribute after navigation
@@ -188,7 +190,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
         setSearchError(true);
       }
     } else {
-      setSearchResults && setSearchResults(results);
+      setSearchResults && setSearchResults(emptySearchResults);
     }
   }
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.tsx
@@ -347,6 +347,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   return (
     <ItemViewerContext.Provider
       value={{
+        isRefactoredContext: false,
         // DATA props:
         query: {
           page,

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
-import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext';
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/legacy';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockAuth,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -10,10 +10,8 @@ import Button from '@weco/common/views/components/Buttons';
 import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import TextInput from '@weco/common/views/components/TextInput';
-import {
-  results,
-  useItemViewerContext,
-} from '@weco/content/contexts/ItemViewerContext';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+import { results } from '@weco/content/contexts/ItemViewerContext/refactored';
 import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
 import { searchWithinLabel } from '@weco/content/text/aria-labels';
 import { TransformedCanvas } from '@weco/content/types/manifest';

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -11,8 +11,10 @@ import LL from '@weco/common/views/components/styled/LL';
 import Space from '@weco/common/views/components/styled/Space';
 import TextInput from '@weco/common/views/components/TextInput';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
-import { results } from '@weco/content/contexts/ItemViewerContext/refactored';
-import { SearchResults } from '@weco/content/services/iiif/types/search/v3';
+import {
+  emptySearchResults,
+  SearchResults,
+} from '@weco/content/services/iiif/types/search/v3';
 import { searchWithinLabel } from '@weco/content/text/aria-labels';
 import { TransformedCanvas } from '@weco/content/types/manifest';
 import {
@@ -182,7 +184,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
       formRef.current.dataset.gtmIsClearing = 'true';
     }
 
-    setSearchResults(results);
+    setSearchResults(emptySearchResults);
     navigateToItem({
       manifest: query.manifest,
       canvas: query.canvas,
@@ -211,7 +213,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
         setSearchError(true);
       }
     } else {
-      setSearchResults(results);
+      setSearchResults(emptySearchResults);
     }
   }
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -372,6 +372,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   return (
     <ItemViewerContext.Provider
       value={{
+        isRefactoredContext: true,
         // DATA props:
         query: {
           page,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext';
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockAuth,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import {
   renderWithContext,
   RenderWithContextOptions,
@@ -27,7 +28,17 @@ jest.mock('@weco/content/hooks/useIsFullscreenEnabled', () => ({
   default: () => true,
 }));
 
-function renderBottomBar(options: RenderWithContextOptions = {}) {
+// Narrows contextProps to the refactored context's own shape (rather than
+// RenderWithContextOptions' generic legacy-or-refactored union), so a stale
+// field name is caught at compile time instead of being silently dropped.
+type RenderBottomBarOptions = Omit<
+  RenderWithContextOptions,
+  'contextProps' | 'useRefactoredContext'
+> & {
+  contextProps?: Partial<ItemViewerContextProps>;
+};
+
+function renderBottomBar(options: RenderBottomBarOptions = {}) {
   return renderWithContext(<ViewerBottomBar />, {
     appContext: { isEnhanced: true, isFullSupportBrowser: true },
     useRefactoredContext: true,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
@@ -1,10 +1,9 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 
-import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import {
   renderWithContext,
-  RenderWithContextOptions,
+  RenderWithRefactoredContextOptions,
 } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockCanvas,
@@ -28,17 +27,7 @@ jest.mock('@weco/content/hooks/useIsFullscreenEnabled', () => ({
   default: () => true,
 }));
 
-// Narrows contextProps to the refactored context's own shape (rather than
-// RenderWithContextOptions' generic legacy-or-refactored union), so a stale
-// field name is caught at compile time instead of being silently dropped.
-type RenderBottomBarOptions = Omit<
-  RenderWithContextOptions,
-  'contextProps' | 'useRefactoredContext'
-> & {
-  contextProps?: Partial<ItemViewerContextProps>;
-};
-
-function renderBottomBar(options: RenderBottomBarOptions = {}) {
+function renderBottomBar(options: RenderWithRefactoredContextOptions = {}) {
   return renderWithContext(<ViewerBottomBar />, {
     appContext: { isEnhanced: true, isFullSupportBrowser: true },
     useRefactoredContext: true,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import {
   renderWithContext,
   RenderWithContextOptions,
@@ -31,9 +32,19 @@ const pdfRendering: TransformedManifest['rendering'] = [
   },
 ];
 
+// Narrows contextProps to the refactored context's own shape (rather than
+// RenderWithContextOptions' generic legacy-or-refactored union), so a stale
+// field name is caught at compile time instead of being silently dropped.
+type RenderTopBarOptions = Omit<
+  RenderWithContextOptions,
+  'contextProps' | 'useRefactoredContext'
+> & {
+  contextProps?: Partial<ItemViewerContextProps>;
+};
+
 // Renders ViewerTopBar with the enhanced/full-support defaults most of these
 // characterisations need, merging in any per-test overrides.
-const renderTopBar = (options: RenderWithContextOptions = {}) =>
+const renderTopBar = (options: RenderTopBarOptions = {}) =>
   renderWithContext(<ViewerTopBar iiifImageLocation={undefined} />, {
     appContext: { isEnhanced: true, isFullSupportBrowser: true },
     useRefactoredContext: true,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
@@ -1,9 +1,8 @@
 import { screen } from '@testing-library/react';
 
-import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import {
   renderWithContext,
-  RenderWithContextOptions,
+  RenderWithRefactoredContextOptions,
 } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockCanvas,
@@ -32,19 +31,9 @@ const pdfRendering: TransformedManifest['rendering'] = [
   },
 ];
 
-// Narrows contextProps to the refactored context's own shape (rather than
-// RenderWithContextOptions' generic legacy-or-refactored union), so a stale
-// field name is caught at compile time instead of being silently dropped.
-type RenderTopBarOptions = Omit<
-  RenderWithContextOptions,
-  'contextProps' | 'useRefactoredContext'
-> & {
-  contextProps?: Partial<ItemViewerContextProps>;
-};
-
 // Renders ViewerTopBar with the enhanced/full-support defaults most of these
 // characterisations need, merging in any per-test overrides.
-const renderTopBar = (options: RenderTopBarOptions = {}) =>
+const renderTopBar = (options: RenderWithRefactoredContextOptions = {}) =>
   renderWithContext(<ViewerTopBar iiifImageLocation={undefined} />, {
     appContext: { isEnhanced: true, isFullSupportBrowser: true },
     useRefactoredContext: true,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 
-import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext';
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockCanvas,


### PR DESCRIPTION
## What does this change?

`ItemViewerContext` comes in two versions — legacy and the new refactored one (behind the `itemViewerRefactor` flag, see RFC 086). Until now they were exact copies, so one shared file exported legacy's type and both sides used it. Now that the refactored version is starting to gain its own fields, that setup meant a component could quietly end up reading legacy's version of the context while thinking it had refactored's — TypeScript wouldn't catch the mismatch.

This PR makes that mismatch impossible to miss:

- Added a field, `isRefactoredContext`, that's always `true` on the refactored context and `false` on legacy. TypeScript can now tell the two apart, so `useItemViewerContext()` correctly returns "either the legacy shape or the refactored shape" instead of treating them as interchangeable.
- Legacy and refactored components now each import their own context file directly, instead of going through the shared one. So changes to one side's fields can no longer leak into the other by accident.
- Updated the test helper (`test/fixtures/iiif/render.tsx`) so it builds the right kind of mock context for whichever version a test is checking, and closed a gap where a test could end up mounting the wrong version without any error.
- `useIIIFProbeService`'s tests now run once against legacy and once against refactored, so if either side's fields drift apart in future, the tests will catch it.
- Removed a duplicated empty-search-results value that had been copy-pasted into both context files, moving it to one shared place instead.

Nothing here changes what users see or how the site behaves — it's all about making sure the code can't quietly drift out of sync as the refactor continues.

## How to test

Do tests pass? Does it run ok locally?

## Have we considered potential risks?

Low risk — everything here is type-checking and test setup, not live code.