### PR TITLE
Add boolean JSX rule and amend across codebase

### DIFF
--- a/cardigan/stories/components/Modals/InactivityRedirect/InactivityRedirect.stories.tsx
+++ b/cardigan/stories/components/Modals/InactivityRedirect/InactivityRedirect.stories.tsx
@@ -8,7 +8,7 @@ type StoryProps = ComponentProps<typeof InactivityRedirect>;
 const CountdownPreview = () => {
   return (
     <div>
-      <InactivityRedirect isCardiganStory={true} />
+      <InactivityRedirect isCardiganStory />
     </div>
   );
 };

--- a/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
+++ b/cardigan/stories/components/PageHeader/PageHeader.stories.tsx
@@ -149,7 +149,7 @@ export const Article: Meta<typeof PageHeader> = {
           }),
           image(florenceWinterfloodImageUrl('3200x3200'), 3200, 3200),
         ]}
-        isFull={true}
+        isFull
       />
     ),
     ContentTypeInfo,
@@ -183,7 +183,7 @@ export const ShortFilm: Meta<typeof PageHeader> = {
               <PageHeader
                 {...args}
                 variant="basic"
-                isContentTypeInfoBeforeMedia={true}
+                isContentTypeInfoBeforeMedia
                 ContentTypeInfo={ContentTypeInfo}
                 labels={{ labels: [{ text: 'Short film' }] }}
                 title="Audrey's archivist"
@@ -279,10 +279,7 @@ export const Event: Meta<typeof PageHeader> = {
     ),
     isContentTypeInfoBeforeMedia: true,
     Background: (
-      <HeaderBackground
-        hasWobblyEdge={true}
-        backgroundTexture={headerBackgroundLs}
-      />
+      <HeaderBackground hasWobblyEdge backgroundTexture={headerBackgroundLs} />
     ),
   },
 };
@@ -313,7 +310,7 @@ export const Exhibition: Meta<typeof PageHeader> = {
           }),
           image(florenceWinterfloodImageUrl('3200x3200'), 3200, 3200),
         ]}
-        isFull={true}
+        isFull
       />
     ),
     ContentTypeInfo: (

--- a/common/views/components/BorderlessClickable/index.tsx
+++ b/common/views/components/BorderlessClickable/index.tsx
@@ -68,17 +68,17 @@ const Button: ForwardRefRenderFunction<
       ref={ref}
       {...elementProps}
     >
-      <BaseButtonInner $isInline={true}>
+      <BaseButtonInner $isInline>
         <>
           {iconLeft && (
-            <ButtonIconWrapper $iconAfter={false}>
+            <ButtonIconWrapper>
               {/* This is all a little hacky and will need some tidy up */}
               {/* We currently only use this in the header sign in button */}
               <span
                 className={typography('body', 'lg', 'regular')}
                 style={{ transform: 'translateY(0.01em)' }}
               >
-                <Icon icon={iconLeft} matchText={true} />
+                <Icon icon={iconLeft} matchText />
               </span>
             </ButtonIconWrapper>
           )}
@@ -90,7 +90,7 @@ const Button: ForwardRefRenderFunction<
             {text}
           </span>
           {icon && (
-            <ButtonIconWrapper $iconAfter={true}>
+            <ButtonIconWrapper $iconAfter>
               <Icon icon={icon} />
             </ButtonIconWrapper>
           )}

--- a/common/views/components/Buttons/Buttons.Dropdown.tsx
+++ b/common/views/components/Buttons/Buttons.Dropdown.tsx
@@ -234,7 +234,7 @@ const DropdownButton: FunctionComponent<
           <Dropdown
             id={id}
             ref={dropdownRef}
-            $isActive={true}
+            $isActive
             $isEnhanced={isEnhanced}
             $isTight={!!isTight}
           >

--- a/common/views/components/Footer/index.tsx
+++ b/common/views/components/Footer/index.tsx
@@ -208,7 +208,7 @@ const Footer: FunctionComponent<Props> = ({
         {!isSimpleFooter && (
           <FooterNavigationContainer>
             <FindUsContainer>
-              <FindUs hideAccessibility={true} />
+              <FindUs hideAccessibility />
             </FindUsContainer>
 
             <OpeningTimesContainer>

--- a/common/views/components/Header/Header.SignIn.Desktop.tsx
+++ b/common/views/components/Header/Header.SignIn.Desktop.tsx
@@ -41,8 +41,8 @@ const DesktopSignIn: FunctionComponent = () => {
       <BorderlessLink
         iconLeft={userIcon}
         text="Library account"
-        isTextHidden={true}
         href="/account"
+        isTextHidden
       />
     </span>
   ) : (

--- a/common/views/components/Header/Header.SignIn.Mobile.tsx
+++ b/common/views/components/Header/Header.SignIn.Mobile.tsx
@@ -51,7 +51,7 @@ const MobileSignIn: FunctionComponent = () => {
         $h={{ size: 'xs', properties: ['margin-right'] }}
         className={typography('body', 'lg', 'regular')}
       >
-        <Icon icon={userIcon} matchText={true} />
+        <Icon icon={userIcon} matchText />
       </Space>
       {!user && (
         <a

--- a/common/views/components/HeaderBackground/index.tsx
+++ b/common/views/components/HeaderBackground/index.tsx
@@ -49,9 +49,9 @@ const HeaderBackground: FunctionComponent<Props> = ({
         <WobblyEdgeContainer>
           <DecorativeEdge
             variant="wobbly"
-            isValley={true}
             intensity={100}
             backgroundColor="white"
+            isValley
           />
         </WobblyEdgeContainer>
       )}

--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -219,9 +219,9 @@ const InactivityRedirect: FunctionComponent<{ isCardiganStory?: boolean }> = ({
       setIsActive={handleCancelRedirect}
       id="kiosk-inactivity-warning"
       openButtonRef={modalButtonRef}
-      showOverlay={true}
       modalStyle="inactivity"
       maxWidth="550px"
+      showOverlay
     >
       <InactivityRedirectModal
         countdown={countdown}

--- a/common/views/components/NewsletterPromo/index.tsx
+++ b/common/views/components/NewsletterPromo/index.tsx
@@ -132,7 +132,6 @@ const NewsletterPromo: FunctionComponent = () => {
                   value={newsletterAddressBook.id}
                 />
                 <TextInput
-                  required={true}
                   id="newsletter-input"
                   type="email"
                   name="email"
@@ -145,6 +144,7 @@ const NewsletterPromo: FunctionComponent = () => {
                   }
                   value={value}
                   setValue={setValue}
+                  required
                   {...emailValidation}
                 />
 

--- a/common/views/components/SearchBar/SearchBar.New.tsx
+++ b/common/views/components/SearchBar/SearchBar.New.tsx
@@ -241,8 +241,8 @@ const SearchBar: FunctionComponent<Props> = ({
           ref={inputRef || defaultInputRef}
           form={form}
           hasClearButton
-          isNewSearchBar={true}
           placeholder=" " // This empty placeholder is required for the :placeholder-shown CSS selector to work
+          isNewSearchBar
         />
       </SearchInputWrapper>
       <SearchButtonWrapper>
@@ -253,7 +253,7 @@ const SearchBar: FunctionComponent<Props> = ({
           form={form}
           colors={theme.buttonColors.greenGreenWhite}
           icon={search}
-          isNewSearchBar={true}
+          isNewSearchBar
         />
       </SearchButtonWrapper>
     </Container>

--- a/common/views/components/TextInput/TextInput.test.tsx
+++ b/common/views/components/TextInput/TextInput.test.tsx
@@ -18,9 +18,9 @@ const ExampleTextInput = () => {
       type="email"
       value={value}
       setValue={setValue}
-      required={true}
       errorMessage="This input has an error"
       successMessage="This input is valid"
+      required
       {...useValidation()}
     />
   );

--- a/common/views/components/VideoEmbed/index.tsx
+++ b/common/views/components/VideoEmbed/index.tsx
@@ -90,10 +90,10 @@ const VideoEmbed: FunctionComponent<Props> = ({
             <iframe
               className="iframe"
               title="Video"
-              allowFullScreen={true}
               allow="autoplay; picture-in-picture"
               src={videoSrc}
               style={{ border: 0 }}
+              allowFullScreen
             />
           ) : (
             <VideoTrigger

--- a/common/views/layouts/ErrorPage/index.tsx
+++ b/common/views/layouts/ErrorPage/index.tsx
@@ -207,7 +207,7 @@ const ErrorPage: NextPage<Props> = ({ statusCode = 500, title }) => {
       url={{ pathname: '/' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
-      hideNewsletterPromo={true}
+      hideNewsletterPromo
     >
       <Space $v={{ size: headerSpaceSize, properties: ['padding-bottom'] }}>
         <PageHeader
@@ -216,7 +216,7 @@ const ErrorPage: NextPage<Props> = ({ statusCode = 500, title }) => {
           labels={undefined}
           title={errorMessage}
           backgroundTexture={headerBackgroundLs}
-          highlightHeading={true}
+          highlightHeading
         />
         <SpacingSection>
           <SpacingComponent>

--- a/content/webapp/test/components/WorkDetailsText.test.tsx
+++ b/content/webapp/test/components/WorkDetailsText.test.tsx
@@ -6,7 +6,7 @@ describe('WorkDetailsText', () => {
     const { container } = renderWithTheme(
       <WorkDetailsText
         html={['This is <strong>bold</strong> text']}
-        allowDangerousRawHtml={true}
+        allowDangerousRawHtml
       />
     );
 
@@ -17,7 +17,7 @@ describe('WorkDetailsText', () => {
     const { container } = renderWithTheme(
       <WorkDetailsText
         text={['You write HTML with angle brackets like <em>']}
-        allowDangerousRawHtml={true}
+        allowDangerousRawHtml
       />
     );
     expect(container.outerHTML.includes('&lt;em&gt;')).toBe(true);

--- a/content/webapp/utils/page-header.tsx
+++ b/content/webapp/utils/page-header.tsx
@@ -79,7 +79,7 @@ export const HeroPicture: FunctionComponent<{
   return (
     <Picture
       images={[{ ...widescreenImage, minWidth: theme.sizes.sm }, squareImage]}
-      isFull={true}
+      isFull
       priority
     />
   );

--- a/content/webapp/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
+++ b/content/webapp/views/components/AudioPlayer/AudioPlayer.PlayRate.tsx
@@ -185,7 +185,7 @@ const PlayRate: FunctionComponent<PlayRateProps> = ({
                       <span
                         style={{ transform: 'scale(1.5)', display: 'flex' }}
                       >
-                        <Icon icon={check} matchText={true} />
+                        <Icon icon={check} matchText />
                       </span>
                     )}
                   </span>

--- a/content/webapp/views/components/Body/index.tsx
+++ b/content/webapp/views/components/Body/index.tsx
@@ -212,7 +212,6 @@ const Body: FunctionComponent<Props> = ({
               {...firstItemProps}
               background={sectionTheme.featuredCardBackground}
               textColor={sectionTheme.featuredCardText}
-              isReversed={false}
               priority={isFirst}
             >
               <h3 className={typography('heading', 'xl', 'strong', 'brand')}>

--- a/content/webapp/views/components/ContentPage/ContentPage.BannerCard.tsx
+++ b/content/webapp/views/components/ContentPage/ContentPage.BannerCard.tsx
@@ -147,9 +147,9 @@ const BannerCard: FunctionComponent<Props> = ({
         <Button
           variant="ButtonSolid"
           colors={theme.buttonColors.whiteTransparentWhite}
-          isIconAfter={true}
           icon={arrowSmall}
           text={`Explore ${type}`}
+          isIconAfter
         />
       </TextWrapper>
       {image && (

--- a/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
+++ b/content/webapp/views/components/Contributors/Contributors.Contributor.tsx
@@ -101,7 +101,7 @@ const Contributor: FunctionComponent<ContributorType> = ({
                 image={contributorImage}
                 maxWidth={72}
                 quality="low"
-                desaturate={true}
+                desaturate
               />
             </PeopleImage>
           )}
@@ -115,7 +115,6 @@ const Contributor: FunctionComponent<ContributorType> = ({
                 image={contributorImage}
                 maxWidth={72}
                 quality="low"
-                desaturate={false}
               />
             </OrganisationImage>
           )}

--- a/content/webapp/views/components/CopyButtons/CopyButtons.Content.tsx
+++ b/content/webapp/views/components/CopyButtons/CopyButtons.Content.tsx
@@ -79,7 +79,7 @@ const CopyContent: FunctionComponent<Props> = ({
             ref={buttonRef}
             text={getButtonMarkup()}
             icon={isTextCopied ? check : undefined}
-            isIconAfter={true}
+            isIconAfter
           />
         </ButtonContainer>
       )}

--- a/content/webapp/views/components/CopyButtons/CopyButtons.Url.tsx
+++ b/content/webapp/views/components/CopyButtons/CopyButtons.Url.tsx
@@ -81,7 +81,7 @@ const CopyUrl: FunctionComponent<Props> = ({
             ref={buttonRef}
             text={getButtonMarkup()}
             icon={isTextCopied ? check : undefined}
-            isIconAfter={true}
+            isIconAfter
           />
         </Space>
       )}

--- a/content/webapp/views/components/DateRange/DateRange.test.tsx
+++ b/content/webapp/views/components/DateRange/DateRange.test.tsx
@@ -31,7 +31,7 @@ describe('DateRange', () => {
     const end   = new Date('2022-09-18T14:30:00+0100'); // prettier-ignore
 
     const { container } = renderWithTheme(
-      <DateRange start={start} end={end} splitTime={true} />
+      <DateRange start={start} end={end} splitTime />
     );
     expect(container.innerHTML).toEqual(
       '<time datetime="2022-09-18T11:00:00.000Z">Sunday 18 September 2022</time><span style="display: block;"><time datetime="2022-09-18T11:00:00.000Z">12:00</time> – <time datetime="2022-09-18T13:30:00.000Z">14:30</time></span>'

--- a/content/webapp/views/components/EventCard/index.tsx
+++ b/content/webapp/views/components/EventCard/index.tsx
@@ -166,8 +166,8 @@ const EventCard: FunctionComponent<Props> = ({
               <DateInfo>
                 <EventDateRange
                   eventTimes={event.times}
-                  splitTime={true}
                   fromDate={fromDate}
+                  splitTime
                 />
               </DateInfo>
               {dateString && <DateInfo>{dateString}</DateInfo>}

--- a/content/webapp/views/components/EventbriteButtons/index.tsx
+++ b/content/webapp/views/components/EventbriteButtons/index.tsx
@@ -30,7 +30,7 @@ const EventbriteButtons: FunctionComponent<Props> = ({ event }) => {
   return (
     <div data-component="eventbrite-buttons">
       {event.isCompletelySoldOut ? (
-        <Button variant="ButtonSolid" disabled={true} text="Fully booked" />
+        <Button variant="ButtonSolid" text="Fully booked" disabled />
       ) : (
         <>
           {event.eventbriteId && (
@@ -45,11 +45,7 @@ const EventbriteButtons: FunctionComponent<Props> = ({ event }) => {
                 }}
               >
                 {event.inVenueSoldOut ? (
-                  <Button
-                    variant="ButtonSolid"
-                    disabled={true}
-                    text="Fully booked"
-                  />
+                  <Button variant="ButtonSolid" text="Fully booked" disabled />
                 ) : (
                   <Button
                     variant="ButtonSolidLink"
@@ -71,11 +67,7 @@ const EventbriteButtons: FunctionComponent<Props> = ({ event }) => {
               {isHybridEvent && <Location>Livestream event</Location>}
               <Space $v={{ size: 'xs', properties: ['margin-bottom'] }}>
                 {event.onlineSoldOut ? (
-                  <Button
-                    variant="ButtonSolid"
-                    disabled={true}
-                    text="Fully booked"
-                  />
+                  <Button variant="ButtonSolid" text="Fully booked" disabled />
                 ) : (
                   <Button
                     variant="ButtonSolidLink"

--- a/content/webapp/views/components/EventsSearchResults/index.tsx
+++ b/content/webapp/views/components/EventsSearchResults/index.tsx
@@ -154,8 +154,8 @@ const EventsSearchResults: FunctionComponent<Props> = ({
                     <DateInfo>
                       <EventDateRange
                         eventTimes={times}
-                        splitTime={true}
                         isInPastListing={isInPastListing}
+                        splitTime
                       />
                     </DateInfo>
                   )}

--- a/content/webapp/views/components/IIIFImage/IIIFImage.test.tsx
+++ b/content/webapp/views/components/IIIFImage/IIIFImage.test.tsx
@@ -13,7 +13,7 @@ describe('IIIFImage', () => {
 
   it('renders a IIIF image URL', async () => {
     const { findByRole } = renderWithTheme(
-      <IIIFImage image={props} priority={true} layout="fixed" />
+      <IIIFImage image={props} layout="fixed" priority />
     );
 
     const image = await findByRole('img');

--- a/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
+++ b/content/webapp/views/components/ImageGallery/ImageGallery.ComicPreviousNext.tsx
@@ -117,20 +117,20 @@ const ComicPreviousNext: FunctionComponent<Props> = ({ previous, next }) => {
               <Title>{previous.title}</Title>
             </TextWrap>
             <Chevron $isNext={false}>
-              <Icon icon={chevron} rotate={90} matchText={true} />
+              <Icon icon={chevron} rotate={90} matchText />
             </Chevron>
           </Inner>
         </Link>
       )}
       {next && (
-        <Link href={`/stories/${next.uid}`} $isNext={true}>
-          <Inner $isNext={true}>
-            <TextWrap $isNext={true}>
+        <Link href={`/stories/${next.uid}`} $isNext>
+          <Inner $isNext>
+            <TextWrap $isNext>
               <InSeries>Next in this series</InSeries>
               <Title>{next.title}</Title>
             </TextWrap>
-            <Chevron $isNext={true}>
-              <Icon icon={chevron} rotate={270} matchText={true} />
+            <Chevron $isNext>
+              <Icon icon={chevron} rotate={270} matchText />
             </Chevron>
           </Inner>
         </Link>

--- a/content/webapp/views/components/ImageGallery/index.tsx
+++ b/content/webapp/views/components/ImageGallery/index.tsx
@@ -175,8 +175,8 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
               <StandaloneWobblyEdge>
                 <DecorativeEdge
                   variant="wobbly"
-                  isRotated={true}
                   backgroundColor="white"
+                  isRotated
                 />
               </StandaloneWobblyEdge>
             )}
@@ -198,11 +198,11 @@ const ImageGallery: FunctionComponent<{ id: string } & Props> = ({
                     ariaExpanded={isActive}
                     dataGtmTrigger="hide_image_gallery"
                     ref={closeButtonRef}
-                    replace={true}
                     colorScheme="light"
                     text="close"
                     icon={cross}
                     clickHandler={handleCloseClicked}
+                    replace
                   />
                 </ControlContainer>
               </CloseWrapper>

--- a/content/webapp/views/components/InPageNavigation/index.tsx
+++ b/content/webapp/views/components/InPageNavigation/index.tsx
@@ -204,8 +204,8 @@ const InPageNavigation: FunctionComponent<Props> = ({
           consider removing once moved to v21 */}
           {createPortal(
             <BackgroundOverlay
-              data-lock-scroll={true}
               onClick={() => setIsListActive(false)}
+              data-lock-scroll
             />,
             document.body
           )}

--- a/content/webapp/views/components/PortraitVideoList/index.tsx
+++ b/content/webapp/views/components/PortraitVideoList/index.tsx
@@ -155,9 +155,9 @@ const PortraitVideoList: FunctionComponent<Props> = ({
               key={activeIndex}
               ref={iframeRef}
               title={activeItem?.title || 'Video'}
-              allowFullScreen={true}
               allow={iframeAllow}
               src={videoSrc}
+              allowFullScreen
             />
           )}
           {activeItem?.transcript && (

--- a/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Hover.tsx
+++ b/content/webapp/views/components/RelatedWorksCard/RelatedWorksCard.Hover.tsx
@@ -26,9 +26,9 @@ const RelatedWorksCard: FunctionComponent<Props> = ({ work }) => {
       style={{ textAlign: 'left' }}
       data-component="related-works-card-hover"
     >
-      <Card as="span" $isHover={true}>
+      <Card as="span" $isHover>
         {thumbnailUrl && (
-          <ImageWrapper $isHover={true}>
+          <ImageWrapper $isHover>
             <img
               src={convertIiifImageUri(thumbnailUrl, 250)}
               alt={work.title}
@@ -38,7 +38,7 @@ const RelatedWorksCard: FunctionComponent<Props> = ({ work }) => {
           </ImageWrapper>
         )}
         <TextWrapper>
-          <Title as="span" $isHover={true} $linesToClamp={1}>
+          <Title as="span" $linesToClamp={1} $isHover>
             {work.title}
           </Title>
 

--- a/content/webapp/views/components/SearchFilters/ResetActiveFilters.tsx
+++ b/content/webapp/views/components/SearchFilters/ResetActiveFilters.tsx
@@ -52,7 +52,7 @@ const CancelFilter: FunctionComponent<CancelFilterProps> = ({
   return (
     <Space as="span" $h={{ size: 'sm', properties: ['margin-right'] }}>
       <IconWrapper as="span">
-        <Icon icon={cross} matchText={true} iconColor="neutral.500" />
+        <Icon icon={cross} iconColor="neutral.500" matchText />
       </IconWrapper>
       <span className="visually-hidden">remove </span>
       {text || children}

--- a/content/webapp/views/components/TextAndImageOrIcons/index.tsx
+++ b/content/webapp/views/components/TextAndImageOrIcons/index.tsx
@@ -99,7 +99,7 @@ const TextAndImageOrIcons: FunctionComponent<Props> = ({ item }) => {
     <DividingLine data-component="text-and-image-or-icons">
       <MediaAndTextWrap>
         {item.type === 'icons' && icons.length > 0 && (
-          <ImageOrIcons $isIcons={true}>
+          <ImageOrIcons $isIcons>
             {/* We're enforcing a maximum of 6 icons within a slice  */}
             {icons.slice(0, 6).map((icon, index) => {
               return (

--- a/content/webapp/views/components/WatchLabel/index.tsx
+++ b/content/webapp/views/components/WatchLabel/index.tsx
@@ -41,7 +41,7 @@ type Props = {
 const WatchLabel: FunctionComponent<Props> = ({ text }) => (
   <Wrapper data-component="watch-label">
     <WatchIconWrapper>
-      <Icon icon={play} matchText={true} />
+      <Icon icon={play} matchText />
     </WatchIconWrapper>
     <WatchText>{text}</WatchText>
   </Wrapper>

--- a/content/webapp/views/layouts/SearchPageLayout/SearchNavigation.tsx
+++ b/content/webapp/views/layouts/SearchPageLayout/SearchNavigation.tsx
@@ -191,13 +191,13 @@ const SearchNavigation: FunctionComponent<SearchNavigationProps> = ({
         )}
       </form>
       {!semanticSearchPrototype && (
-        <TabsBorder $visible={true}>
+        <TabsBorder $visible>
           <Tabs
             tabBehaviour="navigate"
-            hideBorder={true}
             label="Search Categories"
             items={tabItems}
             currentSection={currentSearchCategory}
+            hideBorder
           />
         </TabsBorder>
       )}

--- a/content/webapp/views/pages/about-us/cookie-policy.tsx
+++ b/content/webapp/views/pages/about-us/cookie-policy.tsx
@@ -26,7 +26,7 @@ const CookieTable = ({ rows }: { rows: string[][] }) => {
   return (
     <SpacingComponent>
       <ContaineredLayout gridSizes={gridSize8()}>
-        <Table rows={rows} withBorder={true} hasSmallerCopy></Table>
+        <Table rows={rows} withBorder hasSmallerCopy />
       </ContaineredLayout>
     </SpacingComponent>
   );
@@ -60,18 +60,18 @@ const CookiePolicyPage: NextPage<page.Props> = props => {
     <PageLayout
       title={props.page.title}
       description={props.page.metadataDescription || ''}
-      hideNewsletterPromo={true}
       url={{ pathname: '/about-us/cookie-policy' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
       siteSection={props.page.siteSection}
+      hideNewsletterPromo
     >
       <PageHeader
         variant="basic"
         breadcrumbs={{ items: [] }}
         title={props.page.title}
         backgroundTexture={landingHeaderBackgroundLs}
-        highlightHeading={true}
+        highlightHeading
       />
       <ConditionalWrapper
         condition={isTwoColumns}

--- a/content/webapp/views/pages/books/book/index.tsx
+++ b/content/webapp/views/pages/books/book/index.tsx
@@ -66,7 +66,7 @@ const BookPage: NextPage<Props> = ({ book }) => {
       title={book.title}
       FeaturedMedia={FeaturedMedia}
       ContentTypeInfo={book.subtitle && <Subtitle>{book.subtitle}</Subtitle>}
-      isContentTypeInfoBeforeMedia={true}
+      isContentTypeInfoBeforeMedia
     />
   );
 

--- a/content/webapp/views/pages/books/index.tsx
+++ b/content/webapp/views/pages/books/index.tsx
@@ -56,7 +56,7 @@ const BooksPage: NextPage<Props> = ({ books }) => {
             )
           }
           backgroundTexture={headerBackgroundLs}
-          highlightHeading={true}
+          highlightHeading
         />
 
         {books.totalPages > 1 && (

--- a/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
+++ b/content/webapp/views/pages/collections/collections.BrowseByThemes.tsx
@@ -129,11 +129,7 @@ const BrowseByThemes: FunctionComponent<BrowseByThemeProps> = ({
             {announcement}
           </div>
 
-          <SelectableTags
-            tags={tagData}
-            isMultiSelect={false}
-            onChange={handleCategoryChange}
-          />
+          <SelectableTags tags={tagData} onChange={handleCategoryChange} />
         </Space>
       </ContaineredLayout>
 

--- a/content/webapp/views/pages/collections/index.tsx
+++ b/content/webapp/views/pages/collections/index.tsx
@@ -122,10 +122,7 @@ const CollectionsLandingPage: NextPage<Props> = ({
       </div>
 
       {hasValidThemeCardSlices(themeCardsListSlices) && (
-        <MainBackground
-          data-component="full-width-banner"
-          $isDefaultVariant={true}
-        >
+        <MainBackground data-component="full-width-banner" $isDefaultVariant>
           <Space $v={{ size: 'xl', properties: ['margin-top'] }}>
             <Space $v={{ size: 'md', properties: ['margin-bottom'] }}>
               <SectionHeader title="Browse by theme" gridSize={gridSize12()} />

--- a/content/webapp/views/pages/collections/new-online/index.tsx
+++ b/content/webapp/views/pages/collections/new-online/index.tsx
@@ -63,7 +63,7 @@ const NewOnlinePage: NextPage<Props> = ({ works, apiToolbarLinks }) => {
             )
           }
           backgroundTexture={headerBackgroundLs}
-          highlightHeading={true}
+          highlightHeading
         />
 
         {works.totalPages > 1 && (

--- a/content/webapp/views/pages/concepts/concept/index.tsx
+++ b/content/webapp/views/pages/concepts/concept/index.tsx
@@ -123,10 +123,10 @@ const ConceptPage: NextPage<Props> = ({
         openGraphType="website"
         siteSection="collections"
         jsonLd={{ '@type': 'WebPage' }}
-        hideNewsletterPromo={true}
         apiToolbarLinks={apiToolbarLinks}
-        clipOverflowX={true}
         headerProps={{ hasColorBackground: true }}
+        hideNewsletterPromo
+        clipOverflowX
       >
         <ThemeHeader concept={conceptResponse} hasImages={hasImages} />
 

--- a/content/webapp/views/pages/event-series/index.tsx
+++ b/content/webapp/views/pages/event-series/index.tsx
@@ -55,7 +55,7 @@ const EventSeriesPage: NextPage<Props> = ({
       breadcrumbs={breadcrumbs}
       labels={{ labels: series.labels }}
       title={series.title}
-      Background={<HeaderBackground hasWobblyEdge={true} />}
+      Background={<HeaderBackground hasWobblyEdge />}
       FeaturedMedia={FeaturedMedia}
     />
   );

--- a/content/webapp/views/pages/events/event/index.tsx
+++ b/content/webapp/views/pages/events/event/index.tsx
@@ -171,8 +171,8 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
         FeaturedMedia={maybeFeaturedMedia}
         Background={
           <HeaderBackground
-            hasWobblyEdge={true}
             backgroundTexture={headerBackgroundLs}
+            hasWobblyEdge
           />
         }
         ContentTypeInfo={
@@ -199,7 +199,7 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
           </>
         }
         isFree={!event.cost}
-        isContentTypeInfoBeforeMedia={true}
+        isContentTypeInfoBeforeMedia
       />
 
       {event.bslLeafletVideo && (
@@ -238,7 +238,7 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
         }
         seasons={event.seasons}
         // We hide contributors as we render them higher up the page on events
-        hideContributors={true}
+        hideContributors
       >
         <DateWrapper>
           <h2 id="dates">Dates</h2>
@@ -267,8 +267,8 @@ const EventPage: NextPage<Props> = ({ event, accessResourceLinks, jsonLd }) => {
                   <>
                     <Button
                       variant="ButtonSolid"
-                      disabled={true}
                       text="Fully booked"
+                      disabled
                     />
                   </>
                 ) : (

--- a/content/webapp/views/pages/events/index.tsx
+++ b/content/webapp/views/pages/events/index.tsx
@@ -117,7 +117,7 @@ const EventsPage: NextPage<Props> = props => {
           variant="basic"
           breadcrumbs={getBreadcrumbItems('whats-on')}
           title="Events"
-          isSlim={true}
+          isSlim
         />
 
         {pageDescriptions.events && (

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.BeingHuman.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.BeingHuman.tsx
@@ -126,7 +126,7 @@ const ExhibitionBeingHuman: FunctionComponent<Props> = ({
                         key={i}
                         href={pdf.url}
                         $borderColor={borderColor}
-                        $underlineText={true}
+                        $underlineText
                       >
                         <span className={typography('body', 'md', 'regular')}>
                           {`${pdf.text} PDF`} {`(${pdf.size}kb)`}

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Exhibition.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Exhibition.tsx
@@ -114,7 +114,6 @@ const Exhibition: FunctionComponent<Props> = ({
         breadcrumbs={getBreadcrumbItems('whats-on', extraBreadcrumbs)}
         labels={{ labels: exhibition.labels }}
         title={exhibition.title}
-        fullWidth={true}
         ContentTypeInfo={
           <>
             {!exhibition.isPermanent && (
@@ -132,7 +131,7 @@ const Exhibition: FunctionComponent<Props> = ({
                   start={exhibition.start}
                   end={exhibition.end || new Date()}
                   statusOverride={exhibition.statusOverride}
-                  isLarge={true}
+                  isLarge
                 />
               </Space>
             )}
@@ -142,9 +141,10 @@ const Exhibition: FunctionComponent<Props> = ({
         HeroPicture={
           hasHeroPicture ? <HeroPicture fields={exhibition} /> : undefined
         }
-        isFree={true}
-        isContentTypeInfoBeforeMedia={true}
-        includeAccessibilityProvision={true}
+        fullWidth
+        isFree
+        isContentTypeInfoBeforeMedia
+        includeAccessibilityProvision
       />
 
       {exhibition.bslLeafletVideo && (
@@ -172,7 +172,7 @@ const Exhibition: FunctionComponent<Props> = ({
         />
       }
       seasons={exhibition.seasons}
-      hideContributors={true} // We hide contributors as we show them further up the page
+      hideContributors // We hide contributors as we show them further up the page
     >
       {exhibition.uid === 'being-human' ? (
         <ExhibitionBeingHuman

--- a/content/webapp/views/pages/exhibitions/exhibition/exhibition.Installation.tsx
+++ b/content/webapp/views/pages/exhibitions/exhibition/exhibition.Installation.tsx
@@ -80,7 +80,7 @@ const Installation: FunctionComponent<Props> = ({
         labels={{ labels: installation.labels }}
         title={installation.title}
         FeaturedMedia={FeaturedMedia}
-        Background={<HeaderBackground hasWobblyEdge={true} />}
+        Background={<HeaderBackground hasWobblyEdge />}
         ContentTypeInfo={
           <>
             {installation.start && !installation.statusOverride && (
@@ -98,7 +98,7 @@ const Installation: FunctionComponent<Props> = ({
             )}
           </>
         }
-        isContentTypeInfoBeforeMedia={true}
+        isContentTypeInfoBeforeMedia
       />
 
       {installation.bslLeafletVideo && (

--- a/content/webapp/views/pages/exhibitions/explore-more.tsx
+++ b/content/webapp/views/pages/exhibitions/explore-more.tsx
@@ -58,7 +58,6 @@ const ExploreMorePage: NextPage<Props> = ({
   return (
     <PageLayout
       title={page.title}
-      isNoIndex={true}
       description={
         page.metadataDescription ||
         exhibition.metadataDescription ||
@@ -70,6 +69,7 @@ const ExploreMorePage: NextPage<Props> = ({
       openGraphType="website"
       siteSection="whats-on"
       image={exhibition.image}
+      isNoIndex
     >
       <PageHeader
         variant="basic"
@@ -83,7 +83,7 @@ const ExploreMorePage: NextPage<Props> = ({
           },
         ])}
         title={page.title}
-        isContentTypeInfoBeforeMedia={true}
+        isContentTypeInfoBeforeMedia
         ContentTypeInfo={
           page.introText && page.introText.length > 0 ? (
             <PageHeaderStandfirst html={page.introText} />
@@ -117,7 +117,7 @@ const ExploreMorePage: NextPage<Props> = ({
           group.works.length > 0 ? (
             <div key={group.heading}>
               <ScrollContainer
-                hasWorkCards={true}
+                hasWorkCards
                 CopyContent={
                   <>
                     <h3
@@ -131,7 +131,7 @@ const ExploreMorePage: NextPage<Props> = ({
                   </>
                 }
                 gridSizes={gridSize12()}
-                useShim={true}
+                useShim
               >
                 {group.works.map(work => (
                   <ListItem key={work.id} $usesShim>
@@ -151,7 +151,7 @@ const ExploreMorePage: NextPage<Props> = ({
           <Space $v={{ size: 'md', properties: ['margin-top'] }}>
             <ScrollContainer
               gridSizes={gridSize12()}
-              useShim={true}
+              useShim
               CopyContent={
                 <p>Find the items on display in our online catalogue.</p>
               }

--- a/content/webapp/views/pages/exhibitions/index.tsx
+++ b/content/webapp/views/pages/exhibitions/index.tsx
@@ -85,7 +85,7 @@ const ExhibitionsPage: NextPage<Props> = props => {
           )
         }
         backgroundTexture={headerBackgroundLs}
-        highlightHeading={true}
+        highlightHeading
       />
       {partitionedExhibitionItems.currentAndUpcoming.length > 0 && (
         <>
@@ -119,8 +119,8 @@ const ExhibitionsPage: NextPage<Props> = props => {
           <SpacingSection>
             <CardGrid
               items={partitionedExhibitionItems.past}
-              itemsHaveTransparentBackground={true}
               itemsPerRow={3}
+              itemsHaveTransparentBackground
             />
             {exhibitions.totalPages > 1 && (
               <Container>

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/exhibition.OtherExhibitionGuides.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/exhibition.OtherExhibitionGuides.tsx
@@ -31,12 +31,12 @@ const OtherExhibitionGuides: FunctionComponent<Props> = ({
         </Space>
       </ContaineredLayout>
       <CardGrid
-        itemsHaveTransparentBackground={true}
         items={otherExhibitionGuides.map(result => ({
           ...result,
           type: 'exhibition-guides-links',
         }))}
         itemsPerRow={3}
+        itemsHaveTransparentBackground
       />
     </Space>
   </PromoContainer>

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/index.tsx
@@ -91,7 +91,7 @@ const ExhibitionGuidePage: NextPage<Props> = ({
         isMinimalHeader: true,
       }}
       apiToolbarLinks={[createPrismicLink(pageId || '')]}
-      hideNewsletterPromo={true}
+      hideNewsletterPromo
     >
       <PageHeader
         variant="basic"

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/index.tsx
@@ -107,9 +107,9 @@ const ExhibitionGuideTypePage: NextPage<Props> = ({
         customNavLinks: exhibitionGuidesLinks,
         isMinimalHeader: true,
       }}
-      hideNewsletterPromo={true}
       apiToolbarLinks={[createPrismicLink(exhibitionGuide.id)]}
       skipToContentLinks={skipToContentLinks}
+      hideNewsletterPromo
     >
       <PageHeader
         variant="basic"

--- a/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/exhibition/type/stop/index.tsx
@@ -125,10 +125,10 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
       openGraphType="website"
       siteSection="exhibition-guides"
       image={currentStop.image}
-      hideHeader={true}
-      hideFooter={true}
-      hideNewsletterPromo={true}
       apiToolbarLinks={[createPrismicLink(exhibitionGuideId)]}
+      hideHeader
+      hideFooter
+      hideNewsletterPromo
     >
       <Page>
         <Header ref={headerRef}>
@@ -186,7 +186,7 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
                       embedUrl={currentStop.video}
                       videoThumbnail={currentStop.videoThumbnail}
                       videoProvider={currentStop.videoProvider}
-                      hasFullSizePoster={true}
+                      hasFullSizePoster
                     />
                   )}
                 </>
@@ -206,7 +206,7 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
                   <CollapsibleContent
                     controlText={controlText}
                     id="stop-transcript"
-                    darkTheme={true}
+                    darkTheme
                   >
                     <PrismicHtmlBlock html={relatedText} />
                   </CollapsibleContent>
@@ -219,7 +219,7 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
         {type === 'audio-without-descriptions' && currentStop.audio && (
           <AudioPlayerNewWrapper>
             <Container>
-              <AudioPlayer audioFile={currentStop.audio} isDark={true} />
+              <AudioPlayer audioFile={currentStop.audio} isDark />
             </Container>
           </AudioPlayerNewWrapper>
         )}
@@ -235,7 +235,7 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
                       display: 'inline-block',
                     }}
                     href={`${guideTypeUrl}/${stopNumber - 1}`}
-                    shallow={true}
+                    shallow
                   >
                     <Space
                       $v={{
@@ -269,7 +269,7 @@ const ExhibitionGuideStopPage: NextPage<Props> = ({
                       display: 'inline-block',
                     }}
                     href={`${guideTypeUrl}/${stopNumber + 1}`}
-                    shallow={true}
+                    shallow
                   >
                     <Space
                       $v={{

--- a/content/webapp/views/pages/guides/exhibitions/index.tsx
+++ b/content/webapp/views/pages/guides/exhibitions/index.tsx
@@ -43,7 +43,7 @@ const ExhibitionGuidesPage: NextPage<Props> = props => {
         customNavLinks: exhibitionGuidesLinks,
         isMinimalHeader: true,
       }}
-      hideNewsletterPromo={true}
+      hideNewsletterPromo
     >
       <SpacingSection>
         <PageHeader
@@ -51,7 +51,7 @@ const ExhibitionGuidesPage: NextPage<Props> = props => {
           breadcrumbs={{ items: [], noHomeLink: true }}
           title="Digital Guides"
           backgroundTexture={headerBackgroundLs}
-          highlightHeading={true}
+          highlightHeading
         />
 
         {exhibitionGuides.totalPages > 1 && (

--- a/content/webapp/views/pages/guides/guide/index.tsx
+++ b/content/webapp/views/pages/guides/guide/index.tsx
@@ -54,8 +54,7 @@ export const Guide: FunctionComponent<Props> = ({ guide, jsonLd }) => {
       Background={displayBackground}
       ContentTypeInfo={DateInfo}
       backgroundTexture={!featuredPicture ? headerBackgroundLs : undefined}
-      highlightHeading={true}
-      isContentTypeInfoBeforeMedia={false}
+      highlightHeading
     />
   );
 

--- a/content/webapp/views/pages/index.tsx
+++ b/content/webapp/views/pages/index.tsx
@@ -141,7 +141,7 @@ const Homepage: NextPage<Props> = ({
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
                   transformedHeaderList.value.items as any[]
                 }
-                isFeaturedFirst={true}
+                isFeaturedFirst
               />
             </SpacingComponent>
           </SpacingSection>
@@ -199,8 +199,8 @@ const Homepage: NextPage<Props> = ({
             <CardGrid
               items={articles}
               itemsPerRow={4}
-              itemsHaveTransparentBackground={true}
               links={[{ text: 'All stories', url: '/stories' }]}
+              itemsHaveTransparentBackground
             />
           </SpacingComponent>
         </SpacingSection>

--- a/content/webapp/views/pages/newsletter.tsx
+++ b/content/webapp/views/pages/newsletter.tsx
@@ -21,7 +21,6 @@ const NewsletterPage: NextPage<Props> = ({ result }) => {
     <PageLayout
       title="Sign up to our newsletter"
       description={newsletterDescription}
-      hideNewsletterPromo={true}
       url={{ pathname: '/newsletter' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
@@ -32,13 +31,14 @@ const NewsletterPage: NextPage<Props> = ({ result }) => {
         height: 662,
         alt: '',
       }}
+      hideNewsletterPromo
     >
       <PageHeader
         variant="basic"
         breadcrumbs={{ items: [] }}
         title="Newsletters"
         backgroundTexture={landingHeaderBackgroundLs}
-        highlightHeading={true}
+        highlightHeading
       />
 
       <Space $v={{ size: 'xl', properties: ['margin-top'] }}>

--- a/content/webapp/views/pages/projects/project/index.tsx
+++ b/content/webapp/views/pages/projects/project/index.tsx
@@ -70,8 +70,7 @@ export const ProjectPage: NextPage<Props> = ({
       title={project.title}
       FeaturedMedia={featuredMedia}
       backgroundTexture={!featuredMedia ? headerBackgroundLs : undefined}
-      highlightHeading={true}
-      isContentTypeInfoBeforeMedia={false}
+      highlightHeading
     />
   );
 

--- a/content/webapp/views/pages/search/concepts/index.tsx
+++ b/content/webapp/views/pages/search/concepts/index.tsx
@@ -73,7 +73,7 @@ const ConceptsSearchPage: NextPage<Props> = withSearchLayout(
         <Space $v={{ size: 'md', properties: ['padding-bottom'] }}>
           <Container>
             {hasNoResults ? (
-              <SearchNoResults query={queryString} hasFilters={false} />
+              <SearchNoResults query={queryString} />
             ) : (
               <>
                 <PaginationWrapper $verticalSpacing="md">

--- a/content/webapp/views/pages/search/index.tsx
+++ b/content/webapp/views/pages/search/index.tsx
@@ -377,7 +377,6 @@ const SearchPage: NextPage<Props> = withSearchLayout(
                     <Pagination
                       totalPages={contentResults.totalPages}
                       ariaLabel="Content search results pagination"
-                      isHiddenMobile={false}
                     />
                   )}
                 </ContentResults>

--- a/content/webapp/views/pages/search/search.NoResults.test.tsx
+++ b/content/webapp/views/pages/search/search.NoResults.test.tsx
@@ -6,16 +6,14 @@ describe('SearchNoResults', () => {
   const query = 'hello-query-results';
 
   it('matches the display query param with the results', () => {
-    const { getByText } = renderWithTheme(
-      <SearchNoResults query={query} hasFilters={false} />
-    );
+    const { getByText } = renderWithTheme(<SearchNoResults query={query} />);
     expect(getByText(query));
     expect(() => getByText('with the filters you have selected')).toThrow();
   });
 
   it('displays no results with filters selected', () => {
     const { container, getByText } = renderWithTheme(
-      <SearchNoResults query={query} hasFilters={true} />
+      <SearchNoResults query={query} hasFilters />
     );
     expect(getByText(query));
     expect(

--- a/content/webapp/views/pages/seasons/season/index.tsx
+++ b/content/webapp/views/pages/seasons/season/index.tsx
@@ -77,7 +77,7 @@ const SeasonPage = ({
             gridSizes={gridSize8()}
           />
         }
-        hideContributors={true}
+        hideContributors
       />
 
       {allItems.length > 0 && (

--- a/content/webapp/views/pages/series/series/index.tsx
+++ b/content/webapp/views/pages/series/series/index.tsx
@@ -70,12 +70,12 @@ const ArticleSeriesPage: NextPage<Props> = props => {
       ContentTypeInfo={ContentTypeInfo}
       Background={
         <HeaderBackground
-          hasWobblyEdge={true}
           backgroundTexture={headerBackgroundLs}
+          hasWobblyEdge
         />
       }
       FeaturedMedia={FeaturedMedia}
-      isContentTypeInfoBeforeMedia={true}
+      isContentTypeInfoBeforeMedia
     />
   );
 
@@ -110,11 +110,11 @@ const ArticleSeriesPage: NextPage<Props> = props => {
               <CompactCard
                 variant="article"
                 article={article}
-                showPosition={true}
                 xOfY={{
                   x: index + 1,
                   y: articles.results.length + scheduledItems.length,
                 }}
+                showPosition
               />
             </SeriesItem>
           ))}

--- a/content/webapp/views/pages/stories/index.tsx
+++ b/content/webapp/views/pages/stories/index.tsx
@@ -171,13 +171,13 @@ const StoriesPage: NextPage<Props> = ({
           <CardGrid
             items={comicSeries}
             itemsPerRow={3}
-            itemsHaveTransparentBackground={true}
             links={[
               {
                 text: 'More comics',
                 url: '/search/stories?format=W7d_ghAAALWY3Ujc',
               },
             ]}
+            itemsHaveTransparentBackground
           />
         </SpacingComponent>
       </SpacingSection>

--- a/content/webapp/views/pages/stories/story/index.tsx
+++ b/content/webapp/views/pages/stories/story/index.tsx
@@ -133,7 +133,7 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
       }
       heroImageBgColor={isStandaloneImageGallery ? 'white' : 'warmNeutral.300'}
       SerialPartNumber={SerialPartNumber}
-      isContentTypeInfoBeforeMedia={true}
+      isContentTypeInfoBeforeMedia
     />
   );
 
@@ -176,7 +176,6 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
             comicPreviousNext={
               isComicFormat ? getComicPreviousNext() : undefined
             }
-            isDropCapped={true}
             pageId={article.id}
             pageUid={article.uid}
             gridSizes={isPodcast ? gridSize10() : gridSize8()}
@@ -187,6 +186,7 @@ const ArticlePage: NextPage<Props> = ({ article, serverData, jsonLd }) => {
                   ? 'standalone-image-gallery'
                   : undefined
             }
+            isDropCapped
           />
         }
         RelatedContent={Siblings}

--- a/content/webapp/views/pages/visual-stories/visual-story/index.tsx
+++ b/content/webapp/views/pages/visual-stories/visual-story/index.tsx
@@ -65,8 +65,8 @@ const VisualStoryPage: NextPage<Props> = ({
       }}
       labels={{ labels: [] }}
       title={visualStory.title}
-      isContentTypeInfoBeforeMedia={true}
       ContentTypeInfo={ContentTypeInfo}
+      isContentTypeInfoBeforeMedia
     />
   );
 
@@ -93,9 +93,9 @@ const VisualStoryPage: NextPage<Props> = ({
       url={{ pathname: visualStoryPath }}
       jsonLd={jsonLd}
       openGraphType="website"
-      hideNewsletterPromo={true}
       siteSection={visualStory.siteSection}
       apiToolbarLinks={[createPrismicLink(visualStory.id)]}
+      hideNewsletterPromo
     >
       <ContentPage
         id={visualStory.id}

--- a/content/webapp/views/pages/whats-on/whats-on.ClosedMessage.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.ClosedMessage.tsx
@@ -18,11 +18,7 @@ const ClosedMessage = () => {
       $v={{ size: 'md', properties: ['margin-top', 'margin-bottom'] }}
       style={{ maxWidth: theme.sizes.md }}
     >
-      <InfoBox
-        title="Exhibitions are closed today"
-        hasBiggerHeading={true}
-        items={[]}
-      >
+      <InfoBox title="Exhibitions are closed today" items={[]} hasBiggerHeading>
         <InfoIconWrapper>
           <Icon icon={information} />
         </InfoIconWrapper>

--- a/content/webapp/views/pages/works/work/ArchiveTree/index.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveTree/index.tsx
@@ -179,7 +179,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
                 firstItemTabbable={false}
                 showFirstLevelGuideline={false}
                 ItemRenderer={WorkItem}
-                shouldFetchChildren={true}
+                shouldFetchChildren
               />
             </Tree>
           </Modal>
@@ -208,7 +208,7 @@ const ArchiveTree: FunctionComponent<{ work: Work }> = ({
                 firstItemTabbable={false}
                 showFirstLevelGuideline={false}
                 ItemRenderer={WorkItem}
-                shouldFetchChildren={true}
+                shouldFetchChildren
               />
             </Tree>
           </Space>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/GridViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/GridViewer.tsx
@@ -69,13 +69,12 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
     <div style={style}>
       {scrollVelocity > 1 ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <LL $lighten={true} />
+          <LL $lighten />
         </div>
       ) : (
         currentCanvas && (
           <ThumbnailSpacer>
             <NextLink
-              replace={true}
               {...toWorksItemLink({
                 workId,
                 props: {
@@ -92,6 +91,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
                 setGridVisible(false);
               }}
               tabIndex={gridVisible ? 0 : -1}
+              replace
             >
               <IIIFCanvasThumbnail
                 canvas={currentCanvas}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
@@ -131,7 +131,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
             <>
               {!hasIconPlaceholder ? (
                 <>
-                  {!thumbnailLoaded && <LL $small={true} $lighten={true} />}
+                  {!thumbnailLoaded && <LL $small $lighten />}
 
                   <IIIFViewerImage
                     highlightImage={highlightImage}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFItem/index.tsx
@@ -454,7 +454,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           <VideoPlayer
             placeholderId={placeholderId}
             video={item}
-            showDownloadOptions={true}
+            showDownloadOptions
           />
           {showVideoTranscript && (
             <VideoTranscript
@@ -509,7 +509,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
                     label={itemLabel}
                     fileSize={getFileSize(canvas)}
                     format={'format' in original ? original.format : undefined}
-                    showWarning={true}
+                    showWarning
                   />
                 </IIIFItemWrapper>
               )
@@ -537,7 +537,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             isProbeOk={isProbeOk}
             externalAccessService={adjustedExternalAccessService}
             index={i}
-            removeRestrictedMessage={true}
+            removeRestrictedMessage
           >
             {imageContent}
           </IIIFItemWrapperWithObserver>
@@ -551,7 +551,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           isRestricted={isRestricted}
           isProbeOk={isProbeOk}
           externalAccessService={adjustedExternalAccessService}
-          removeRestrictedMessage={true}
+          removeRestrictedMessage
         >
           {imageContent}
         </IIIFItemWrapper>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFSearchWithin.tsx
@@ -96,7 +96,7 @@ const Loading = () => (
       height: '80px',
     }}
   >
-    <LL $small={true} $lighten={true} />
+    <LL $small $lighten />
     <span className="visually-hidden">Loading</span>
   </div>
 );
@@ -229,10 +229,10 @@ const IIIFSearchWithin: FunctionComponent = () => {
             name="query"
             value={value}
             setValue={setValue}
-            required={true}
             ref={inputRef}
             hasClearButton
             clearHandler={handleClearResults}
+            required
           />
         </SearchInputWrapper>
         <SearchButtonWrapper>
@@ -240,8 +240,8 @@ const IIIFSearchWithin: FunctionComponent = () => {
             variant="ButtonSolid"
             icon={search}
             text="search within"
-            isTextHidden={true}
             colors={theme.buttonColors.yellowYellowBlack}
+            isTextHidden
           />
         </SearchButtonWrapper>
       </SearchForm>
@@ -283,7 +283,6 @@ const IIIFSearchWithin: FunctionComponent = () => {
             return (
               <ListItem key={i}>
                 <NextLink
-                  replace={true}
                   {...toWorksItemLink({
                     workId: work.id,
                     props: {
@@ -296,6 +295,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
                     },
                   })}
                   onClick={() => setIsMobileSidebarActive(false)}
+                  replace
                 >
                   <Hit
                     hit={hit}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
@@ -82,7 +82,7 @@ const IIIFViewerImage = (
 
   return (
     <>
-      {!hasLoaded && isFullSupportBrowser && <LL $lighten={true} />}
+      {!hasLoaded && isFullSupportBrowser && <LL $lighten />}
       <Image
         data-testid={index !== undefined ? `image-${index}` : null}
         ref={ref}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ImageViewer.tsx
@@ -158,7 +158,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
           updateImagePosition();
         }}
         errorHandler={errorHandler}
-        zoomOnClick={true}
+        zoomOnClick
       />
       {alt ? (
         <span className="visually-hidden" id={`image-${index + 1}`}>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.tsx
@@ -274,7 +274,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     <div style={style}>
       {scrollVelocity === 3 ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <LL $lighten={true} />
+          <LL $lighten />
         </div>
       ) : (
         <>
@@ -311,8 +311,8 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
                     setImageRect={setImageRect}
                     setImageContainerRect={setImageContainerRect}
                     externalAccessService={externalAccessService}
-                    shouldScrollToUpdateUrl={true}
                     showVideoTranscript={false}
+                    shouldScrollToUpdateUrl
                   />
                 </ItemWrapper>
               );
@@ -461,7 +461,7 @@ const MainViewer: FunctionComponent = () => {
 
   if (hasOnlyRenderableImages) {
     return (
-      <MainViewerContainer $useFixedList={true} data-testid="main-viewer">
+      <MainViewerContainer data-testid="main-viewer" $useFixedList>
         <FixedSizeList
           width={mainAreaWidth}
           style={{ width: `${mainAreaWidth}px`, margin: '0 auto' }}
@@ -502,9 +502,9 @@ const MainViewer: FunctionComponent = () => {
                   canvas={currentCanvas}
                   titleOverride={`${canvas}/${canvases?.length}`}
                   exclude={[]}
-                  isDark={true}
                   externalAccessService={externalAccessService}
                   showVideoTranscript={false}
+                  isDark
                 />
               </ItemWrapper>
             )

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MultipleManifestList.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MultipleManifestList.tsx
@@ -24,7 +24,6 @@ const MultipleManifestList: FunctionComponent = () => {
           >
             <NextLink
               data-gtm-trigger="volumes_nav_link"
-              replace={true}
               {...toWorksItemLink({
                 workId: work.id,
                 props: {
@@ -41,6 +40,7 @@ const MultipleManifestList: FunctionComponent = () => {
               onClick={() => {
                 setIsMobileSidebarActive(false);
               }}
+              replace
             >
               {(manifest.label &&
                 getMultiVolumeLabel(manifest.label, work?.title || '')) ||

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/NoScriptImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/NoScriptImage.tsx
@@ -52,7 +52,7 @@ export const NoScriptImage = ({ urlTemplate, canvasOcr }: Props) => {
   return (
     <>
       <NoScriptLoadingWrapper>
-        <LL $lighten={true} />
+        <LL $lighten />
       </NoScriptLoadingWrapper>
       <DelayVisibility>
         <CanvasPaginator />

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/Paginators.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/Paginators.tsx
@@ -35,11 +35,11 @@ const PaginatorButtons = ({
           <Rotator $rotate={270}>
             <Control
               scroll={false}
-              replace={true}
               link={prevLink}
               colorScheme="light"
               icon={arrow}
               text="Previous page"
+              replace
             />
           </Rotator>
         </Space>
@@ -49,11 +49,11 @@ const PaginatorButtons = ({
           <Rotator $rotate={90}>
             <Control
               scroll={false}
-              replace={true}
               link={nextLink}
               colorScheme="light"
               icon={arrow}
               text="Next page"
+              replace
             />
           </Rotator>
         </Space>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerBottomBar.tsx
@@ -160,7 +160,6 @@ const ViewerBottomBar: FunctionComponent = () => {
               canvases.length > 1 &&
               !isMobileSidebarActive && (
                 <ToolbarSegmentedControl
-                  hideLabels={true}
                   items={[
                     {
                       id: 'pageView',
@@ -182,6 +181,7 @@ const ViewerBottomBar: FunctionComponent = () => {
                     },
                   ]}
                   activeId={gridVisible ? 'gridView' : 'pageView'}
+                  hideLabels
                 />
               )}
           </LeftZone>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerSidebar.tsx
@@ -222,7 +222,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     <>
       {isWorkVisibleWithPermission && (
         <RestrictedMessage>
-          <RestrictedItemMessage plural={true} />
+          <RestrictedItemMessage plural />
         </RestrictedMessage>
       )}
       <Inner className={typography('body', 'md', 'strong')}>
@@ -266,7 +266,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
               $h={{ size: 'xs', properties: ['margin-left'] }}
               style={{ display: 'flex', alignItems: 'center' }}
             >
-              <Icon icon={arrow} matchText={true} iconColor="white" />
+              <Icon icon={arrow} iconColor="white" matchText />
             </Space>
           </WorkLink>
         </Space>
@@ -311,8 +311,8 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
           >
             <div style={{ overflow: 'auto' }}>
               <WorksTree
-                isDarkMode={true}
                 hasStructures={Boolean(structures && structures.length > 0)}
+                isDarkMode
               >
                 <NestedList
                   currentWorkId={work.id}
@@ -322,10 +322,6 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
                   level={1}
                   tabbableId={tabbableId}
                   setTabbableId={setTabbableId}
-                  firstItemTabbable={true}
-                  showFirstLevelGuideline={true}
-                  shouldFetchChildren={false}
-                  isDarkMode={true}
                   ItemRenderer={DownloadItemRenderer}
                   itemRendererProps={{
                     linkToCanvas: true,
@@ -335,6 +331,10 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
                     itemOnClick: () => setIsMobileSidebarActive(false),
                     canvases: transformedManifest?.canvases,
                   }}
+                  firstItemTabbable
+                  showFirstLevelGuideline
+                  shouldFetchChildren={false}
+                  isDarkMode
                 />
               </WorksTree>
             </div>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerStructures.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerStructures.tsx
@@ -95,7 +95,6 @@ const Structures: FunctionComponent<Props> = ({
               condition={Boolean(nestedRanges.length === 0)}
               wrapper={children => (
                 <NextLink
-                  replace={true}
                   {...toWorksItemLink({
                     workId: work.id,
                     props: {
@@ -116,6 +115,7 @@ const Structures: FunctionComponent<Props> = ({
                   onClick={() => {
                     setIsMobileSidebarActive(false);
                   }}
+                  replace
                 >
                   {children}
                 </NextLink>

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ViewerTopBar.tsx
@@ -341,7 +341,6 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
               canvases.length > 1 &&
               isFullSupportBrowser && (
                 <ToolbarSegmentedControl
-                  hideLabels={true}
                   items={[
                     {
                       id: 'pageView',
@@ -363,6 +362,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                     },
                   ]}
                   activeId={gridVisible ? 'gridView' : 'pageView'}
+                  hideLabels
                 />
               )}
           </LeftZone>
@@ -393,8 +393,8 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                     <Download
                       ariaControlsId="itemDownloads"
                       downloadOptions={downloadOptions}
-                      useDarkControl={true}
-                      isInline={true}
+                      useDarkControl
+                      isInline
                     />
                   </Space>
                 )}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.tsx
@@ -69,13 +69,12 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
     <div style={style}>
       {scrollVelocity > 1 ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <LL $lighten={true} />
+          <LL $lighten />
         </div>
       ) : (
         currentCanvas && (
           <ThumbnailSpacer>
             <NextLink
-              replace={true}
               {...toWorksItemLink({
                 workId,
                 props: {
@@ -92,6 +91,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
                 setGridVisible(false);
               }}
               tabIndex={gridVisible ? 0 : -1}
+              replace
             >
               <IIIFCanvasThumbnail
                 canvas={currentCanvas}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
@@ -131,7 +131,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
             <>
               {!hasIconPlaceholder ? (
                 <>
-                  {!thumbnailLoaded && <LL $small={true} $lighten={true} />}
+                  {!thumbnailLoaded && <LL $small $lighten />}
 
                   <IIIFViewerImage
                     highlightImage={highlightImage}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
@@ -454,7 +454,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           <VideoPlayer
             placeholderId={placeholderId}
             video={item}
-            showDownloadOptions={true}
+            showDownloadOptions
           />
           {showVideoTranscript && (
             <VideoTranscript
@@ -509,7 +509,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
                     label={itemLabel}
                     fileSize={getFileSize(canvas)}
                     format={'format' in original ? original.format : undefined}
-                    showWarning={true}
+                    showWarning
                   />
                 </IIIFItemWrapper>
               )
@@ -537,7 +537,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
             isProbeOk={isProbeOk}
             externalAccessService={adjustedExternalAccessService}
             index={i}
-            removeRestrictedMessage={true}
+            removeRestrictedMessage
           >
             {imageContent}
           </IIIFItemWrapperWithObserver>
@@ -551,7 +551,7 @@ const IIIFItem: FunctionComponent<ItemProps> = ({
           isRestricted={isRestricted}
           isProbeOk={isProbeOk}
           externalAccessService={adjustedExternalAccessService}
-          removeRestrictedMessage={true}
+          removeRestrictedMessage
         >
           {imageContent}
         </IIIFItemWrapper>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -96,7 +96,7 @@ const Loading = () => (
       height: '80px',
     }}
   >
-    <LL $small={true} $lighten={true} />
+    <LL $small $lighten />
     <span className="visually-hidden">Loading</span>
   </div>
 );
@@ -229,10 +229,10 @@ const IIIFSearchWithin: FunctionComponent = () => {
             name="query"
             value={value}
             setValue={setValue}
-            required={true}
             ref={inputRef}
-            hasClearButton
             clearHandler={handleClearResults}
+            hasClearButton
+            required
           />
         </SearchInputWrapper>
         <SearchButtonWrapper>
@@ -240,8 +240,8 @@ const IIIFSearchWithin: FunctionComponent = () => {
             variant="ButtonSolid"
             icon={search}
             text="search within"
-            isTextHidden={true}
             colors={theme.buttonColors.yellowYellowBlack}
+            isTextHidden
           />
         </SearchButtonWrapper>
       </SearchForm>
@@ -283,7 +283,6 @@ const IIIFSearchWithin: FunctionComponent = () => {
             return (
               <ListItem key={i}>
                 <NextLink
-                  replace={true}
                   {...toWorksItemLink({
                     workId: work.id,
                     props: {
@@ -296,6 +295,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
                     },
                   })}
                   onClick={() => setIsMobileSidebarActive(false)}
+                  replace
                 >
                   <Hit
                     hit={hit}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
@@ -82,7 +82,7 @@ const IIIFViewerImage = (
 
   return (
     <>
-      {!hasLoaded && isFullSupportBrowser && <LL $lighten={true} />}
+      {!hasLoaded && isFullSupportBrowser && <LL $lighten />}
       <Image
         data-testid={index !== undefined ? `image-${index}` : null}
         ref={ref}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewer.tsx
@@ -158,7 +158,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
           updateImagePosition();
         }}
         errorHandler={errorHandler}
-        zoomOnClick={true}
+        zoomOnClick
       />
       {alt ? (
         <span className="visually-hidden" id={`image-${index + 1}`}>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/MultipleManifestList.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/MultipleManifestList.tsx
@@ -24,7 +24,6 @@ const MultipleManifestList: FunctionComponent = () => {
           >
             <NextLink
               data-gtm-trigger="volumes_nav_link"
-              replace={true}
               {...toWorksItemLink({
                 workId: work.id,
                 props: {
@@ -41,6 +40,7 @@ const MultipleManifestList: FunctionComponent = () => {
               onClick={() => {
                 setIsMobileSidebarActive(false);
               }}
+              replace
             >
               {(manifest.label &&
                 getMultiVolumeLabel(manifest.label, work?.title || '')) ||

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
@@ -52,7 +52,7 @@ export const NoScriptImage = ({ urlTemplate, canvasOcr }: Props) => {
   return (
     <>
       <NoScriptLoadingWrapper>
-        <LL $lighten={true} />
+        <LL $lighten />
       </NoScriptLoadingWrapper>
       <DelayVisibility>
         <CanvasPaginator />

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
@@ -52,9 +52,9 @@ const PaginatedItemViewer: FunctionComponent = () => {
         canvas={currentCanvas}
         titleOverride={`${canvas}/${canvases?.length}`}
         exclude={[]}
-        isDark={true}
         externalAccessService={externalAccessService}
         showVideoTranscript={false}
+        isDark
       />
     </ItemWrapper>
   ));

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
@@ -35,11 +35,11 @@ const PaginatorButtons = ({
           <Rotator $rotate={270}>
             <Control
               scroll={false}
-              replace={true}
               link={prevLink}
               colorScheme="light"
               icon={arrow}
               text="Previous page"
+              replace
             />
           </Rotator>
         </Space>
@@ -49,11 +49,11 @@ const PaginatorButtons = ({
           <Rotator $rotate={90}>
             <Control
               scroll={false}
-              replace={true}
               link={nextLink}
               colorScheme="light"
               icon={arrow}
               text="Next page"
+              replace
             />
           </Rotator>
         </Space>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -160,7 +160,6 @@ const ViewerBottomBar: FunctionComponent = () => {
               canvases.length > 1 &&
               !isMobileSidebarActive && (
                 <ToolbarSegmentedControl
-                  hideLabels={true}
                   items={[
                     {
                       id: 'pageView',
@@ -182,6 +181,7 @@ const ViewerBottomBar: FunctionComponent = () => {
                     },
                   ]}
                   activeId={gridVisible ? 'gridView' : 'pageView'}
+                  hideLabels
                 />
               )}
           </LeftZone>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerSidebar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerSidebar.tsx
@@ -222,7 +222,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
     <>
       {isWorkVisibleWithPermission && (
         <RestrictedMessage>
-          <RestrictedItemMessage plural={true} />
+          <RestrictedItemMessage plural />
         </RestrictedMessage>
       )}
       <Inner className={typography('body', 'md', 'strong')}>
@@ -266,7 +266,7 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
               $h={{ size: 'xs', properties: ['margin-left'] }}
               style={{ display: 'flex', alignItems: 'center' }}
             >
-              <Icon icon={arrow} matchText={true} iconColor="white" />
+              <Icon icon={arrow} iconColor="white" matchText />
             </Space>
           </WorkLink>
         </Space>
@@ -311,8 +311,8 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
           >
             <div style={{ overflow: 'auto' }}>
               <WorksTree
-                isDarkMode={true}
                 hasStructures={Boolean(structures && structures.length > 0)}
+                isDarkMode
               >
                 <NestedList
                   currentWorkId={work.id}
@@ -322,10 +322,6 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
                   level={1}
                   tabbableId={tabbableId}
                   setTabbableId={setTabbableId}
-                  firstItemTabbable={true}
-                  showFirstLevelGuideline={true}
-                  shouldFetchChildren={false}
-                  isDarkMode={true}
                   ItemRenderer={DownloadItemRenderer}
                   itemRendererProps={{
                     linkToCanvas: true,
@@ -335,6 +331,10 @@ const ViewerSidebar: FunctionComponent<ViewerSidebarProps> = ({
                     itemOnClick: () => setIsMobileSidebarActive(false),
                     canvases: transformedManifest?.canvases,
                   }}
+                  isDarkMode
+                  firstItemTabbable
+                  showFirstLevelGuideline
+                  shouldFetchChildren={false}
                 />
               </WorksTree>
             </div>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerStructures.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerStructures.tsx
@@ -95,7 +95,6 @@ const Structures: FunctionComponent<Props> = ({
               condition={Boolean(nestedRanges.length === 0)}
               wrapper={children => (
                 <NextLink
-                  replace={true}
                   {...toWorksItemLink({
                     workId: work.id,
                     props: {
@@ -116,6 +115,7 @@ const Structures: FunctionComponent<Props> = ({
                   onClick={() => {
                     setIsMobileSidebarActive(false);
                   }}
+                  replace
                 >
                   {children}
                 </NextLink>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -341,7 +341,6 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
               canvases.length > 1 &&
               isFullSupportBrowser && (
                 <ToolbarSegmentedControl
-                  hideLabels={true}
                   items={[
                     {
                       id: 'pageView',
@@ -363,6 +362,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                     },
                   ]}
                   activeId={gridVisible ? 'gridView' : 'pageView'}
+                  hideLabels
                 />
               )}
           </LeftZone>
@@ -393,8 +393,8 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                     <Download
                       ariaControlsId="itemDownloads"
                       downloadOptions={downloadOptions}
-                      useDarkControl={true}
-                      isInline={true}
+                      useDarkControl
+                      isInline
                     />
                   </Space>
                 )}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
@@ -61,7 +61,7 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
     <div style={style}>
       {scrollVelocity === 3 ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <LL $lighten={true} />
+          <LL $lighten />
         </div>
       ) : (
         <>
@@ -85,8 +85,8 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
                     setImageRect={setImageRect}
                     setImageContainerRect={setImageContainerRect}
                     externalAccessService={externalAccessService}
-                    shouldScrollToUpdateUrl={true}
                     showVideoTranscript={false}
+                    shouldScrollToUpdateUrl
                   />
                 </ItemWrapper>
               );

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/RequestDialog/RequestDialog.RequestingDayPicker.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/ItemRequestModal/RequestDialog/RequestDialog.RequestingDayPicker.tsx
@@ -42,10 +42,10 @@ const RequestingDayPicker: FunctionComponent<Props> = ({
       <Select
         name="calendar_dates"
         label="Select a date"
-        hideLabel={true}
         options={availabilitySlotsToSelectOptions(availableDates)}
         value={pickUpDate || 'Select a date'}
         onChange={e => setPickUpDate(e.target.value)}
+        hideLabel
       />
     </div>
   );

--- a/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/PhysicalItems/PhysicalItem.Details.tsx
@@ -241,9 +241,9 @@ const PhysicalItemDetails: FunctionComponent<Props> = ({
         )}
         <StackingTable
           rows={createRows()}
-          plain={true}
           maxWidth={isArchive ? '61.25rem' : '38.75rem'}
           columnWidths={[180, 200, undefined, undefined]}
+          plain
         />
 
         {(accessNote || isHeldByUser) && (

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -159,7 +159,7 @@ const ItemPageLink = ({
         wrapper={children => (
           <Layout gridSizes={gridSize12()}>
             <RestrictedMessage>
-              <RestrictedItemMessage headingLevel={3} plural={true}>
+              <RestrictedItemMessage headingLevel={3} plural>
                 {children}
               </RestrictedItemMessage>
             </RestrictedMessage>
@@ -333,11 +333,11 @@ const WorkDetailsAvailableOnline = ({
                   level={1}
                   tabbableId={tabbableId}
                   setTabbableId={setTabbableId}
-                  firstItemTabbable={true}
-                  showFirstLevelGuideline={true}
                   ItemRenderer={DownloadItemRenderer}
-                  shouldFetchChildren={false}
                   itemRendererProps={{}}
+                  shouldFetchChildren={false}
+                  firstItemTabbable
+                  showFirstLevelGuideline
                 />
               </WorksTree>
             )}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.test.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.test.tsx
@@ -54,11 +54,7 @@ const renderDownloadItem = (props: {
             userIsStaffWithRestricted: props.userIsStaffWithRestricted ?? false,
           }}
         >
-          <DownloadItem
-            canvas={mockCanvas}
-            item={mockDownloadItem}
-            linkToCanvas={false}
-          />
+          <DownloadItem canvas={mockCanvas} item={mockDownloadItem} />
         </UserContext.Provider>
       </KioskContext.Provider>
     </ThemeProvider>

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.DownloadItem.tsx
@@ -175,7 +175,7 @@ const DownloadItem: FunctionComponent<DownloadItemProps> = ({
       icon={
         format?.endsWith('jpeg') || format?.endsWith('gif') ? imageFile : file
       }
-      matchText={true}
+      matchText
       sizeOverride={
         format?.endsWith('jpeg') || format?.endsWith('gif')
           ? undefined

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Holdings.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Holdings.tsx
@@ -54,17 +54,17 @@ const WorkDetailsHoldings = ({ holdings }: { holdings: Holding[] }) => {
                   {locationShelfmark && (
                     <WorkDetailsText
                       title="Location"
-                      noSpacing={true}
                       text={`${locationLabel} ${locationShelfmark}`}
+                      noSpacing
                     />
                   )}
 
                   {holding.note && (
                     <WorkDetailsText
                       title="Note"
-                      inlineHeading={true}
-                      noSpacing={true}
                       text={holding.note}
+                      inlineHeading
+                      noSpacing
                     />
                   )}
                 </Space>

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Licence.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Licence.tsx
@@ -56,8 +56,8 @@ const WorkDetailsLicence = ({
         <Space $v={{ size: 'md', properties: ['margin-top'] }}>
           <WorkDetailsText
             title="Access conditions"
-            noSpacing={true}
             text={accessConditionsTerms}
+            noSpacing
           />
         </Space>
       )}

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Tree.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.Tree.tsx
@@ -61,8 +61,8 @@ const WorksTree: FunctionComponent<
         <TreeContainer $isDarkMode={isDarkMode}>
           <Tree
             $isEnhanced={isEnhanced}
-            $showFirstLevelGuideline={true}
             $isDarkMode={isDarkMode}
+            $showFirstLevelGuideline
           >
             {isEnhanced && (
               <TreeInstructions>{`Download tree: ${treeInstructions}`}</TreeInstructions>

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.WhereToFind.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.WhereToFind.tsx
@@ -38,7 +38,7 @@ const WhereToFindIt = ({ work, physicalItems, locationOfWork }: Props) => {
         <WorkDetailsText
           title={locationOfWork.noteType.label}
           html={locationOfWork.contents}
-          allowDangerousRawHtml={true}
+          allowDangerousRawHtml
         />
       )}
       <PhysicalItems work={work} items={physicalItems} />

--- a/content/webapp/views/pages/works/work/WorkDetails/index.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/index.tsx
@@ -232,7 +232,7 @@ const WorkDetails: FunctionComponent<Props> = ({
           <WorkDetailsText
             title="Description"
             html={work.description}
-            allowDangerousRawHtml={true}
+            allowDangerousRawHtml
           />
         )}
 
@@ -267,7 +267,7 @@ const WorkDetails: FunctionComponent<Props> = ({
           <WorkDetailsText
             title="Physical description"
             html={work.physicalDescription}
-            allowDangerousRawHtml={true}
+            allowDangerousRawHtml
           />
         )}
         {seriesPartOfs.length > 0 && (
@@ -320,7 +320,7 @@ const WorkDetails: FunctionComponent<Props> = ({
             key={note.noteType.label}
             title={note.noteType.label}
             html={note.contents}
-            allowDangerousRawHtml={true}
+            allowDangerousRawHtml
           />
         ))}
 
@@ -345,7 +345,7 @@ const WorkDetails: FunctionComponent<Props> = ({
             key={note.noteType.label}
             title={note.noteType.label}
             html={note.contents}
-            allowDangerousRawHtml={true}
+            allowDangerousRawHtml
           />
         ))}
         {/*

--- a/content/webapp/views/pages/works/work/download.tsx
+++ b/content/webapp/views/pages/works/work/download.tsx
@@ -119,7 +119,7 @@ const WorkDownloadPage: NextPage<Props> = ({ transformedManifest, work }) => {
       openGraphType="website"
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
-      hideNewsletterPromo={true}
+      hideNewsletterPromo
     >
       <ContaineredLayout gridSizes={gridSize8()}>
         <SpacingSection>

--- a/content/webapp/views/pages/works/work/images.tsx
+++ b/content/webapp/views/pages/works/work/images.tsx
@@ -46,9 +46,9 @@ const WorkImagesPage: NextPage<Props> = ({
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
       apiToolbarLinks={apiToolbarLinks}
-      hideNewsletterPromo={true}
-      hideFooter={true}
-      hideTopContent={true}
+      hideNewsletterPromo
+      hideFooter
+      hideTopContent
     >
       {iiifImageLocation ? (
         <IIIFViewer

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -117,7 +117,7 @@ export const WorkPage: NextPage<Props> = ({
         siteSection="collections"
         image={image}
         apiToolbarLinks={createApiToolbarWorkLinks(work, apiUrl)}
-        hideNewsletterPromo={true}
+        hideNewsletterPromo
       >
         {!isKiosk && (
           <Container>

--- a/content/webapp/views/pages/works/work/items.tsx
+++ b/content/webapp/views/pages/works/work/items.tsx
@@ -176,9 +176,9 @@ const WorkItemPage: NextPage<Props> = ({
       jsonLd={{ '@type': 'WebPage' }}
       siteSection="collections"
       apiToolbarLinks={apiToolbarLinks}
-      hideNewsletterPromo={true}
-      hideFooter={true}
-      hideTopContent={true}
+      hideNewsletterPromo
+      hideFooter
+      hideTopContent
     >
       {shouldUseAuthMessageIframe && (
         <IframeAuthMessage
@@ -196,8 +196,8 @@ const WorkItemPage: NextPage<Props> = ({
         id="auth-modal"
         isActive={showModal}
         setIsActive={setShowModal}
-        removeCloseButton={true}
         openButtonRef={{ current: null }}
+        removeCloseButton
       >
         <div className={typography('body', 'md', 'regular')}>
           {modalContent?.label && (

--- a/content/webapp/views/pages/works/work/work.ArchiveBreadcrumb.test.tsx
+++ b/content/webapp/views/pages/works/work/work.ArchiveBreadcrumb.test.tsx
@@ -34,7 +34,7 @@ describe('ArchiveBreadcrumb', () => {
       designation: [],
     };
     const { getByText } = renderWithTheme(
-      <IsArchiveContext.Provider value={true}>
+      <IsArchiveContext.Provider value>
         <ArchiveBreadcrumb work={w} />
       </IsArchiveContext.Provider>
     );
@@ -95,7 +95,7 @@ describe('ArchiveBreadcrumb', () => {
     };
 
     const { container } = renderWithTheme(
-      <IsArchiveContext.Provider value={true}>
+      <IsArchiveContext.Provider value>
         <ArchiveBreadcrumb work={w} />
       </IsArchiveContext.Provider>
     );
@@ -132,7 +132,7 @@ describe('ArchiveBreadcrumb', () => {
     };
 
     const { container } = renderWithTheme(
-      <IsArchiveContext.Provider value={true}>
+      <IsArchiveContext.Provider value>
         <ArchiveBreadcrumb work={w} />
       </IsArchiveContext.Provider>
     );

--- a/content/webapp/views/pages/works/work/work.ArchiveBreadcrumb.tsx
+++ b/content/webapp/views/pages/works/work/work.ArchiveBreadcrumb.tsx
@@ -103,7 +103,7 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }) => {
       <ul>
         {firstCrumb && (
           <li style={{ display: 'flex' }}>
-            <Icon matchText={true} icon={archive} />
+            <Icon icon={archive} matchText />
             <WorkLink
               id={firstCrumb.id}
               className="crumb-inner"
@@ -126,7 +126,7 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }) => {
                   {middleCrumbs.map(crumb => {
                     return (
                       <li key={crumb.id} style={{ display: 'flex' }}>
-                        <Icon matchText={true} icon={folder} />
+                        <Icon icon={folder} matchText />
                         <WorkLink
                           id={crumb.id}
                           className="crumb-inner"
@@ -149,7 +149,7 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }) => {
             {middleCrumbs.map(crumb => {
               return (
                 <li key={crumb.id} style={{ display: 'flex' }}>
-                  <Icon matchText={true} icon={folder} />
+                  <Icon icon={folder} matchText />
                   <WorkLink
                     id={crumb.id}
                     className="crumb-inner"
@@ -168,7 +168,7 @@ const ArchiveBreadcrumb: FunctionComponent<Props> = ({ work }) => {
         )}
         {lastCrumb && (
           <li style={{ display: 'flex' }}>
-            <Icon matchText={true} icon={folder} />
+            <Icon icon={folder} matchText />
             <span className="crumb-inner">
               <WorkTitle
                 title={`${lastCrumb.title}${

--- a/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/work.DownloadItemRenderer.tsx
@@ -88,8 +88,8 @@ const DownloadItemRenderer: FunctionComponent<DownloadItemRendererProps> = ({
           <span style={{ marginRight: '10px' }}>
             <Icon
               icon={item.openStatus ? openFolder : closedFolder}
-              matchText={true}
               sizeOverride="height: 14px; width:16px;"
+              matchText
             />
           </span>
           {item.data.title}
@@ -111,16 +111,15 @@ const DownloadItemRenderer: FunctionComponent<DownloadItemRendererProps> = ({
               item={download}
               workId={workId}
               canvasIndex={canvasIndex}
-              linkToCanvas={true}
               currentCanvasIndex={currentCanvasIndex}
               onClick={itemOnClick}
+              linkToCanvas
             />
           ) : (
             <DownloadItem
               key={download.id}
               canvas={item.data as TransformedCanvas}
               item={download}
-              linkToCanvas={false}
               currentCanvasIndex={currentCanvasIndex}
             />
           );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,7 @@ const sharedRules = {
   'prettier/prettier': 'error',
   'react/no-deprecated': 'error',
   'react/react-in-jsx-scope': 'off',
+  'react/jsx-boolean-value': 'warn',
   'react/jsx-curly-brace-presence': [
     'warn',
     { props: 'never', children: 'never', propElementValues: 'always' },

--- a/identity/webapp/test/ChangeEmail.test.tsx
+++ b/identity/webapp/test/ChangeEmail.test.tsx
@@ -133,7 +133,7 @@ describe('ChangeEmail', () => {
     );
     rerender(
       <ThemeProvider theme={theme}>
-        <ChangeEmail {...defaultProps} isActive={true} />
+        <ChangeEmail {...defaultProps} isActive />
       </ThemeProvider>
     );
     await expect(emailAddressInput).toHaveValue('');

--- a/identity/webapp/test/ChangePassword.test.tsx
+++ b/identity/webapp/test/ChangePassword.test.tsx
@@ -107,7 +107,7 @@ describe('ChangePassword', () => {
     );
     rerender(
       <ThemeProvider theme={theme}>
-        <ChangePassword {...defaultProps} isActive={true} />
+        <ChangePassword {...defaultProps} isActive />
       </ThemeProvider>
     );
     await expect(currentPasswordInput).toHaveValue('');

--- a/identity/webapp/test/DeleteAccount.test.tsx
+++ b/identity/webapp/test/DeleteAccount.test.tsx
@@ -87,7 +87,7 @@ describe('DeleteAccount', () => {
     );
     rerender(
       <ThemeProvider theme={theme}>
-        <DeleteAccount {...defaultProps} isActive={true} />
+        <DeleteAccount {...defaultProps} isActive />
       </ThemeProvider>
     );
 

--- a/identity/webapp/views/components/Loading/index.tsx
+++ b/identity/webapp/views/components/Loading/index.tsx
@@ -14,7 +14,7 @@ const Loading: FunctionComponent<{ variant?: 'inline' }> = ({ variant }) => {
   if (variant === 'inline') {
     return (
       <InlineWrapper>
-        <LL $small={true} $lighten={true} />
+        <LL $small $lighten />
         <span className="visually-hidden">Loading</span>
       </InlineWrapper>
     );
@@ -22,7 +22,7 @@ const Loading: FunctionComponent<{ variant?: 'inline' }> = ({ variant }) => {
 
   return (
     <>
-      <LL $lighten={false} />
+      <LL />
       <span className="visually-hidden" role="status" aria-label="loading">
         Loading
       </span>

--- a/identity/webapp/views/pages/index.tsx
+++ b/identity/webapp/views/pages/index.tsx
@@ -198,11 +198,9 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
           {isPasswordUpdated && (
             <AccountStatus type="success">Password updated</AccountStatus>
           )}
-          <SectionHeading $addBottomPadding={true}>
-            Personal details
-          </SectionHeading>
+          <SectionHeading $addBottomPadding>Personal details</SectionHeading>
           <Container>
-            <Wrapper $removeBottomPadding={true}>
+            <Wrapper $removeBottomPadding>
               <DetailList listItems={listItems} />
               <ButtonWrapper>
                 <ChangeDetailsModal
@@ -227,9 +225,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
             </Wrapper>
           </Container>
 
-          <SectionHeading $addBottomPadding={true}>
-            Item requests
-          </SectionHeading>
+          <SectionHeading $addBottomPadding>Item requests</SectionHeading>
           <Container>
             <Wrapper>
               {!requestedItems ? (
@@ -354,7 +350,7 @@ const AccountPage: NextPage<Props> = ({ user: auth0UserClaims }) => {
             </Wrapper>
           </Container>
 
-          <SectionHeading $addBottomPadding={true}>
+          <SectionHeading $addBottomPadding>
             Cancel library membership
           </SectionHeading>
           <Container>


### PR DESCRIPTION
- For fun

## What does this change?

Talked with the FEs and we decided this was a rule we wanted for readability. I applied it, had the linter fix the issues, and also removed the `={false}` that weren't necessary. Those will only be the ones that are EXPLICITELY defaulting to `false` in their components.

I will say, what this has brought to light is how unclear it sometimes is that a prop is a boolean because the name doesn't make it clear. I'll suggest a follow-up PR that follows the rules we've set for ourselves in the [item viewer refactor RFC](https://github.com/wellcomecollection/docs/blob/main/rfcs/086-item-viewer-refactor/03-naming-conventions.md) that will address that.

**EDIT:** As much as I'd like to do that, I looked into it and it's sort of dangerous considering some of these come from API or our Prismic model, so I'd suggest we just enforce ourselves as part of BAU/code review; if we spot any props that aren't named properly, we flag/change it. I'll also add this to our agents instructions.

## How to test

Do tests pass?

## Have we considered potential risks?
Potentially will have removed something I shouldn't have, let's see if we trust our tests enough.