### PR TITLE
Add `Vary: Cookie` to our cache controls

### DIFF
--- a/content/webapp/utils/setCacheControl.ts
+++ b/content/webapp/utils/setCacheControl.ts
@@ -29,5 +29,5 @@ export const setCacheControl = (
    * different cookie state (e.g. a different feature toggle value), even
    * though CloudFront's own cache is correctly keyed on those cookies.
    */
-  res.setHeader('Vary', 'Cookie');
+  res.appendHeader('Vary', 'Cookie');
 };

--- a/content/webapp/utils/setCacheControl.ts
+++ b/content/webapp/utils/setCacheControl.ts
@@ -20,4 +20,14 @@ export const setCacheControl = (
    * https://github.com/wellcomecollection/wellcomecollection.org/blob/main/cache/modules/cloudfront_policies/cache_policies.tf
    */
   res.setHeader('Cache-Control', `max-age=${ttl}`);
+
+  /**
+   * Response content depends on toggle_* and other cookies (see
+   * common/server-data/toggles.ts), but browsers cache HTTP responses per-URL
+   * regardless of cookies unless told otherwise. Without this, a browser can
+   * serve a locally cached response for a URL that was fetched under a
+   * different cookie state (e.g. a different feature toggle value), even
+   * though CloudFront's own cache is correctly keyed on those cookies.
+   */
+  res.setHeader('Vary', 'Cookie');
 };


### PR DESCRIPTION
- For https://wellcome.slack.com/archives/CUA669WHH/p1785751084744549

## What does this change?

Fixes `itemViewerRefactor/apiToolbar` toggles flickering on/off while navigating between canvases in the item viewer.

`setCacheControl` sets `Cache-Control: max-age=3600` but no Vary header, even though the response depends on `toggle_* cookies`. CloudFront's cache is correctly keyed on those cookies, but a browser's local cache isn't — it caches per-URL regardless of cookies, so it could serve a canvas response cached under an old toggle state. Only affects staff testing toggles; regular visitors won't see this.

Adding Vary: Cookie fixes it. Checked our cookies (`toggle_*, WC_*, consent, auth`) — all set-once-per-session, so no real hit to cache rates. Used `appendHeader` instead of `setHeader` so we can't clobber an existing `Vary` value if one's ever added elsewhere (nothing sets one today).

How to test

Can't be tested locally — Next dev forces `Cache-Control: no-store` on `getServerSideProps` pages, so the browser never caches in dev. On staging: set a toggle cookie, navigate between canvases with DevTools cache enabled, confirm the toggle stays consistent and responses show `Vary: Cookie`.

Have we considered potential risks?

Low. Only affects browser-side caching, not CloudFront's. No new alarms needed.