### PR TITLE
IVR: move hasMultipleCanvases to context

### DIFF
--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -36,6 +36,7 @@ export type ItemViewerContextProps = {
   canvasIndexById: Record<string, number>;
   currentCanvas: TransformedCanvas | undefined;
   totalCanvases: number;
+  hasMultipleCanvases: boolean;
 
   // UI props:
   viewerRef: RefObject<HTMLDivElement | null> | undefined;
@@ -107,6 +108,7 @@ export const defaultItemViewerContext: ItemViewerContextProps = {
   canvasIndexById: {},
   currentCanvas: undefined,
   totalCanvases: 0,
+  hasMultipleCanvases: false,
 
   // UI props:
   viewerRef: undefined,

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -73,18 +73,23 @@ export function createMockRefactoredItemViewerContext(
     overrides.canvasIndexById ??
     defaultItemViewerContextRefactored.canvasIndexById;
 
+  const totalCanvases = transformedManifest.canvases.length;
+
   return {
     ...defaultItemViewerContextRefactored,
     transformedManifest,
-    // Mirrors how the real provider (IIIFViewer.tsx) derives currentCanvas and
-    // totalCanvases, so tests overriding transformedManifest/query still get
-    // sensible defaults without also having to pass these by hand.
+    // Mirrors how the real provider (IIIFViewer.tsx) derives these, so tests
+    // overriding transformedManifest/query still get sensible defaults without
+    // having to pass each one by hand. Anything derived from the manifest that
+    // goes on the context needs adding here too, or tests that override the
+    // manifest will silently fall back to the default context's value.
     currentCanvas: getCurrentCanvas({
       transformedManifest,
       canvasIndexById,
       canvas: query.canvas,
     }),
-    totalCanvases: transformedManifest.canvases.length,
+    totalCanvases,
+    hasMultipleCanvases: totalCanvases > 1,
     ...overrides,
   };
 }

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -313,7 +313,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   );
   // useFixedSizeList is true when all items are images (using FixedSizeList for virtualization)
   const useFixedSizeList = hasOnlyRenderableImages;
-  const hasMultipleCanvases = (transformedManifest?.canvases?.length || 0) > 1;
+  const hasMultipleCanvases = totalCanvases > 1;
 
   // showControls' initial value depends on the derived values above, so it's
   // declared here rather than grouped with the other state
@@ -395,6 +395,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         canvasIndexById,
         currentCanvas,
         totalCanvases,
+        hasMultipleCanvases,
 
         // UI Props:
         viewerRef,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -126,7 +126,6 @@ const ViewerBottomBar: FunctionComponent = () => {
   const { isEnhanced } = useAppContext();
   const isFullscreenEnabled = useIsFullscreenEnabled();
   const {
-    transformedManifest,
     gridVisible,
     setGridVisible,
     showZoomed,
@@ -136,10 +135,10 @@ const ViewerBottomBar: FunctionComponent = () => {
     work,
     query,
     totalCanvases,
+    hasMultipleCanvases,
     hasOnlyRenderableImages,
   } = useItemViewerContext();
 
-  const { canvases } = { ...transformedManifest };
   const { canvas } = query;
 
   const canNavigatePrevious = canvas > 1;
@@ -152,7 +151,6 @@ const ViewerBottomBar: FunctionComponent = () => {
     ? toWorksItemLink({ workId: work.id, props: { canvas: canvas + 1 } })
     : null;
 
-  const hasMultipleCanvases = (canvases?.length || 0) > 1;
   const shouldShowCanvasNavigation =
     !hasOnlyRenderableImages && hasMultipleCanvases;
   const shouldShowViewToggle =

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -218,6 +218,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     showFullscreenControl,
     hasOnlyRenderableImages,
     currentCanvas,
+    hasMultipleCanvases,
   } = useItemViewerContext();
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const { userIsStaffWithRestricted } = useUserContext();
@@ -238,7 +239,6 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
   const isRestricted = currentCanvas && hasRestrictedItem(currentCanvas);
   const currentPageLabel = currentCanvas?.label?.trim();
 
-  const hasMultipleCanvases = Boolean(canvases && canvases.length > 1);
   const shouldShowViewToggle =
     !showZoomed && hasMultipleCanvases && isFullSupportBrowser;
   const shouldShowPageIndicator =


### PR DESCRIPTION
- Part of #12986 (step 3/10)

## What does this change?

`hasMultipleCanvases` was worked out three separate times — in `IIIFViewer`, `ViewerBottomBar` and `ViewerTopBar`. It's now derived once from the `totalCanvases` added by the previous PR in the stack, and all three read it from context.

`ViewerBottomBar` no longer destructures `transformedManifest`. It only ever did so to reach `canvases`, and this flag was the last thing using it — so the component now reads nothing but derived values and UI state off the context.

The plan for this step predicted the existing tests would just keep passing. They didn't: on the first run, 6 of the 17 tests in `ViewerTopBar.test.tsx` failed, along with 8 of the 16 in `ViewerBottomBar.test.tsx`.

The cause is the test fixture, not the change. `createMockRefactoredItemViewerContext` builds a context value from `defaultItemViewerContextRefactored` and then derives the manifest-dependent values on top. Anything it doesn't explicitly derive falls back to the default — so with `hasMultipleCanvases` unhandled, every test that overrode `transformedManifest` with multiple canvases still got `false`, and lost the controls it was asserting on.

Fixed by deriving it in the fixture alongside `currentCanvas` and `totalCanvases`. It fails loudly rather than silently, which is the good version of this problem, but steps 4 and 5 add two more manifest-derived values (`mainImageService`, `isCurrentCanvasRestricted`) and will hit exactly the same thing, so there's now a comment in the fixture saying so.

## How to test

- Tests: from `content/webapp`, `yarn jest views/pages/works/work/IIIFViewer test/fixtures/iiif hooks/useIIIFProbeService views/pages/works/work/work.helpers` — 181 passing, unchanged
- Full `yarn test:content` is 608 passing
- `yarn tsc` clean from the root


## Have we considered potential risks?

Small tested change behind a toggle – low risk.