### PR TITLE
Don't export things we don't need to

### DIFF
--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -51,7 +51,7 @@ type ItemViewerContextOverridesRefactored = Partial<
   Omit<ItemViewerContextPropsRefactored, 'isRefactoredContext'>
 >;
 
-export function createMockItemViewerContext(
+function createMockItemViewerContext(
   overrides: ItemViewerContextOverridesLegacy = {}
 ): ItemViewerContextPropsLegacy {
   return {
@@ -62,7 +62,7 @@ export function createMockItemViewerContext(
   };
 }
 
-export function createMockRefactoredItemViewerContext(
+function createMockRefactoredItemViewerContext(
   overrides: ItemViewerContextOverridesRefactored = {}
 ): ItemViewerContextPropsRefactored {
   // A single-image manifest is the most common baseline; override as needed.


### PR DESCRIPTION
## What does this change?

I noticed we were exporting these two functions which aren't used outside the file (and seem unlikely to be used outside the file in future).

## How to test

- `yarn tsc` should do it?

## Have we considered potential risks?

n/a