### PR TITLE
Claude settings + new command for TS check

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See [AGENTS.md](../AGENTS.md) for the full guidelines. The line below is a Claude Code import directive, not a GitHub @-mention — it pulls that file's contents into context automatically:
+
+@../AGENTS.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "attribution": {
+    "pr": ""
+  },
+  "permissions": {
+    "ask": ["Bash(git commit *)"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ tsconfig.tsbuildinfo
 # Code editor
 .zed/
 
-# AI
-.claude/
+# AI personal preferences
+.claude/*.local.*
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-See [AGENTS.md](./AGENTS.md) for the full guidelines. The line below is a Claude Code import directive, not a GitHub @-mention — it pulls that file's contents into context automatically:
-
-@AGENTS.md

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "deploy-dev": "yarn workspace @weco/deploy deploy-dev",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "lint:css": "stylelint \"**/*.{js,ts,tsx}\"",
-    "tsc": "tsc --build --verbose"
+    "tsc": "tsc --build --verbose",
+    "tsc:clean": "rimraf --glob **/tsconfig.tsbuildinfo && yarn tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[As discussed](https://wellcome.slack.com/archives/CUA669WHH/p1785859650329269), I'm reorganising our Claude settings.

I'm also adding `settings.json` so we can start setting some shared setting rules, starting with the PR attribution [Robert requested we turn off](https://wellcome.slack.com/archives/C3TQSF63C/p1786004522677469).

I'm also sliding in an unrelated new command, which allows us to run `tsc:clean` locally, meaning it'll be done without cached file. [I'd done a change to our Typescript check](https://github.com/wellcomecollection/wellcomecollection.org/pull/13066) that allows those to run much quicker locally, only running tests where files were changed. This was found to cause issues in PR runs, where they always run on all files for safety, and then catches things we didn't catch locally. For example, if a component was modified, but not its story, `tsc` would pass locally, but not in PR. This allows us to run it fully, if we want to do it manually.
