### PR TITLE
Add archive browse testing mode

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -196,6 +196,11 @@ const toggleConfig = {
           id: 'axiell-collections-testing',
           label: 'Axiell Collections testing (new Axiell/FOLIO pipeline)',
         },
+        {
+          id: 'archive-browse-testing',
+          label:
+            'Archive browse testing (only use in combination with the Staging API toggle)',
+        },
       ],
     },
   ] as const,


### PR DESCRIPTION
- For https://github.com/wellcomecollection/platform/issues/6469

## What does this change?

Add a new `Archive browse testing` mode which, when combined with the `Staging API` toggle, routes all catalogue API requests to a non-production works index which supports experimental archive browsing features. Upstream catalogue API changes enabling this functionality are implemented in [this PR](https://github.com/wellcomecollection/catalogue-api/pull/942).

## How to test

1. Enable the `Staging API` toggle
2. Enable the `Archive browse testing` mode
3. Verify that the API supports all features described in [this document](https://app.notion.com/p/wellcometrust/Archive-browsing-API-guide-3b16687658a18047a31cf3773677afd4)
4. Optional: Run [this demo version](https://github.com/wellcomecollection/wellcomecollection.org/compare/main...sb/archive-filters-demo) of the frontend locally. The works search page integrates all the new filtering/aggregation/sort options for easy testing.


## Have we considered potential risks?

This change does not change production behaviour and is low risk.