### PR TITLE
Remove the archive-browse-testing pipeline option

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -196,11 +196,6 @@ const toggleConfig = {
           id: 'axiell-collections-testing',
           label: 'Axiell Collections testing (new Axiell/FOLIO pipeline)',
         },
-        {
-          id: 'archive-browse-testing',
-          label:
-            'Archive browse testing (only use in combination with the Staging API toggle)',
-        },
       ],
     },
   ] as const,


### PR DESCRIPTION
## What does this change?

Removes the `archive-browse-testing` option from the Catalogue pipeline toggle. The archive fields have been served by the production works index since 2026-08-11 (wellcomecollection/platform#6509), so the testing route is redundant: it points at the same data the default API already returns.

Ordering matters. This has to merge and deploy before wellcomecollection/catalogue-api#950 removes the matching cluster entry, because a request that selects a cluster the API no longer knows about returns 404.

The `archiveBrowsing` feature toggle is deliberately untouched. It gates the new frontend pages, which are still in development.

Part of wellcomecollection/platform#6511.
