### PR TITLE
Add /collections/archives page and link from the archives card list

### DIFF
--- a/common/views/slices/ArchiveCardList/index.tsx
+++ b/common/views/slices/ArchiveCardList/index.tsx
@@ -2,6 +2,7 @@ import { SliceComponentProps } from '@prismicio/react';
 import { FunctionComponent } from 'react';
 
 import { ArchiveCardListSlice as RawArchiveCardListSlice } from '@weco/common/prismicio-types';
+import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { typography } from '@weco/common/utils/classnames';
 import { isNotUndefined } from '@weco/common/utils/type-guards';
 import { Container } from '@weco/common/views/components/styled/Container';
@@ -15,6 +16,7 @@ import SpacingComponent from '@weco/common/views/components/styled/SpacingCompon
 import { asText } from '@weco/content/services/prismic/transformers';
 import ArchiveCard from '@weco/content/views/components/ArchiveCard';
 import { SliceZoneContext } from '@weco/content/views/components/Body';
+import MoreLink from '@weco/content/views/components/MoreLink';
 
 type ArchiveCardListSliceProps = SliceComponentProps<
   RawArchiveCardListSlice,
@@ -25,6 +27,7 @@ const ArchiveCardListSlice: FunctionComponent<ArchiveCardListSliceProps> = ({
   slice,
   context,
 }) => {
+  const { archiveBrowsing } = useFeatureFlags();
   const { title, items } = slice.primary;
   const archiveWorks = context?.archiveWorks ?? {};
 
@@ -80,6 +83,16 @@ const ArchiveCardListSlice: FunctionComponent<ArchiveCardListSliceProps> = ({
             </GridCell>
           ))}
         </Grid>
+        {archiveBrowsing && (
+          <Space
+            $v={{
+              size: 'sm',
+              properties: ['margin-top'],
+            }}
+          >
+            <MoreLink url="/collections/archives" name="Browse archives" />
+          </Space>
+        )}
       </Container>
     </SpacingComponent>
   );

--- a/content/webapp/pages/collections/archives.tsx
+++ b/content/webapp/pages/collections/archives.tsx
@@ -1,0 +1,39 @@
+import { NextPage } from 'next';
+
+import { getServerData } from '@weco/common/server-data';
+import { serialiseProps } from '@weco/common/utils/json';
+import {
+  ServerSideProps,
+  ServerSidePropsOrAppError,
+} from '@weco/common/views/pages/_app';
+import { setCacheControl } from '@weco/content/utils/setCacheControl';
+import ArchivesPage, {
+  Props as ArchivesPageProps,
+} from '@weco/content/views/pages/collections/archives';
+
+const Page: NextPage<ArchivesPageProps> = props => {
+  return <ArchivesPage {...props} />;
+};
+
+type Props = ServerSideProps<ArchivesPageProps>;
+
+export const getServerSideProps: ServerSidePropsOrAppError<
+  Props
+> = async context => {
+  setCacheControl(context.res);
+  const serverData = await getServerData(context);
+
+  if (!serverData.toggles.featureFlags.archiveBrowsing) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: serialiseProps<Props>({
+      serverData,
+    }),
+  };
+};
+
+export default Page;

--- a/content/webapp/views/pages/collections/archives/archives.Header.tsx
+++ b/content/webapp/views/pages/collections/archives/archives.Header.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+
+import { typography } from '@weco/common/utils/classnames';
+import Breadcrumb, {
+  getBreadcrumbItems,
+} from '@weco/common/views/components/Breadcrumb';
+import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
+import Layout, {
+  gridSize10,
+  gridSize8,
+} from '@weco/common/views/components/Layout';
+import { Container } from '@weco/common/views/components/styled/Container';
+import Space from '@weco/common/views/components/styled/Space';
+
+// Same styling as ThematicBrowsing.Header, without the category navigation -
+// archives isn't one of the thematic browsing categories.
+const ArchivesHeaderContainer = styled(Space).attrs({
+  $v: { size: 'sm', properties: ['padding-top'] },
+})`
+  background-color: ${props => props.theme.color('accent.lightGreen')};
+
+  ${props => props.theme.makeSpacePropertyValues('xl', ['padding-bottom'])};
+`;
+
+const ArchivesHeader = ({
+  title,
+  introText,
+}: {
+  title: string;
+  introText?: string;
+}) => {
+  return (
+    <>
+      <ArchivesHeaderContainer>
+        <Container>
+          <Space
+            $v={{
+              size: 'sm',
+              properties: ['margin-bottom'],
+              overrides: { md: '150' },
+            }}
+          >
+            <Breadcrumb items={getBreadcrumbItems('collections').items} />
+          </Space>
+
+          <Layout gridSizes={gridSize10(false)}>
+            <h1 className={typography('heading', 'xxl', 'strong', 'brand')}>
+              {title}
+            </h1>
+          </Layout>
+
+          {introText && (
+            <Layout gridSizes={gridSize8(false)}>
+              <div
+                className={`${typography('body', 'xl', 'regular')} body-text`}
+              >
+                <p>{introText}</p>
+              </div>
+            </Layout>
+          )}
+        </Container>
+      </ArchivesHeaderContainer>
+
+      <DecorativeEdge variant="wobbly" backgroundColor="white" />
+    </>
+  );
+};
+
+export default ArchivesHeader;

--- a/content/webapp/views/pages/collections/archives/index.tsx
+++ b/content/webapp/views/pages/collections/archives/index.tsx
@@ -14,6 +14,7 @@ const ArchivesPage: NextPage<Props> = () => {
       url={{ pathname: '/collections/archives' }}
       jsonLd={{ '@type': 'WebPage' }}
       openGraphType="website"
+      siteSection="collections"
       headerProps={{ hasColorBackground: true }}
       hideNewsletterPromo
       clipOverflowX

--- a/content/webapp/views/pages/collections/archives/index.tsx
+++ b/content/webapp/views/pages/collections/archives/index.tsx
@@ -1,0 +1,29 @@
+import { NextPage } from 'next';
+
+import PageLayout from '@weco/common/views/layouts/PageLayout';
+
+import ArchivesHeader from './archives.Header';
+
+export type Props = Record<string, never>;
+
+const ArchivesPage: NextPage<Props> = () => {
+  return (
+    <PageLayout
+      title="Archives"
+      description="Browse the archives held by Wellcome Collection."
+      url={{ pathname: '/collections/archives' }}
+      jsonLd={{ '@type': 'WebPage' }}
+      openGraphType="website"
+      headerProps={{ hasColorBackground: true }}
+      hideNewsletterPromo
+      clipOverflowX
+    >
+      <ArchivesHeader
+        title="Archives"
+        introText="Original records created by individuals and organisations."
+      />
+    </PageLayout>
+  );
+};
+
+export default ArchivesPage;


### PR DESCRIPTION
- For #13318

## What does this change?

- Adds a new /collections/archives page, currently just a header, behind the existing archiveBrowsing feature flag.
- Adds a "Browse archives" link to it from ArchiveCardList (the slice shown on pages featuring curated archive cards)

N.B archives.Header is temporary and will be replaced in next PR

## How to test

- With archiveBrowsing off: /collections/archives 404s, and the "Browse archives" link doesn't appear in [ArchiveCardList](https://www-dev.wellcomecollection.org/collections/people-and-organisations)
- With [archiveBrowsing on](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveBrowsing) the link appears and goes to /collections/archives, showing just the "Archives" header.

## Have we considered potential risks?

Low risk — everything here is behind an off-by-default toggle.