### PR TITLE
Block requests with an unrecognised Host header at the WAF

### DIFF
--- a/cache/cloudfront_e2e.tf
+++ b/cache/cloudfront_e2e.tf
@@ -51,4 +51,7 @@ module "e2e_wc_org_cloudfront_distribution" {
   google_bots_ip_set_arn    = aws_wafv2_ip_set.google_bots.arn
   github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
   header_shared_secret      = local.current_shared_secret
+
+  # Proven on stage; see cloudfront_prod.tf.
+  enable_unrecognised_host_block = true
 }

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -35,6 +35,11 @@ module "prod_wc_org_cloudfront_distribution" {
 
   enable_waf_logging = true
 
+  # Proven on stage; turns scanner traffic to the *.cloudfront.net default
+  # domain into 403s instead of origin cert-mismatch 502s that trip the 5xx
+  # alarm.
+  enable_unrecognised_host_block = true
+
   # Proven on stage; see the search-challenge rule in the module for why this
   # is high-risk.
   enable_search_challenge = true

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -35,6 +35,14 @@ module "prod_wc_org_cloudfront_distribution" {
 
   enable_waf_logging = true
 
+  # Turns scanner traffic to the *.cloudfront.net default domain into 403s
+  # instead of origin cert-mismatch 502s that trip the 5xx alarm. This ACL is
+  # shared with the preview.wellcomecollection.org distribution, whose
+  # hostname must be allowed here: on 2026-08-13 enabling the rule without it
+  # 403d preview traffic for 22 minutes.
+  enable_unrecognised_host_block = true
+  extra_allowed_hosts            = ["preview.wellcomecollection.org"]
+
   # Proven on stage; see the search-challenge rule in the module for why this
   # is high-risk.
   enable_search_challenge = true

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -35,11 +35,6 @@ module "prod_wc_org_cloudfront_distribution" {
 
   enable_waf_logging = true
 
-  # Proven on stage; turns scanner traffic to the *.cloudfront.net default
-  # domain into 403s instead of origin cert-mismatch 502s that trip the 5xx
-  # alarm.
-  enable_unrecognised_host_block = true
-
   # Proven on stage; see the search-challenge rule in the module for why this
   # is high-risk.
   enable_search_challenge = true

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -32,6 +32,12 @@ module "stage_wc_org_cloudfront_distribution" {
   github_actions_ip_set_arn = aws_wafv2_ip_set.github_actions.arn
   header_shared_secret      = local.current_shared_secret
 
+  # Trialling the unrecognised-Host block here before prod: scanners hitting
+  # the distribution's *.cloudfront.net default domain get cert-mismatch 502s
+  # at the origin, which trip the CloudFront 5xx alarm (three times on
+  # 2026-08-12/13). Nothing legitimate uses that hostname.
+  enable_unrecognised_host_block = true
+
   # Trialling the /search challenge here before prod (see the search-challenge
   # rule in the module for why this is high-risk).
   enable_search_challenge = true

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -73,6 +73,12 @@ variable "enable_unrecognised_host_block" {
   description = "Block requests whose Host header is not one of the distribution's aliases (in practice, its *.cloudfront.net default domain). These fail TLS verification at the origin and pollute the 5xx alarm. Prove on stage before enabling elsewhere."
 }
 
+variable "extra_allowed_hosts" {
+  type        = set(string)
+  default     = []
+  description = "Hostnames beyond this distribution's aliases that the unrecognised-host block must accept. A web ACL evaluates traffic for every distribution associated with it, so any other distribution sharing this ACL must have its aliases listed here or the rule will 403 them."
+}
+
 variable "enable_search_challenge" {
   type        = bool
   default     = false

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -70,7 +70,7 @@ variable "github_actions_ip_set_arn" {
 variable "enable_unrecognised_host_block" {
   type        = bool
   default     = false
-  description = "Block requests whose Host header is not one of the distribution's aliases (i.e. its *.cloudfront.net default domain). These fail TLS verification at the origin and pollute the 5xx alarm. Prove on stage before enabling elsewhere."
+  description = "Block requests whose Host header is not one of the distribution's aliases (in practice, its *.cloudfront.net default domain). These fail TLS verification at the origin and pollute the 5xx alarm. Prove on stage before enabling elsewhere."
 }
 
 variable "enable_search_challenge" {

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -67,6 +67,12 @@ variable "github_actions_ip_set_arn" {
   description = "ARN of the shared github-actions IP set (defined at root level)"
 }
 
+variable "enable_unrecognised_host_block" {
+  type        = bool
+  default     = false
+  description = "Block requests whose Host header is not one of the distribution's aliases (i.e. its *.cloudfront.net default domain). These fail TLS verification at the origin and pollute the 5xx alarm. Prove on stage before enabling elsewhere."
+}
+
 variable "enable_search_challenge" {
   type        = bool
   default     = false

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -154,9 +154,61 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  dynamic "rule" {
+    for_each = var.enable_unrecognised_host_block ? [1] : []
+    content {
+      name     = "unrecognised-host-block"
+      priority = 1
+
+      action {
+        block {}
+      }
+
+      // Requests whose Host header is not one of this distribution's aliases
+      // (in practice, its *.cloudfront.net default domain) fail TLS
+      // verification at the ALB origin and surface as 502s, polluting the
+      // 5xxErrorRate alarm. Turn them away with a 403 before the allow rules
+      // below, which would otherwise let them through to the origin.
+      statement {
+        not_statement {
+          statement {
+            or_statement {
+              dynamic "statement" {
+                for_each = var.aliases
+                content {
+                  byte_match_statement {
+                    positional_constraint = "EXACTLY"
+                    search_string         = lower(statement.value)
+
+                    field_to_match {
+                      single_header {
+                        name = "host"
+                      }
+                    }
+
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "unrecognised-host-block-${var.namespace}"
+      }
+    }
+  }
+
   rule {
     name     = "ip-allowlist"
-    priority = 1
+    priority = 2
 
     action {
       allow {}
@@ -177,7 +229,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "ip-blocklist"
-    priority = 2
+    priority = 3
 
     action {
       block {}
@@ -198,7 +250,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "ip-watchlist"
-    priority = 3
+    priority = 4
 
     action {
       count {}
@@ -219,7 +271,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "allow-google-bots"
-    priority = 4
+    priority = 5
 
     action {
       allow {}
@@ -261,7 +313,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "allow-github-actions"
-    priority = 5
+    priority = 6
 
     action {
       allow {}
@@ -282,7 +334,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "managed-ip-blocking"
-    priority = 6
+    priority = 7
 
     override_action {
       none {}
@@ -305,7 +357,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-user-agent-manual"
-    priority = 7
+    priority = 8
 
     action {
       block {}
@@ -453,7 +505,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "apac-captcha-consent-block"
-    priority = 8
+    priority = 9
 
     action {
       captcha {}
@@ -503,7 +555,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "latam-captcha-consent-block"
-    priority = 9
+    priority = 10
 
     action {
       captcha {}
@@ -561,7 +613,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_legacy_ua_block ? [1] : []
     content {
       name     = "search-legacy-ua-block"
-      priority = 10
+      priority = 11
 
       action {
         block {}
@@ -621,7 +673,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_missing_lang_block ? [1] : []
     content {
       name     = "search-missing-lang-block"
-      priority = 11
+      priority = 12
 
       action {
         block {}
@@ -691,7 +743,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_works_fabricated_ua_block ? [1] : []
     content {
       name     = "works-fabricated-ua-block"
-      priority = 12
+      priority = 13
 
       action {
         block {}
@@ -808,7 +860,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
     for_each = var.enable_search_challenge ? [1] : []
     content {
       name     = "search-challenge"
-      priority = 14
+      priority = 15
 
       action {
         challenge {}
@@ -846,7 +898,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 15
+    priority = 16
 
     action {
       block {
@@ -881,7 +933,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 16
+    priority = 17
 
     action {
       block {
@@ -921,7 +973,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 17
+    priority = 18
 
     action {
       block {
@@ -958,7 +1010,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 18
+    priority = 19
 
     action {
       block {}
@@ -980,7 +1032,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 19
+    priority = 20
 
     action {
       block {}
@@ -1018,7 +1070,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 20
+    priority = 21
 
     override_action {
       none {}
@@ -1041,7 +1093,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 21
+    priority = 22
 
     override_action {
       none {}
@@ -1064,7 +1116,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 22
+    priority = 23
 
     override_action {
       none {}
@@ -1086,7 +1138,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "bot-control-rule-group"
-    priority = 13
+    priority = 14
 
     // Because the Bot Control rules are quite aggressive, they block some useful bots
     // such as Updown. While we could add overrides for specific bots, we don"t want to have to
@@ -1162,7 +1214,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // /search once the group is scoped down for targeted inspection.
   rule {
     name     = "seo-user-agent-block"
-    priority = 23
+    priority = 24
 
     action {
       block {}

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -169,12 +169,14 @@ resource "aws_wafv2_web_acl" "wc_org" {
       // verification at the ALB origin and surface as 502s, polluting the
       // 5xxErrorRate alarm. Turn them away with a 403 before the allow rules
       // below, which would otherwise let them through to the origin.
+      // Explicit default ports (alias:443, alias:80) are a legal Host form
+      // that CloudFront accepts for our aliases, so match those too.
       statement {
         not_statement {
           statement {
             or_statement {
               dynamic "statement" {
-                for_each = var.aliases
+                for_each = toset(flatten([for a in var.aliases : [a, "${a}:443", "${a}:80"]]))
                 content {
                   byte_match_statement {
                     positional_constraint = "EXACTLY"

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -176,7 +176,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
           statement {
             or_statement {
               dynamic "statement" {
-                for_each = toset(flatten([for a in var.aliases : [a, "${a}:443", "${a}:80"]]))
+                for_each = toset(flatten([for a in setunion(var.aliases, var.extra_allowed_hosts) : [a, "${a}:443", "${a}:80"]]))
                 content {
                   byte_match_statement {
                     positional_constraint = "EXACTLY"


### PR DESCRIPTION
- For #13378

## What does this change?

Adds a WAF rule, `unrecognised-host-block`, that returns 403 to any request whose Host header is not one of the distribution's aliases. It sits behind a new module flag, off by default and enabled on stage only, following our stage-first convention for WAF changes.

The prod CloudFront 5xx alarm fired three times on 12 and 13 August 2026, each time because scanners were probing the distribution's default cloudfront.net hostname. The ALB certificate only covers the wellcomecollection.org names, so those requests fail TLS at the origin and CloudFront serves 502s that count towards the alarm (2% threshold on roughly 2,300 requests per minute, so about 50 scanner requests a minute trips it). No real users were affected. Blocking the traffic at the edge turns it into 4xx, so the alarm goes back to reflecting genuine origin failures.

- The rule sits at priority 1, ahead of the terminating allow rules: one scanner IP was in Azure ranges that overlap the github-actions allowlist, so a later rule could miss it.
- Host matching is a lowercased exact match against the module's aliases, and also accepts the explicit default-port forms (`alias:443`, `alias:80`). These are a legal Host variant that CloudFront accepts, and the stage soak caught the rule blocking a real client that sent one.
- Existing rules shift down one priority to make room, a pure relabel applied atomically.

## How to test

- `terraform fmt` and `terraform validate` pass; a targeted plan against the stage ACL shows the new rule at priority 1 and the existing rules renumbered, nothing added or destroyed.
- After the stage apply, this returns 403 while normal www-stage requests are unaffected:
  ```
  curl -sk -H 'Host: <stage distribution>.cloudfront.net' https://www-stage.wellcomecollection.org/ -o /dev/null -w '%{http_code}'
  ```
- The rule emits an `unrecognised-host-block-stage` CloudWatch metric, which should only ever count scanner traffic. Once soaked, promoting to prod is a one-line change in `cache/cloudfront_prod.tf`.

## Have we considered potential risks?

- Anything legitimately using the raw cloudfront.net hostname would start getting 403s. The repo has no references to it, and the stage soak plus the per-rule metric would surface a false positive before prod.
- A web ACL evaluates traffic for every distribution associated with it, not just the one the module creates. The prod ACL is shared with the preview.wellcomecollection.org distribution, and the first prod rollout missed this and 403d preview traffic for 22 minutes before being rolled back. The module now takes `extra_allowed_hosts` for exactly this, and the prod config lists preview; anyone attaching another distribution to one of these ACLs must add its hostnames there.
- The priority renumbering also applies to the prod and e2e ACLs on their next apply, even with the flag off there. It is behaviour-neutral and goes in atomically.


