### PR TITLE
Switch tabs align behaviour

### DIFF
--- a/content/webapp/views/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.Switch.tsx
@@ -2,7 +2,6 @@ import {
   Dispatch,
   FunctionComponent,
   KeyboardEvent,
-  ReactNode,
   SetStateAction,
   useRef,
 } from 'react';
@@ -26,10 +25,10 @@ import {
 
 type SwitchSelectableTextLink = {
   id: string;
-  text: ReactNode;
+  text: string;
   url?: string;
   icon?: IconSvg;
-  dataGtmProps: { label: DataGtmProps['label'] };
+  dataGtmProps?: { label: DataGtmProps['label'] };
 };
 
 export type Props = {
@@ -137,6 +136,7 @@ const TabsSwitch: FunctionComponent<Props> = ({
                 $selected={isSelected}
                 $isWhite={isWhite}
                 {...dataGtmPropsToAttributes({
+                  label: item.text,
                   ...item.dataGtmProps,
                   trigger: `tab_${toSnakeCase(label)}`,
                   'position-in-list': `${index + 1}`,

--- a/content/webapp/views/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.Switch.tsx
@@ -106,6 +106,8 @@ const TabsSwitch: FunctionComponent<Props> = ({
     >
       {items.map((item, index) => {
         const isSelected = isEnhanced && selectedTab === item.id;
+        const url = item.url ?? `#tabpanel-${item.id}`;
+
         return (
           <Tab
             key={item.id}
@@ -144,8 +146,8 @@ const TabsSwitch: FunctionComponent<Props> = ({
               >
                 <NavItemShim>{item.text}</NavItemShim>
                 <ConditionalWrapper
-                  condition={Boolean(item.url && !isEnhanced)}
-                  wrapper={children => <a href={item.url}>{children}</a>}
+                  condition={!isEnhanced}
+                  wrapper={children => <a href={url}>{children}</a>}
                 >
                   {item.icon && (
                     <Space

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -62,6 +62,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
               <PreviewImage
                 alt=""
                 src={convertIiifImageUri(work.thumbnail.url, 120)}
+                loading="lazy"
               />
             </Preview>
           )}

--- a/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
@@ -60,9 +60,6 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
     .map(tabType => ({
       id: tabType,
       text: getSectionTypeLabel(tabType, config, 'works'),
-      dataGtmProps: {
-        label: getSectionTypeLabel(tabType, config, 'works') || '""',
-      },
     }));
 
   const [selectedTab, setSelectedTab] = useState<ThemeTabType | null>(

--- a/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
+++ b/content/webapp/views/pages/concepts/concept/concept.WorksResults.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, useState } from 'react';
 import styled, { useTheme } from 'styled-components';
 
+import { useAppContext } from '@weco/common/contexts/AppContext';
 import { typography } from '@weco/common/utils/classnames';
 import { capitalize, pluralize } from '@weco/common/utils/grammar';
 import DecorativeEdge from '@weco/common/views/components/DecorativeEdge';
@@ -50,6 +51,7 @@ type Props = {
 
 const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
   const theme = useTheme();
+  const { isEnhanced } = useAppContext();
   const { config } = useConceptPageContext();
   const tabs = themeTabOrder
     .filter(
@@ -69,12 +71,6 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
   if (!selectedTab) {
     return null;
   }
-
-  const activePanel: SectionData = sectionsData[selectedTab];
-  if (!activePanel.works || activePanel.totalResults.works === undefined)
-    return null;
-
-  const labelBasedCount = activePanel.totalResults.works;
 
   return (
     <>
@@ -102,31 +98,40 @@ const WorksResults: FunctionComponent<Props> = ({ concept, sectionsData }) => {
           as="section"
           data-testid="works-section"
         >
-          <div
-            {...(tabs.length > 1 && {
-              role: 'tabpanel',
-              id: `tabpanel-${selectedTab}`,
-              'aria-labelledby': `tab-${selectedTab}`,
-            })}
-          >
-            <WorksCount>
-              {pluralize(activePanel.works.totalResults, 'work')}
-            </WorksCount>
-            <Space $v={{ size: 'md', properties: ['margin-top'] }}>
-              <WorksSearchResults works={activePanel.works!.pageResults} />
-            </Space>
+          {tabs.map(tab => {
+            const panel: SectionData = sectionsData[tab.id];
+            const works = panel.works!;
+            const labelBasedCount =
+              panel.totalResults.works ?? works.pageResults.length;
 
-            {labelBasedCount > activePanel.works.pageResults.length && (
-              <Space $v={{ size: 'md', properties: ['padding-top'] }}>
-                <MoreLink
-                  ariaLabel={`View all works for ${concept.displayLabel}`}
-                  name="View all"
-                  url={getAllWorksLink(selectedTab, concept)}
-                  colors={theme.buttonColors.greenGreenWhite}
-                />
-              </Space>
-            )}
-          </div>
+            return (
+              <div
+                key={tab.id}
+                {...(tabs.length > 1 && {
+                  role: 'tabpanel',
+                  id: `tabpanel-${tab.id}`,
+                  'aria-labelledby': `tab-${tab.id}`,
+                })}
+                hidden={isEnhanced && selectedTab !== tab.id}
+              >
+                <WorksCount>{pluralize(works.totalResults, 'work')}</WorksCount>
+                <Space $v={{ size: 'md', properties: ['margin-top'] }}>
+                  <WorksSearchResults works={works.pageResults} />
+                </Space>
+
+                {labelBasedCount > works.pageResults.length && (
+                  <Space $v={{ size: 'md', properties: ['padding-top'] }}>
+                    <MoreLink
+                      ariaLabel={`View all works for ${concept.displayLabel}`}
+                      name="View all"
+                      url={getAllWorksLink(tab.id, concept)}
+                      colors={theme.buttonColors.greenGreenWhite}
+                    />
+                  </Space>
+                )}
+              </div>
+            );
+          })}
         </Space>
       </Space>
     </>

--- a/content/webapp/views/pages/concepts/concept/concept.helpers.ts
+++ b/content/webapp/views/pages/concepts/concept/concept.helpers.ts
@@ -24,7 +24,7 @@ export function getSectionTypeLabel(
   tabType: ThemeTabType,
   config: ConceptConfig,
   sectionType: 'images' | 'works'
-): string | undefined {
+): string {
   const capitalisedSectionType = sectionType === 'images' ? 'Images' : 'Works';
 
   switch (tabType) {

--- a/content/webapp/views/pages/whats-on/whats-on.EventsByMonth.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.EventsByMonth.tsx
@@ -70,34 +70,31 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
         </Container>
       </Space>
 
-      {monthsWithEvents
-        .filter(i =>
-          isEnhanced ? i.id === (activeId || monthsWithEvents[0].id) : true
-        )
-        .map(({ id, month, events }) => (
-          <GridCell
-            $sizeMap={gridSize12()}
-            key={id}
-            role="tabpanel"
-            id={`tabpanel-${id}`}
-            aria-labelledby={`tab-${id}`}
+      {monthsWithEvents.map(({ id, month, events }) => (
+        <GridCell
+          $sizeMap={gridSize12()}
+          key={id}
+          role="tabpanel"
+          id={`tabpanel-${id}`}
+          aria-labelledby={`tab-${id}`}
+          hidden={isEnhanced && id !== (activeId || monthsWithEvents[0].id)}
+        >
+          <Container
+            as="h2"
+            className={classNames({
+              'is-hidden': Boolean(isEnhanced),
+            })}
           >
-            <Container
-              as="h2"
-              className={classNames({
-                'is-hidden': Boolean(isEnhanced),
-              })}
-            >
-              {month.month}
-            </Container>
-            <CardGrid
-              items={events}
-              itemsPerRow={3}
-              links={links}
-              fromDate={startOf(month)}
-            />
-          </GridCell>
-        ))}
+            {month.month}
+          </Container>
+          <CardGrid
+            items={events}
+            itemsPerRow={3}
+            links={links}
+            fromDate={startOf(month)}
+          />
+        </GridCell>
+      ))}
     </>
   );
 };

--- a/content/webapp/views/pages/whats-on/whats-on.EventsByMonth.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.EventsByMonth.tsx
@@ -31,7 +31,6 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
 
           return {
             id,
-            url: `#${id}`,
             text: month.month,
             month,
             // Add daily tour promo to each month's events array during grouping
@@ -79,16 +78,15 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
           <GridCell
             $sizeMap={gridSize12()}
             key={id}
-            className={classNames({
-              'is-hidden': Boolean(activeId) && activeId !== id,
-            })}
+            role="tabpanel"
+            id={`tabpanel-${id}`}
+            aria-labelledby={`tab-${id}`}
           >
             <Container
               as="h2"
               className={classNames({
                 'is-hidden': Boolean(isEnhanced),
               })}
-              id={id}
             >
               {month.month}
             </Container>

--- a/content/webapp/views/pages/whats-on/whats-on.EventsByMonth.tsx
+++ b/content/webapp/views/pages/whats-on/whats-on.EventsByMonth.tsx
@@ -36,9 +36,6 @@ const EventsByMonth: FunctionComponent<Props> = ({ events, links }) => {
             month,
             // Add daily tour promo to each month's events array during grouping
             events: events.concat(dailyTourPromo),
-            dataGtmProps: {
-              label: month.month,
-            },
           };
         })
         .slice(0, 4) // never show more than 4 months

--- a/content/webapp/views/pages/works/work/ArchiveCollection/index.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/index.tsx
@@ -19,13 +19,11 @@ const ArchiveCollectionLayout = ({ work }: { work: WorkType }) => {
       id: 'about',
       text: 'About this archive collection',
       url: '#tabpanel-about',
-      dataGtmProps: { label: 'About this archive collection' },
     },
     {
       id: 'contents',
       text: 'Collection contents',
       url: '#tabpanel-contents',
-      dataGtmProps: { label: 'Collection contents' }, // Is this just always the same as the label?
     },
   ];
 

--- a/content/webapp/views/pages/works/work/ArchiveCollection/index.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/index.tsx
@@ -18,12 +18,10 @@ const ArchiveCollectionLayout = ({ work }: { work: WorkType }) => {
     {
       id: 'about',
       text: 'About this archive collection',
-      url: '#tabpanel-about',
     },
     {
       id: 'contents',
       text: 'Collection contents',
-      url: '#tabpanel-contents',
     },
   ];
 


### PR DESCRIPTION
## What does this change?
After working on https://github.com/wellcomecollection/wellcomecollection.org/pull/13381 I realised why we had [this bug](https://github.com/wellcomecollection/wellcomecollection.org/issues/10445), and it was due to having to implement the functionality every time we declared the component. As we don't keep No Js in mind all the time, it fell in some cracks.

So I tried to move as much as possible within the Switch Tabs component and adjust where it was used. There is one I didn't fix as part of this and have left a [comment](https://github.com/wellcomecollection/wellcomecollection.org/issues/10445#issuecomment-5280994145) in the bug ticket to that effect.


**GTM label default.** `Tabs.Switch`'s `dataGtmProps.label` was required, but usually just duplicated `text`. Made it optional, defaulting to `text`, and dropped the now-redundant explicit labels in `ArchiveCollection`, `whats-on.EventsByMonth` and `concept.WorksResults`. `sub-theme.Works.tsx` keeps its explicit label since there `text` has a count suffix (`"All (12)"`) that shouldn't leak into GTM. Also tightened `getSectionTypeLabel`'s return type to `string` (every branch already returned one), needed since `text` is now `string` rather than `ReactNode`.

**No JS fallback for switch tabs ([#10445](https://github.com/wellcomecollection/wellcomecollection.org/issues/10445)).** Switch-style tabs were inaccessible without JS:

- `Tabs.Switch` only got a no-JS anchor fallback when a caller explicitly passed `url` — easy to forget. Now defaults to `#tabpanel-{id}`, matching the `aria-controls` convention it already used.
- `concept.WorksResults` only rendered the *selected* tab's panel, so other tabs had nothing to link to. Now renders every panel, hiding non-selected ones once enhanced (same pattern as `ArchiveCollection`).
- `whats-on.EventsByMonth`  — moved the `id/role="tabpanel"/aria-labelledby` onto the panel wrapper. It also unmounted every inactive month's panel via `.filter()` once enhanced, which left `aria-controls` dangling on the still-visible inactive tabs; now every month's panel stays mounted and only the inactive ones get hidden, matching `ArchiveCollection/concept.WorksResults`. Safe to keep them all mounted since event thumbnails already lazy-load via `next/image`.
- Rendering all panels means hidden ones' thumbnails would load anyway (`display:none` doesn't stop an `<img>` fetching) — added `loading="lazy"` to work thumbnails.


## How to test

- https://www-dev.wellcomecollection.org/whats-on Interact with month tabs with and without JS, make sure they work well and stay accessible
- [This toggle on](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveBrowsing) and https://www-dev.wellcomecollection.org/works/aegabdcp, with and without JS
- https://www-dev.wellcomecollection.org/concepts/vb3xq295 with and without toggle

## Have we considered potential risks?
I don't think I have changed anything for analytics, and should have mostly improved behaviours.