### PR TITLE
Scale the e2e environment down outside office hours

### DIFF
--- a/content/terraform/main.tf
+++ b/content/terraform/main.tf
@@ -50,6 +50,10 @@ module "content-e2e" {
 
   use_fargate_spot = true
 
+  // As for module "identity-e2e"; one Buildkite step scales both services.
+  turn_off_outside_office_hours = true
+  desired_task_count            = 0
+
   providers = {
     aws = aws.stage
   }

--- a/identity/terraform/main.tf
+++ b/identity/terraform/main.tf
@@ -67,6 +67,11 @@ module "identity-e2e" {
 
   use_fargate_spot = true
 
+  // Backstop for when Buildkite skips its scale-down step. A count of 0 keeps
+  // the morning schedule from starting an environment nobody asked for.
+  turn_off_outside_office_hours = true
+  desired_task_count            = 0
+
   providers = {
     aws = aws.stage
   }

--- a/identity/terraform/stack/main.tf
+++ b/identity/terraform/stack/main.tf
@@ -44,6 +44,7 @@ module "identity-service-18012021" {
 
   allow_scaling_to_zero = var.env_suffix != "prod"
 
+  desired_task_count            = var.desired_task_count
   use_fargate_spot              = var.use_fargate_spot
   turn_off_outside_office_hours = var.turn_off_outside_office_hours
 }

--- a/identity/terraform/stack/variables.tf
+++ b/identity/terraform/stack/variables.tf
@@ -35,6 +35,11 @@ variable "turn_off_outside_office_hours" {
   default = false
 }
 
+variable "desired_task_count" {
+  type    = number
+  default = 3
+}
+
 variable "cloudfront_header_secrets" {
   type    = list(string)
   default = []


### PR DESCRIPTION
## What

Adds `turn_off_outside_office_hours = true` to both e2e services, with `desired_task_count = 0` so that both scheduled actions scale down rather than up.

## Why

The e2e environment is meant to run only during a test run. `.buildkite/e2e_on_pull_requests/set_desired_task_count.sh` says so, and the PR pipeline scales both services to 3, deploys, tests, then scales back to 0.

That teardown is skipped when a run fails or is cancelled, because the "Scale down e2e environment" step sits behind a bare `- wait`. Both e2e services have been at 3 desired / 3 running since the identity service's primary deployment was created on 2026-08-14 at 11:32 BST, with no test run since.

Leaving a failed run's environment up is deliberate and worth keeping, so this doesn't change the pipeline. It adds the scheduled scale-down that stage has had since 2023 and e2e never got, as a backstop for when teardown is skipped. A run that fails at 11:00 still leaves the environment up for the rest of the working day.

The prompt for this was an Auth0 failed-login alert over the weekend: a crawler walked www-e2e at 04:43 UTC on Sunday and again at 01:02 UTC on Monday, both times when the environment should have been at zero tasks.

## Why desired_task_count = 0

`turn_off_outside_office_hours` creates two schedules in `terraform-aws-ecs-service//modules/service/scaling.tf`: 19:00 UTC weekdays sets DesiredCount to 0, and 07:00 UTC weekdays sets it back to `desired_task_count`, which defaults to 3. Applied on its own, that would start the e2e environment every weekday morning whether or not anyone was testing it, which is the opposite of what we want. Setting the count to 0 makes both schedules teardown-only.

`desired_task_count` was already plumbed through the content stack; this adds the same variable to the identity stack, defaulting to 3 so prod and stage are unaffected.

## This does not disrupt the PR scale-up

Two things were checked:

- The pipeline scales up with a hardcoded `set_desired_task_count.sh 3`, which calls `aws ecs update-service` directly. It doesn't read anything from terraform.
- `aws_ecs_service` in the pinned v4.0.0 module sets `lifecycle { ignore_changes = [desired_count] }`, so terraform never clamps a running service back down. The config value only takes effect at creation time and as the morning schedule's input.

The one behaviour change is that if the ECS service were ever destroyed and recreated, it would come back at 0 tasks rather than 3. For an environment that should be at zero when idle, that's correct, and the next pipeline run scales it up.

## Testing

`terraform fmt` leaves the added lines alone. The files carry pre-existing `environment` alignment findings on main, which I've left rather than mixing unrelated formatting into this diff.

Planned against both stacks with Terraform 1.9.8, which is what the backend config requires (the repo still uses the legacy `role_arn` attribute, removed in 1.10).

`identity/terraform`: **4 to add, 0 to change, 0 to destroy**. The scheduler IAM role, its policy, and the two schedules, all on `identity-18012021-e2e`. Nothing on prod or stage, and no diff on `desired_count`, confirming the `ignore_changes` behaviour.

`content/terraform`: **4 to add, 1 to change, 0 to destroy**. The same four resources on `content-17092020-e2e`. The one in-place change is pre-existing drift unrelated to this PR: `task_definition` would roll back from revision 12, deployed by the last Buildkite e2e run, to revision 10 from the checked-out config. I confirmed it by planning the base commit, which gives 0 to add, 1 to change. Worth deciding what to do about that before applying the content stack, since applying it would roll the e2e content service back.

Both schedules on both services carry `DesiredCount = 0`, so neither can start the environment.

Not applied.



Part of wellcomecollection/platform#6523.