### PR TITLE
Don't show contributor on archive collection result

### DIFF
--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -100,7 +100,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
                 </>
               )}
 
-              {primaryContributorLabel && (
+              {!shouldShowArchiveCollectionInfo && primaryContributorLabel && (
                 <>
                   <WorkInformationItemSeparator aria-hidden>
                     {' | '}


### PR DESCRIPTION
- For #13320 

## What does this change?

Hides contributor on Archive Collection result as per Anna's request


## How to test

https://www-dev.wellcomecollection.org/search/works?query=Cleave%2C+Surgeon+Captain+%27Peter%27+Thomas+Latimer

with the Archive browser toggle on


## Have we considered potential risks?
N/A