### PR TITLE
zoom level should be 125

### DIFF
--- a/common/views/components/InactivityRedirect/index.tsx
+++ b/common/views/components/InactivityRedirect/index.tsx
@@ -58,9 +58,9 @@ const InactivityRedirect: FunctionComponent<{ isCardiganStory?: boolean }> = ({
       // Clear navigation history to start fresh
       resetNavigationHistory();
 
-      // Append kp_zoomLevel=100 to reset zoom in Kiosk Pro browser
+      // Append kp_zoomLevel=125 to reset zoom in Kiosk Pro browser
       const separator = kioskHomepageUrl.includes('?') ? '&' : '?';
-      const urlWithZoomReset = `${kioskHomepageUrl}${separator}kp_zoomLevel=100`;
+      const urlWithZoomReset = `${kioskHomepageUrl}${separator}kp_zoomLevel=125`;
 
       router.push(urlWithZoomReset);
     },


### PR DESCRIPTION
## What does this change?

⏫ 

This may or may not be responsible for the fact the zoom isn't working on the kiosk, but the should be 125 either way

## How to test

Test on the iPads when deployed

## Have we considered potential risks?

none 