### PR TITLE
Kiosk zoom bug

### DIFF
--- a/common/contexts/AppContext/index.tsx
+++ b/common/contexts/AppContext/index.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { useTheme } from 'styled-components';
 
-import { isValidKioskMode } from '@weco/common/contexts/KioskContext';
+import { isValidKioskMode } from '@weco/common/contexts/KioskContext/is-valid-kiosk-mode';
 import useIsomorphicLayoutEffect from '@weco/common/hooks/useIsomorphicLayoutEffect';
 import {
   ACTIVE_COOKIE_BANNER_ID,

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -18,25 +18,6 @@ import {
   ReadingRoomStories,
   TendernessAndRageContent,
 } from '@weco/common/server-data/prismic';
-import { KioskModeOptionId } from '@weco/toggles';
-import toggleConfig from '@weco/toggles/toggles';
-
-// Valid kiosk mode IDs extracted from toggles config
-const VALID_KIOSK_MODE_IDS =
-  toggleConfig.modes
-    .find(mode => mode.id === 'kioskMode')
-    ?.options.map(option => option.id) ?? [];
-
-/**
- * Validates that a cookie value is a valid kiosk mode option ID.
- * Use this server-side to validate the toggle_kioskMode cookie before using it.
- */
-export function isValidKioskMode(value: unknown): value is KioskModeOptionId {
-  return (
-    typeof value === 'string' &&
-    (VALID_KIOSK_MODE_IDS as readonly string[]).includes(value)
-  );
-}
 
 export type KioskContextType = {
   isKiosk: boolean;

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -14,6 +14,7 @@ import {
   kioskExperienceNames,
   KiosksContentType,
 } from '@weco/common/contexts/KioskContext/kiosks-content';
+import { HistoryProvider } from '@weco/common/hooks/useNavigationHistory';
 import {
   ReadingRoomStories,
   TendernessAndRageContent,
@@ -96,10 +97,30 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
     [kioskExperienceName, kiosksContent]
   );
 
-  // Note: HistoryProvider wraps KioskProvider children in common/views/pages/_app.tsx
-  // It's dynamically imported there (not here) to prevent bundling in non-kiosk apps like identity
+  // HistoryProvider (kiosk prev/next navigation history) safely lives here, wrapping KioskProvider's
+  // own children, because this module is no longer reachable from the identity app at all -
+  // isValidKioskMode (the one thing identity needed from here, via AppContext/civic-uk.ts) now has
+  // its own tiny module (./is-valid-kiosk-mode) instead of going through this barrel.
+  //
+  // History: this used to matter a lot. HistoryProvider previously lived here too, and it broke
+  // identity's build with "Error: Invariant: AsyncLocalStorage accessed in runtime where it is not
+  // available", even though identity never sets kiosk mode - because AppContext (used by identity's
+  // IdentityPageLayout on every page) imported isValidKioskMode from this same file, so anything
+  // else imported here (including HistoryProvider's next/router + sessionStorage code) rode along
+  // into identity's build too, conflicting with identity's Edge middleware (nextjs-auth0 v4) and its
+  // use of AsyncLocalStorage. HistoryProvider got moved out to _app.tsx as a workaround at the time,
+  // wrapped in next/dynamic with ssr:false - which introduced a separate bug, since that meant
+  // nothing rendered at all for the subtree it wrapped (i.e. the whole page) until the client-side
+  // chunk loaded, defeating KioskPro's configured browser zoom level on kiosk pages. Once we found
+  // the actual cause of the identity crash, we fixed it at the source instead (the isValidKioskMode
+  // extraction above) and moved HistoryProvider back here, which is a more natural home for it
+  // anyway - no next/dynamic, no ssr option to get wrong, just a plain import. Verified by literally
+  // reproducing the identity crash with HistoryProvider here before the extraction, and confirming
+  // it's gone after.
   return (
-    <KioskContext.Provider value={value}>{children}</KioskContext.Provider>
+    <KioskContext.Provider value={value}>
+      <HistoryProvider>{children}</HistoryProvider>
+    </KioskContext.Provider>
   );
 };
 

--- a/common/contexts/KioskContext/index.tsx
+++ b/common/contexts/KioskContext/index.tsx
@@ -97,26 +97,6 @@ export const KioskProvider: FunctionComponent<KioskProviderProps> = ({
     [kioskExperienceName, kiosksContent]
   );
 
-  // HistoryProvider (kiosk prev/next navigation history) safely lives here, wrapping KioskProvider's
-  // own children, because this module is no longer reachable from the identity app at all -
-  // isValidKioskMode (the one thing identity needed from here, via AppContext/civic-uk.ts) now has
-  // its own tiny module (./is-valid-kiosk-mode) instead of going through this barrel.
-  //
-  // History: this used to matter a lot. HistoryProvider previously lived here too, and it broke
-  // identity's build with "Error: Invariant: AsyncLocalStorage accessed in runtime where it is not
-  // available", even though identity never sets kiosk mode - because AppContext (used by identity's
-  // IdentityPageLayout on every page) imported isValidKioskMode from this same file, so anything
-  // else imported here (including HistoryProvider's next/router + sessionStorage code) rode along
-  // into identity's build too, conflicting with identity's Edge middleware (nextjs-auth0 v4) and its
-  // use of AsyncLocalStorage. HistoryProvider got moved out to _app.tsx as a workaround at the time,
-  // wrapped in next/dynamic with ssr:false - which introduced a separate bug, since that meant
-  // nothing rendered at all for the subtree it wrapped (i.e. the whole page) until the client-side
-  // chunk loaded, defeating KioskPro's configured browser zoom level on kiosk pages. Once we found
-  // the actual cause of the identity crash, we fixed it at the source instead (the isValidKioskMode
-  // extraction above) and moved HistoryProvider back here, which is a more natural home for it
-  // anyway - no next/dynamic, no ssr option to get wrong, just a plain import. Verified by literally
-  // reproducing the identity crash with HistoryProvider here before the extraction, and confirming
-  // it's gone after.
   return (
     <KioskContext.Provider value={value}>
       <HistoryProvider>{children}</HistoryProvider>

--- a/common/contexts/KioskContext/is-valid-kiosk-mode.ts
+++ b/common/contexts/KioskContext/is-valid-kiosk-mode.ts
@@ -1,0 +1,26 @@
+import { KioskModeOptionId } from '@weco/toggles';
+import toggleConfig from '@weco/toggles/toggles';
+
+// Valid kiosk mode IDs extracted from toggles config
+const VALID_KIOSK_MODE_IDS =
+  toggleConfig.modes
+    .find(mode => mode.id === 'kioskMode')
+    ?.options.map(option => option.id) ?? [];
+
+/**
+ * Validates that a cookie value is a valid kiosk mode option ID.
+ * Use this server-side to validate the toggle_kioskMode cookie before using it.
+ *
+ * This is deliberately kept in its own module, separate from KioskContext/index.tsx (which it's
+ * conceptually part of) - AppContext and civic-uk.ts both need this check, but pulling it in via
+ * the KioskContext barrel would make KioskContext's React Context/Provider code (and anything else
+ * added there, e.g. HistoryProvider previously) part of every app's module graph, including
+ * identity's, which doesn't use kiosk mode at all. See _app.tsx for the history of why that
+ * mattered.
+ */
+export function isValidKioskMode(value: unknown): value is KioskModeOptionId {
+  return (
+    typeof value === 'string' &&
+    (VALID_KIOSK_MODE_IDS as readonly string[]).includes(value)
+  );
+}

--- a/common/contexts/KioskContext/is-valid-kiosk-mode.ts
+++ b/common/contexts/KioskContext/is-valid-kiosk-mode.ts
@@ -13,10 +13,8 @@ const VALID_KIOSK_MODE_IDS =
  *
  * This is deliberately kept in its own module, separate from KioskContext/index.tsx (which it's
  * conceptually part of) - AppContext and civic-uk.ts both need this check, but pulling it in via
- * the KioskContext barrel would make KioskContext's React Context/Provider code (and anything else
- * added there, e.g. HistoryProvider previously) part of every app's module graph, including
- * identity's, which doesn't use kiosk mode at all. See _app.tsx for the history of why that
- * mattered.
+ * the KioskContext would make KioskContext's React Context/Provider code (and anything else
+ * added there, e.g. HistoryProvider) part of the identity app's module graph, which doesn't use kiosk mode at all.
  */
 export function isValidKioskMode(value: unknown): value is KioskModeOptionId {
   return (

--- a/common/services/app/civic-uk.test.ts
+++ b/common/services/app/civic-uk.test.ts
@@ -2,13 +2,13 @@ jest.mock('cookies-next', () => ({
   getCookies: jest.fn(),
 }));
 
-jest.mock('@weco/common/contexts/KioskContext', () => ({
+jest.mock('@weco/common/contexts/KioskContext/is-valid-kiosk-mode', () => ({
   isValidKioskMode: jest.fn(),
 }));
 
 import { getCookies } from 'cookies-next';
 
-import { isValidKioskMode } from '@weco/common/contexts/KioskContext';
+import { isValidKioskMode } from '@weco/common/contexts/KioskContext/is-valid-kiosk-mode';
 
 import { getAllConsentStates, getErrorPageConsent } from './civic-uk';
 

--- a/common/services/app/civic-uk.ts
+++ b/common/services/app/civic-uk.ts
@@ -1,7 +1,7 @@
 import { getCookies } from 'cookies-next';
 import { GetServerSidePropsContext } from 'next';
 
-import { isValidKioskMode } from '@weco/common/contexts/KioskContext';
+import { isValidKioskMode } from '@weco/common/contexts/KioskContext/is-valid-kiosk-mode';
 import { ConsentStatusProps } from '@weco/common/server-data/types';
 
 export const ACTIVE_COOKIE_BANNER_ID = 'ccc-overlay';

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -36,13 +36,31 @@ import ErrorPage from '@weco/common/views/layouts/ErrorPage';
 import { createTheme } from '@weco/common/views/themes/config';
 import { GlobalStyle } from '@weco/common/views/themes/default';
 
-// Dynamically import HistoryProvider to prevent it from being bundled in apps that don't use kiosk mode (e.g. identity)
+// Dynamically importing HistoryProvider prevents it from being bundled into the identity app, which doesn't use kiosk mode.
+//
+// ssr must stay true, otherwise KioskPro's configured browser zoom level
+// does not get applied properly.
+// With ssr:false, nothing renders for the subtree wrapped by HistoryProvider
+// until the client-side chunk has loaded and the zoom got applied to the
+// black page, then lost when the real content appeared.
+//
+// ssr:true is also just the better default.
+// HistoryProvider's provides sensible fallback values and there is no reason to withhold SSR from everything nested inside it.
+//
+// N.B. (ssr:false was added in July 2026 as part of a fix for a crash in identity
+// "Error: Invariant: AsyncLocalStorage accessed in runtime where it is not available"
+// which seemed to arise from this module being
+// evaluated server-side wherever this file is used,
+// conflicting with how identity's Edge middleware (nextjs-auth0 v4) sets up AsyncLocalStorage.
+// This no longer seems to be the case.
+// Both ssr:true and a fully static, non-dynamic import no longer produces the crash.
+// If identity's build/middleware ever throws that error again, this is the line to look at first.
 const HistoryProvider = dynamic(
   () =>
     import('@weco/common/hooks/useNavigationHistory').then(
       mod => mod.HistoryProvider
     ),
-  { ssr: false }
+  { ssr: true }
 );
 
 // Error pages can't send anything via the data fetching methods as

--- a/common/views/pages/_app.tsx
+++ b/common/views/pages/_app.tsx
@@ -1,6 +1,5 @@
 import { GetServerSideProps, NextPage } from 'next';
 import type { AppProps } from 'next/app';
-import dynamic from 'next/dynamic';
 import React, { ReactElement, ReactNode, useEffect, useMemo } from 'react';
 import { ThemeProvider } from 'styled-components';
 
@@ -35,33 +34,6 @@ import LoadingIndicator from '@weco/common/views/components/LoadingIndicator';
 import ErrorPage from '@weco/common/views/layouts/ErrorPage';
 import { createTheme } from '@weco/common/views/themes/config';
 import { GlobalStyle } from '@weco/common/views/themes/default';
-
-// Dynamically importing HistoryProvider prevents it from being bundled into the identity app, which doesn't use kiosk mode.
-//
-// ssr must stay true, otherwise KioskPro's configured browser zoom level
-// does not get applied properly.
-// With ssr:false, nothing renders for the subtree wrapped by HistoryProvider
-// until the client-side chunk has loaded and the zoom got applied to the
-// black page, then lost when the real content appeared.
-//
-// ssr:true is also just the better default.
-// HistoryProvider's provides sensible fallback values and there is no reason to withhold SSR from everything nested inside it.
-//
-// N.B. (ssr:false was added in July 2026 as part of a fix for a crash in identity
-// "Error: Invariant: AsyncLocalStorage accessed in runtime where it is not available"
-// which seemed to arise from this module being
-// evaluated server-side wherever this file is used,
-// conflicting with how identity's Edge middleware (nextjs-auth0 v4) sets up AsyncLocalStorage.
-// This no longer seems to be the case.
-// Both ssr:true and a fully static, non-dynamic import no longer produces the crash.
-// If identity's build/middleware ever throws that error again, this is the line to look at first.
-const HistoryProvider = dynamic(
-  () =>
-    import('@weco/common/hooks/useNavigationHistory').then(
-      mod => mod.HistoryProvider
-    ),
-  { ssr: true }
-);
 
 // Error pages can't send anything via the data fetching methods as
 // the page needs to be rendered as soon as the error happens.
@@ -218,9 +190,7 @@ const WecoApp: NextPage<WecoAppProps> = ({ pageProps, router, Component }) => {
                         serverData.prismic.tendernessAndRageContent
                       }
                     >
-                      {/* HistoryProvider is dynamically imported above and wrapped here (not in KioskProvider)
-                          to prevent bundling in non-kiosk apps like identity */}
-                      <HistoryProvider>{children}</HistoryProvider>
+                      {children}
                     </KioskProvider>
                   )}
                 >


### PR DESCRIPTION
## What does this change?

### Issue being solved

Pages weren't respecting KioskPro's configured zoom level when a kiosk mode was selected.

This happened because `HistoryProvider` (used for kiosk prev/next navigation history logic) was dynamically imported into `_app.tsx` with `{ ssr: false }` (in #13252, see below for why). This meant Next.js rendered nothing for the entire subtree wrapped by HistoryProvider — i.e. the whole page — until the client-side JS chunk had loaded. The server-rendered HTML was effectively blank, so KioskPro's configured zoom got applied to nothing, then lost when the real content rendered.

### Why `ssr: false` was there in the first place

The `dynamic(..., { ssr: false })` wrapper (added in #13252) existed as part of a fix to prevent the identity app from crashing - `Error: Invariant: AsyncLocalStorage accessed in runtime where it is not available`, but it wasn't a material part of the fix. Simply moving `HistoryProvider`'s import out of `KioskContext/index.tsx` and into `_app.tsx` was the important part.

Digging into it now it looks like `AppContext` (used by identity's `IdentityPageLayout` on every page) and `civic-uk.ts` (also on identity's path, via `_document.tsx`) both import `isValidKioskMode` from `KioskContext`. Since importing anything from a file pulls in the whole module, that import was enough to bundle whatever else lived in `KioskContext/index.tsx` into identity's build too - including `HistoryProvider`, while it was there. Moving `HistoryProvider` out meant `AppContext`'s/`civic-uk.ts`'s import no longer dragged it along.

Putting `HistoryProvider` back inside `KioskContext/index.tsx` (with `AppContext`/`civic-uk.ts` still importing via the barrel) reproduces the identity crash, and it goes away again once those two imports are moved off the barrel - see risks below. Not sure why that path mattered and `_app.tsx`'s own import doesn't, but fixing the actual coupling, rather than just working around it, lets us put `HistoryProvider` back where it belongs.

## Fix

The simple fix for the immediate zoom issue would be to set `{ ssr: true }`.
However, moving `HistoryProvider` out to `_app.tsx` in #13252 worked around the identity app issue without addressing the actual coupling issues (`AppContext`/`civic-uk.ts` reaching `KioskContext/index.tsx` via its barrel). A better fix is to sort that out too, which means we can directly import `HistoryProvider` and take care of the zoom issue at the same time.

That's what this PR does.

- `isValidKioskMode` is extracted into its own module (`common/contexts/KioskContext/is-valid-kiosk-mode.ts`)
- `AppContext`/`civic-uk.ts` now import it directly rather than through the `KioskContext` barrel - this was the specific path we confirmed reproduces the crash (see above and risks below), so removing it means we're no longer relying on being careful about what we add to `KioskContext/index.tsx`.

With that fixed:

- `HistoryProvider` has been moved back into `KioskContext/index.tsx` (its more natural home, next to `KioskProvider`)
- `_app.tsx` is back to simply rendering `KioskProvider`'s children
- the `next/dynamic` wrapper is gone entirely (the module is ~6.6KB source with no heavy dependencies, so the bundle-splitting it was providing wasn't worth the complexity)
- The kiosk pages now render server side, which is better anyway. They were unnecessarily blocked from rendering by the `HistoryProvider`, which provides sensible fallbacks until its effects run and populate the real state from sessionStorage.

## How to test

### Make sure identity app still works:

- Run the identity app (`yarn identity`)
- Are you able to log in and view your account page?

### Check kioskPro zoom:

N.B. The easiest way to do this is to deploy it, which I think is fine because it is behind a toggle and currently broken. (Also I've tested locally (which is a bit of a pain) and deployed the fix directly to stage in the process of doing this work and I'm confident it works)

- On an iPad, run kioskPro with a zoom level configured
- Select a kiosk mode (Tenderness & Rage or Reading Room) via the [toggles dashboard](https://dash.wellcomecollection.org/toggles/#modes)
- Load a kiosk page (e.g. the [T&R explore-more page](https://wellcomecollection.org/exhibitions/tenderness-and-rage/explore-more))
- The zoom should stay applied
- Confirm kiosk prev/next navigation (left side of the nav bar) still works as expected.

## Have we considered potential risks?

Low risk.

- Putting `HistoryProvider` back inside `KioskContext/index.tsx` confirmed it is what produces the `AsyncLocalStorage` error
- Putting `HistoryProvider` back in `KioskContext/index.tsx` after the `isValidKioskMode` extraction no longer crashes identity - in this state, `_app.tsx` is still importing `KioskProvider` from `KioskContext/index.tsx` directly (as it always has), so this test does cover that remaining import path, not just the `AppContext`/`civic-uk.ts` one
- Confirmed `ssr:true` vs `ssr:false` and `next/dynamic` vs a plain import make no difference to identity on their own, which is what was expected.
