### PR TITLE
Thumbnail image bug

### DIFF
--- a/common/utils/convert-image-uri.ts
+++ b/common/utils/convert-image-uri.ts
@@ -2,7 +2,7 @@ import urlTemplate from 'url-template';
 
 const prismicBaseUri = 'https://images.prismic.io/wellcomecollection';
 const iiifImageUri = 'https://iiif.wellcomecollection.org/image/';
-const iiifThumbsUri = 'https://iiif.wellcomecollection.org/thumbs/';
+export const iiifThumbsUri = 'https://iiif.wellcomecollection.org/thumbs/';
 
 function determineSrc(url: string): string {
   if (url.startsWith(prismicBaseUri)) {

--- a/content/webapp/test/utils/convert-iiif-uri.test.ts
+++ b/content/webapp/test/utils/convert-iiif-uri.test.ts
@@ -10,12 +10,28 @@ describe('convertRequestUriToInfoUri', () => {
     );
   });
 
-  it('finds the info.json for an unrecognised URI', () => {
+  it('finds the info.json for a IIIF URI with no request parameters', () => {
     const result = convertRequestUriToInfoUri(
       'https://iiif.wellcomecollection.org/image/b0007.jp2'
     );
     expect(result).toEqual(
       'https://iiif.wellcomecollection.org/image/b0007.jp2/info.json'
+    );
+  });
+
+  it('returns undefined for an unrecognised URI', () => {
+    const result = convertRequestUriToInfoUri(
+      'https://example.com/not-a-iiif-uri'
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('finds the info.json for a /thumbs/ URI', () => {
+    const result = convertRequestUriToInfoUri(
+      'https://iiif.wellcomecollection.org/thumbs/b30268412_0027.jp2/full/238,/0/default.jpg'
+    );
+    expect(result).toEqual(
+      'https://iiif.wellcomecollection.org/thumbs/b30268412_0027.jp2/info.json'
     );
   });
 });

--- a/content/webapp/utils/iiif/convert-iiif-uri.ts
+++ b/content/webapp/utils/iiif/convert-iiif-uri.ts
@@ -3,15 +3,13 @@
 // {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}
 // Image Information Request URI Syntax
 // {scheme}://{server}{/prefix}/{identifier}/info.json
-export function convertRequestUriToInfoUri(requestUri: string): string {
+export function convertRequestUriToInfoUri(
+  requestUri: string
+): string | undefined {
   const match =
     requestUri &&
     requestUri.match(
-      /^https:\/\/iiif\.wellcomecollection\.org\/image\/([^/]+)/
+      /^https:\/\/iiif\.wellcomecollection\.org\/(?:image|thumbs)\/([^/]+)/
     );
-  if (match && match[0]) {
-    return `${match[0]}/info.json`;
-  } else {
-    return `${requestUri}/info.json`;
-  }
+  return match && match[0] ? `${match[0]}/info.json` : undefined;
 }

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFItem/index.tsx
@@ -35,7 +35,6 @@ import { fetchCanvasOcr } from '@weco/content/services/iiif/fetch/canvasOcr';
 import { transformCanvasOcr } from '@weco/content/services/iiif/transformers/canvasOcr';
 import { missingAltTextMessage } from '@weco/content/services/wellcome/catalogue/works';
 import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
-import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 import { hasRestrictedItem } from '@weco/content/utils/iiif/v3';
 import {
   getFileSize,
@@ -169,7 +168,6 @@ const IIIFImage: FunctionComponent<{
   const [ocrText, setOcrText] = useState(missingAltTextMessage);
   const imageService = getImageServiceFromItem(item);
   const imageUrl = imageService?.['@id'] || '';
-  const infoUrl = convertRequestUriToInfoUri(imageUrl);
   const urlTemplate = imageUrl ? iiifImageTemplate(imageUrl) : undefined;
   useEffect(() => {
     const fetchOcr = async () => {
@@ -191,7 +189,7 @@ const IIIFImage: FunctionComponent<{
         <ImageViewerContainer>
           <ImageViewerPositioned>
             <ImageViewer
-              infoUrl={infoUrl}
+              imageUrl={imageUrl}
               id={imageUrl}
               width={canvas.width || 0}
               height={canvas.height || 0}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.tsx
@@ -436,7 +436,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
               !hasImageService &&
               (isFullSupportBrowser || !hasOnlyRenderableImages) && (
                 <ImageViewer
-                  infoUrl={iiifImageLocation.url}
+                  imageUrl={iiifImageLocation.url}
                   id={imageUrl}
                   width={800}
                   index={0}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
@@ -126,13 +126,12 @@ const IIIFViewerImage = (
               currentTarget.src = newSrc;
               currentTarget.removeAttribute('srcset');
               currentTarget.removeAttribute('sizes');
-            } else {
-              errorHandler && errorHandler();
             }
-          } else {
-            // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
-            errorHandler && errorHandler();
           }
+          // Even if we found a smaller size to retry, the failure may also be
+          // because the authorisation cookie is missing/no longer valid, so
+          // we always check that too
+          errorHandler && errorHandler();
         }}
         src={src}
         srcSet={srcSet}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
@@ -6,20 +6,19 @@ import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
 import { IIIFImage } from '@weco/content/services/iiif/types/image/v2';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
-async function getImageMax(url: string): Promise<number> {
+async function getImageMax(url: string): Promise<number | undefined> {
+  const infoUrl = convertRequestUriToInfoUri(url);
+  if (!infoUrl) return undefined;
   try {
-    const infoUrl = convertRequestUriToInfoUri(url);
     const resp = await fetch(infoUrl);
     const info: Partial<IIIFImage> = await resp.json();
     // N.B property is called maxWidth, but it is actually the max allowed for the longest side, see https://wellcome.slack.com/archives/CBT40CMKQ/p1702897884100559
-    const max =
-      info.profile?.find(
-        (item): item is { maxWidth: number } =>
-          typeof item !== 'string' && Boolean(item.maxWidth)
-      )?.maxWidth || 1000;
-    return max || 1001;
+    return info.profile?.find(
+      (item): item is { maxWidth: number } =>
+        typeof item !== 'string' && Boolean(item.maxWidth)
+    )?.maxWidth;
   } catch {
-    return 1000;
+    return undefined;
   }
 }
 
@@ -113,13 +112,17 @@ const IIIFViewerImage = (
             setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
             // we need to know the max size of the longest side first
             const imageMax = await getImageMax(currentTarget.src);
-            const isPortrait = Boolean(height && height > width);
-            const newSrc = isPortrait
-              ? convertIiifImageUri(currentTarget.src, imageMax, true)
-              : convertIiifImageUri(currentTarget.src, imageMax);
-            currentTarget.src = newSrc;
-            currentTarget.removeAttribute('srcset');
-            currentTarget.removeAttribute('sizes');
+            if (imageMax) {
+              const isPortrait = Boolean(height && height > width);
+              const newSrc = isPortrait
+                ? convertIiifImageUri(currentTarget.src, imageMax, true)
+                : convertIiifImageUri(currentTarget.src, imageMax);
+              currentTarget.src = newSrc;
+              currentTarget.removeAttribute('srcset');
+              currentTarget.removeAttribute('sizes');
+            } else {
+              errorHandler && errorHandler();
+            }
           } else {
             // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
             errorHandler && errorHandler();

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewerImage.tsx
@@ -2,11 +2,17 @@ import { ForwardedRef, forwardRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
+import {
+  convertIiifImageUri,
+  iiifThumbsUri,
+} from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
 import { IIIFImage } from '@weco/content/services/iiif/types/image/v2';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 async function getImageMax(url: string): Promise<number | undefined> {
+  // /thumbs/ is a fixed-size derivative service with no maxWidth/access-cap
+  // concept, so there's no point requesting its info.json at all
+  if (url.startsWith(iiifThumbsUri)) return undefined;
   const infoUrl = convertRequestUriToInfoUri(url);
   if (!infoUrl) return undefined;
   try {

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ImageViewer.tsx
@@ -43,7 +43,7 @@ type ImageViewerProps = {
   id: string;
   width: number;
   height?: number;
-  infoUrl: string;
+  imageUrl: string;
   alt: string;
   urlTemplate: (v: IIIFUriProps) => string;
   loadHandler?: () => void;
@@ -56,7 +56,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   width,
   height,
   alt,
-  infoUrl,
+  imageUrl,
   urlTemplate,
   loadHandler,
   index,
@@ -118,7 +118,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         })
         .join(',')
     );
-  }, [infoUrl, rotation]);
+  }, [imageUrl, rotation]);
 
   const escapeCloseViewer = ({ keyCode }: KeyboardEvent) => {
     if (keyCode === 27) {

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/ZoomedImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/ZoomedImage.tsx
@@ -121,7 +121,9 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   }
 
   useEffect(() => {
-    !hasInitialised.current && setupViewer(zoomInfoUrl, 'zoomedImage');
+    !hasInitialised.current &&
+      zoomInfoUrl &&
+      setupViewer(zoomInfoUrl, 'zoomedImage');
     lastControl?.current && lastControl.current.focus();
 
     return () => viewerRef.current?.destroy();

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
@@ -35,7 +35,6 @@ import { fetchCanvasOcr } from '@weco/content/services/iiif/fetch/canvasOcr';
 import { transformCanvasOcr } from '@weco/content/services/iiif/transformers/canvasOcr';
 import { missingAltTextMessage } from '@weco/content/services/wellcome/catalogue/works';
 import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
-import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 import { hasRestrictedItem } from '@weco/content/utils/iiif/v3';
 import {
   getFileSize,
@@ -167,7 +166,6 @@ const IIIFImage: FunctionComponent<{
   const [ocrText, setOcrText] = useState(missingAltTextMessage);
   const imageService = getImageServiceFromItem(item);
   const imageUrl = imageService?.['@id'] || '';
-  const infoUrl = convertRequestUriToInfoUri(imageUrl);
   const urlTemplate = imageUrl ? iiifImageTemplate(imageUrl) : undefined;
   useEffect(() => {
     const fetchOcr = async () => {
@@ -189,7 +187,7 @@ const IIIFImage: FunctionComponent<{
         <ImageViewerContainer>
           <ImageViewerPositioned>
             <ImageViewer
-              infoUrl={infoUrl}
+              imageUrl={imageUrl}
               id={imageUrl}
               width={canvas.width || 0}
               height={canvas.height || 0}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -472,7 +472,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
               !hasIiifImageService &&
               (isFullSupportBrowser || !hasOnlyRenderableImages) && (
                 <ImageViewer
-                  infoUrl={iiifImageLocation.url}
+                  imageUrl={iiifImageLocation.url}
                   id={imageUrl}
                   width={800}
                   index={0}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
@@ -126,13 +126,12 @@ const IIIFViewerImage = (
               currentTarget.src = newSrc;
               currentTarget.removeAttribute('srcset');
               currentTarget.removeAttribute('sizes');
-            } else {
-              errorHandler && errorHandler();
             }
-          } else {
-            // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
-            errorHandler && errorHandler();
           }
+          // Even if we found a smaller size to retry, the failure may also be
+          // because the authorisation cookie is missing/no longer valid, so
+          // we always check that too
+          errorHandler && errorHandler();
         }}
         src={src}
         srcSet={srcSet}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
@@ -6,20 +6,19 @@ import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
 import { IIIFImage } from '@weco/content/services/iiif/types/image/v2';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
-async function getImageMax(url: string): Promise<number> {
+async function getImageMax(url: string): Promise<number | undefined> {
+  const infoUrl = convertRequestUriToInfoUri(url);
+  if (!infoUrl) return undefined;
   try {
-    const infoUrl = convertRequestUriToInfoUri(url);
     const resp = await fetch(infoUrl);
     const info: Partial<IIIFImage> = await resp.json();
     // N.B property is called maxWidth, but it is actually the max allowed for the longest side, see https://wellcome.slack.com/archives/CBT40CMKQ/p1702897884100559
-    const max =
-      info.profile?.find(
-        (item): item is { maxWidth: number } =>
-          typeof item !== 'string' && Boolean(item.maxWidth)
-      )?.maxWidth || 1000;
-    return max || 1001;
+    return info.profile?.find(
+      (item): item is { maxWidth: number } =>
+        typeof item !== 'string' && Boolean(item.maxWidth)
+    )?.maxWidth;
   } catch {
-    return 1000;
+    return undefined;
   }
 }
 
@@ -113,13 +112,17 @@ const IIIFViewerImage = (
             setTryLoadingSmallerImg(false); // prevent looping if image fails to load again
             // we need to know the max size of the longest side first
             const imageMax = await getImageMax(currentTarget.src);
-            const isPortrait = Boolean(height && height > width);
-            const newSrc = isPortrait
-              ? convertIiifImageUri(currentTarget.src, imageMax, true)
-              : convertIiifImageUri(currentTarget.src, imageMax);
-            currentTarget.src = newSrc;
-            currentTarget.removeAttribute('srcset');
-            currentTarget.removeAttribute('sizes');
+            if (imageMax) {
+              const isPortrait = Boolean(height && height > width);
+              const newSrc = isPortrait
+                ? convertIiifImageUri(currentTarget.src, imageMax, true)
+                : convertIiifImageUri(currentTarget.src, imageMax);
+              currentTarget.src = newSrc;
+              currentTarget.removeAttribute('srcset');
+              currentTarget.removeAttribute('sizes');
+            } else {
+              errorHandler && errorHandler();
+            }
           } else {
             // If the image still fails to load, we check to see if it's because the authorisation cookie is missing/no longer valid
             errorHandler && errorHandler();

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
@@ -2,11 +2,17 @@ import { ForwardedRef, forwardRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { convertIiifImageUri } from '@weco/common/utils/convert-image-uri';
+import {
+  convertIiifImageUri,
+  iiifThumbsUri,
+} from '@weco/common/utils/convert-image-uri';
 import LL from '@weco/common/views/components/styled/LL';
 import { IIIFImage } from '@weco/content/services/iiif/types/image/v2';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 async function getImageMax(url: string): Promise<number | undefined> {
+  // /thumbs/ is a fixed-size derivative service with no maxWidth/access-cap
+  // concept, so there's no point requesting its info.json at all
+  if (url.startsWith(iiifThumbsUri)) return undefined;
   const infoUrl = convertRequestUriToInfoUri(url);
   if (!infoUrl) return undefined;
   try {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewer.tsx
@@ -43,7 +43,7 @@ type ImageViewerProps = {
   id: string;
   width: number;
   height?: number;
-  infoUrl: string;
+  imageUrl: string;
   alt: string;
   urlTemplate: (v: IIIFUriProps) => string;
   loadHandler?: () => void;
@@ -56,7 +56,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
   width,
   height,
   alt,
-  infoUrl,
+  imageUrl,
   urlTemplate,
   loadHandler,
   index,
@@ -120,7 +120,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
         })
         .join(',')
     );
-  }, [infoUrl, rotation]);
+  }, [imageUrl, rotation]);
 
   const escapeCloseViewer = ({ keyCode }: KeyboardEvent) => {
     if (keyCode === 27) {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
@@ -131,7 +131,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   }
 
   useEffect(() => {
-    if (!hasInitialised.current) {
+    if (!hasInitialised.current && zoomInfoUrl) {
       setupViewer(zoomInfoUrl, 'zoomedImage');
     }
     if (lastControl.current) {


### PR DESCRIPTION
- For #13395

## What does this change?
The viewer's image onError handler assumes any failed image load might be due to an access-tier size cap, so it looks up the image's info.json to find its maxWidth and retries at a smaller size. 

There are 2 issues related to this for /thumbs/ images:

1. convertRequestUriToInfoUri() only recognised /image/ request URIs. For a /thumbs/... URL it fell through to a fallback that appended /info.json to the whole request path — region, size, rotation, quality and format included — producing an invalid lookup URL (e.g. .../thumbs/b30268412_0027.jp2/full/238,/0/default.jpg/info.json).

2. Even with a well-formed URL, /thumbs/ is a fixed-size derivative service with no maxWidth/access-cap concept, so the retry could never succeed anyway. This generates ~59.4M malformed info.json requests/month. 

Fixing the URL alone would just turn these into well-formed-but-pointless requests without cutting the volume, so the fix has two parts:

- convertRequestUriToInfoUri() now also matches /thumbs/ URIs, and returns undefined for anything it doesn't recognise instead of guessing a malformed fallback.
- getImageMax() short-circuits before ever calling fetch when the failing image is a /thumbs/ URL (checked via the existing iiifThumbsUri constant, now exported from convert-image-uri.ts). It also returns undefined (rather than a default guess) whenever there's no usable info URL or no maxWidth in the profile.
- The viewer's onError handler now checks imageMax before attempting a retry; if it's undefined, it falls straight through to the existing fallback (errorHandler, which checks for a missing/invalid auth cookie) instead of constructing a bogus retry URL.
- As a smaller cleanup: ImageViewer's infoUrl prop was only ever used as a useEffect dependency to trigger recomputing the image src/srcset — never read as an actual URL — so it's renamed to imageUrl to reflect what's actually passed in, and a redundant convertRequestUriToInfoUri call in IIIFItem (which produced a value used the same way) was removed in favour of passing imageUrl directly.

All of the above is duplicated across the refactored/ and legacy/ copies of the IIIF viewer, matching the existing structure of that component tree.

## How to test
- `yarn tsc` and `yarn test:content` pass.
- `yarn content` open a work with a /thumbs/ derivative image that fails to load (e.g. throttle/block the request in devtools). 
- Open Developer Tools and click on the Network tab.
- Click the three-dots menu icon for the Network tab and then 'More tools'.
- Click 'Request conditions' to open the request blocking pane. 
- Click Add pattern and paste in the following pattern `https://iiif.wellcomecollection.org/thumbs/*`
- Ensure the blocking checkbox is enabled and reload the page
- You should see blocked images, but no requests for info.json files under Fetch/XHR (compare to prod where you will see both blocked image requests AND blocked info.json requests)
- Delete the blocking rule and then use [this work](https://www-dev.wellcomecollection.org/works/j3g3map9/items) to confirm the /image/ (in-copyright/size-capped) viewer retry behaviour is unchanged.
- Scroll the main images and you should see failing images requests, info.json requests and successful image requests for smaller images in the dev tools network tab (looks like info.json returns status of 401, but the response body is there and correct)

## Have we considered potential risks?
Low risk — this only changes behaviour on the error/retry path for failed image loads, not the happy path.
The main risk is a case where getImageMax's old "always return a number, defaulting to 1000" behaviour was silently masking something (i.e. some /image/ URL that doesn't match the regex for a reason other than being /thumbs/). With the new undefined-on-fail behaviour, such cases now go straight to the auth-cookie error handler rather than retrying with a guessed 1000px size. This seems like the more correct behaviour, but is worth flagging as a change in what the fallback path does for edge cases.
