### PR TITLE
IVR: Move `mainImageService` to context

### DIFF
--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -12,6 +12,7 @@ import {
   CanvasRotatedImage,
   ItemViewerQuery,
   ParentManifest,
+  PartialImageService,
 } from '@weco/content/types/item-viewer';
 import {
   TransformedCanvas,
@@ -37,6 +38,7 @@ export type ItemViewerContextProps = {
   currentCanvas: TransformedCanvas | undefined;
   totalCanvases: number;
   hasMultipleCanvases: boolean;
+  mainImageService: PartialImageService;
 
   // UI props:
   viewerRef: RefObject<HTMLDivElement | null> | undefined;
@@ -111,6 +113,7 @@ export const defaultItemViewerContext: ItemViewerContextProps = {
   currentCanvas: undefined,
   totalCanvases: 0,
   hasMultipleCanvases: false,
+  mainImageService: { '@id': undefined },
 
   // UI props:
   viewerRef: undefined,

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -74,6 +74,11 @@ function createMockRefactoredItemViewerContext(
     defaultItemViewerContextRefactored.canvasIndexById;
 
   const totalCanvases = transformedManifest.canvases.length;
+  const currentCanvas = getCurrentCanvas({
+    transformedManifest,
+    canvasIndexById,
+    canvas: query.canvas,
+  });
 
   return {
     ...defaultItemViewerContextRefactored,
@@ -83,13 +88,10 @@ function createMockRefactoredItemViewerContext(
     // having to pass each one by hand. Anything derived from the manifest that
     // goes on the context needs adding here too, or tests that override the
     // manifest will silently fall back to the default context's value.
-    currentCanvas: getCurrentCanvas({
-      transformedManifest,
-      canvasIndexById,
-      canvas: query.canvas,
-    }),
+    currentCanvas,
     totalCanvases,
     hasMultipleCanvases: totalCanvases > 1,
+    mainImageService: { '@id': currentCanvas?.imageServiceId },
     ...overrides,
   };
 }

--- a/content/webapp/test/utils/convert-iiif-uri.test.ts
+++ b/content/webapp/test/utils/convert-iiif-uri.test.ts
@@ -26,6 +26,11 @@ describe('convertRequestUriToInfoUri', () => {
     expect(result).toBeUndefined();
   });
 
+  it('returns undefined when given undefined', () => {
+    const result = convertRequestUriToInfoUri(undefined);
+    expect(result).toBeUndefined();
+  });
+
   it('finds the info.json for a /thumbs/ URI', () => {
     const result = convertRequestUriToInfoUri(
       'https://iiif.wellcomecollection.org/thumbs/b30268412_0027.jp2/full/238,/0/default.jpg'

--- a/content/webapp/utils/iiif/convert-iiif-uri.ts
+++ b/content/webapp/utils/iiif/convert-iiif-uri.ts
@@ -4,7 +4,7 @@
 // Image Information Request URI Syntax
 // {scheme}://{server}{/prefix}/{identifier}/info.json
 export function convertRequestUriToInfoUri(
-  requestUri: string
+  requestUri: string | undefined
 ): string | undefined {
   const match =
     requestUri &&

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import {
   Work,
@@ -105,5 +105,59 @@ describe('IIIFViewer', () => {
     );
 
     expect(screen.queryByTestId('active-index')).not.toBeInTheDocument();
+  });
+
+  // These exercise the real IIIFViewer -> context -> ZoomedImage wiring for
+  // mainImageService, rather than ZoomedImage.test.tsx's mocked context value
+  // (which derives mainImageService independently in the test fixture and so
+  // wouldn't catch a break in IIIFViewer's own derivation/provider wiring).
+  describe('zoomed image', () => {
+    const originalFetch = global.fetch;
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+      // Never resolves - we only care which URL it's called with (or whether
+      // it's called at all), and letting the promise settle would require
+      // also faking openseadragon's viewer shape.
+      fetchMock = jest.fn(() => new Promise(() => undefined));
+      global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("fetches the info.json for the current canvas's image service when zoomed in", async () => {
+      renderViewer(
+        createMockManifest({
+          canvases: [
+            createMockCanvas({
+              imageServiceId:
+                'https://iiif.wellcomecollection.org/image/b0001.jp2',
+            }),
+          ],
+        })
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+
+      expect(await screen.findByTestId('zoomed-image')).toBeInTheDocument();
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://iiif.wellcomecollection.org/image/b0001.jp2/info.json'
+      );
+    });
+
+    it('does not fetch, and does not crash, when the current canvas has no image service', async () => {
+      renderViewer(
+        createMockManifest({
+          canvases: [createMockCanvas({ imageServiceId: undefined })],
+        })
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+
+      expect(await screen.findByTestId('zoomed-image')).toBeInTheDocument();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -396,6 +396,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         currentCanvas,
         totalCanvases,
         hasMultipleCanvases,
+        mainImageService,
 
         // UI Props:
         viewerRef,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewerImage.tsx
@@ -9,15 +9,20 @@ import {
 import LL from '@weco/common/views/components/styled/LL';
 import { IIIFImage } from '@weco/content/services/iiif/types/image/v2';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
+
 async function getImageMax(url: string): Promise<number | undefined> {
   // /thumbs/ is a fixed-size derivative service with no maxWidth/access-cap
   // concept, so there's no point requesting its info.json at all
   if (url.startsWith(iiifThumbsUri)) return undefined;
+
   const infoUrl = convertRequestUriToInfoUri(url);
+
   if (!infoUrl) return undefined;
+
   try {
     const resp = await fetch(infoUrl);
     const info: Partial<IIIFImage> = await resp.json();
+
     // N.B property is called maxWidth, but it is actually the max allowed for the longest side, see https://wellcome.slack.com/archives/CBT40CMKQ/p1702897884100559
     return info.profile?.find(
       (item): item is { maxWidth: number } =>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.test.tsx
@@ -1,3 +1,5 @@
+import { screen } from '@testing-library/react';
+
 import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
 import {
@@ -42,13 +44,11 @@ describe('ZoomedImage', () => {
   });
 
   it('renders the zoomed image container', () => {
-    const { container } = renderZoomedImage({
+    renderZoomedImage({
       transformedManifest: createMockManifest(),
     });
 
-    expect(
-      container.querySelector('#image-viewer-zoomedImage')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('zoomed-image')).toBeInTheDocument();
   });
 
   it('fetches the info.json for the canvas in the correct structural position, not just its array position', () => {
@@ -82,14 +82,12 @@ describe('ZoomedImage', () => {
       imageServiceId: undefined,
     });
 
-    const { container } = renderZoomedImage({
+    renderZoomedImage({
       transformedManifest: createMockManifest({
         canvases: [canvasWithNoImageService],
       }),
     });
 
-    expect(
-      container.querySelector('#image-viewer-zoomedImage')
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('zoomed-image')).toBeInTheDocument();
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.test.tsx
@@ -75,4 +75,21 @@ describe('ZoomedImage', () => {
       'https://iiif.wellcomecollection.org/image/canvas-b.jp2/info.json'
     );
   });
+
+  it('renders without crashing when the current canvas has no image service', () => {
+    const canvasWithNoImageService = createMockCanvas({
+      id: 'a',
+      imageServiceId: undefined,
+    });
+
+    const { container } = renderZoomedImage({
+      transformedManifest: createMockManifest({
+        canvases: [canvasWithNoImageService],
+      }),
+    });
+
+    expect(
+      container.querySelector('#image-viewer-zoomedImage')
+    ).toBeInTheDocument();
+  });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
@@ -62,7 +62,7 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   const { mainImageService, setShowZoomed } = useItemViewerContext();
   const zoomInfoUrl = iiifImageLocation
     ? iiifImageLocation.url
-    : convertRequestUriToInfoUri(mainImageService['@id'] || '');
+    : convertRequestUriToInfoUri(mainImageService['@id']);
   const [scriptError, setScriptError] = useState(false);
   // osdViewerInstance re-renders the click handlers below with the current
   // viewer; viewerRef tracks the same instance without triggering a

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ZoomedImage.tsx
@@ -16,7 +16,6 @@ import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 import Control from '@weco/common/views/components/Control';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
-import { PartialImageService } from '@weco/content/types/item-viewer';
 import { convertRequestUriToInfoUri } from '@weco/content/utils/iiif/convert-iiif-uri';
 
 const ZoomedImageContainer = styled.div`
@@ -60,10 +59,7 @@ type ZoomedImageProps = OptionalToUndefined<{
 const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
   iiifImageLocation,
 }) => {
-  const { currentCanvas, setShowZoomed } = useItemViewerContext();
-  const mainImageService: PartialImageService = {
-    '@id': currentCanvas?.imageServiceId,
-  };
+  const { mainImageService, setShowZoomed } = useItemViewerContext();
   const zoomInfoUrl = iiifImageLocation
     ? iiifImageLocation.url
     : convertRequestUriToInfoUri(mainImageService['@id'] || '');
@@ -253,7 +249,10 @@ const ZoomedImage: FunctionComponent<ZoomedImageProps> = ({
           </ControlSpacer>
         </Space>
       </Controls>
-      <OpenSeadragonContainer id="image-viewer-zoomedImage">
+      <OpenSeadragonContainer
+        id="image-viewer-zoomedImage"
+        data-testid="zoomed-image"
+      >
         {scriptError && <ErrorMessage />}
       </OpenSeadragonContainer>
     </ZoomedImageContainer>


### PR DESCRIPTION
- For #12986 

## What does this change?

- Moved `mainImageService` to context and removed other calculation
- Added a test before the change to make sure the behaviour stayed the same
- Modified the test selection, added a `testId` since the actual ID is used for functionality and we want those separate.
- I modified `convertRequestUriToInfoUri` so it accepted `undefined` props. They could be so, and I prefer managing that within the helper than having to pass an empty string to satisfy its types. The helper IS used in both refactored and legacy, but it still accepts empty string so it's fine.
- Added a `IIIFViewer` integration test covering `mainImageService`, since the existing `ZoomedImage` tests only exercise a mocked context value and wouldn't catch the real provider wiring breaking.

## How to test

I just logged the results in https://www-dev.wellcomecollection.org/works/a2239muq/items and made sure they were the same with an without the toggle. Other ideas welcome!

## Have we considered potential risks?
N/A changes only in Refactored.