### PR TITLE
New toggle for `archiveCollection`

### DIFF
--- a/toggles/webapp/toggles.ts
+++ b/toggles/webapp/toggles.ts
@@ -114,6 +114,14 @@ const toggleConfig = {
       type: 'experimental',
     },
     {
+      id: 'archiveCollection',
+      title: 'Archive Collection level pages',
+      initialValue: false,
+      description:
+        'Enables access to the new Archive Collection level pages, changes to the work page and search result.',
+      type: 'experimental',
+    },
+    {
       id: 'thematicBrowsing',
       title: 'Thematic browsing: category pages',
       initialValue: false,


### PR DESCRIPTION
- For #13405

## What does this change?

We wanted a new toggle as the Archive Collection level pages work will be released separately to Archives Browsing. 
I'll make the relevant changes in a follow-up PR.
