### PR TITLE
Move archive collection work to new toggle

### DIFF
--- a/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
+++ b/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<StoryProps> = {
       control: 'boolean',
     },
   },
-  // TODO remove once archiveBrowsing is fully rolled out
+  // TODO remove once archiveCollection is fully rolled out
   decorators: [
     Story => (
       <ServerDataContext.Provider
@@ -43,7 +43,7 @@ const meta: Meta<StoryProps> = {
             ...defaultServerData.toggles,
             featureFlags: {
               ...defaultServerData.toggles.featureFlags,
-              archiveBrowsing: true,
+              archiveCollection: true,
             },
           },
         }}
@@ -77,7 +77,7 @@ export const Basic: Story = {
               marginTop: '1rem',
             }}
           >
-            This is currently behind the <code>archiveBrowsing</code> feature
+            This is currently behind the <code>archiveCollection</code> feature
             flag
           </div>
         )}

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -33,7 +33,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
   work,
   resultPosition,
 }) => {
-  const { archiveBrowsing } = useFeatureFlags();
+  const { archiveCollection } = useFeatureFlags();
   const {
     isRootCollection,
     archiveLabels,
@@ -43,7 +43,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
     productionDates,
   } = work;
 
-  const shouldShowArchiveCollectionInfo = archiveBrowsing && isRootCollection;
+  const shouldShowArchiveCollectionInfo = archiveCollection && isRootCollection;
 
   return (
     <NextLink

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -63,12 +63,12 @@ export const WorkPage: NextPage<Props> = ({
   transformedManifest,
 }) => {
   const { isKiosk } = useKiosk();
-  const { archiveBrowsing } = useFeatureFlags();
+  const { archiveCollection } = useFeatureFlags();
   const { userIsStaffWithRestricted } = useUserContext();
   const isArchive = !!(
     work.parts.length || getArchiveAncestorArray(work).length > 0
   );
-  const displayCollectionRoot = !!work.collection?.isRoot && archiveBrowsing;
+  const displayCollectionRoot = !!work.collection?.isRoot && archiveCollection;
 
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
   const iiifPresentationLocation = getDigitalLocationOfType(


### PR DESCRIPTION
- For #13405 

## What does this change?

Puts the relevant work behind the new toggle as we'll release it separately to Archives Browsing

## How to test

- All toggles off
  - https://www-dev.wellcomecollection.org/works/aegabdcp looks like in production, like it's always looked
  - https://www-dev.wellcomecollection.org/search/works?query=Surgeon+Captain+%27Peter%27+Thomas+Latimer all search results look the same
  - https://www-dev.wellcomecollection.org/collections/archives 404s
- [Archives browsing toggle on](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveBrowsing)
  - https://www-dev.wellcomecollection.org/works/aegabdcp looks like any other work
  - https://www-dev.wellcomecollection.org/search/works?query=Surgeon+Captain+%27Peter%27+Thomas+Latimer all search results look the same
  - https://www-dev.wellcomecollection.org/collections/archives is available
- [Archives browsing toggle OFF](https://dash.wellcomecollection.org/toggles/?disableToggle=archiveBrowsing) & [Archives Collection toggle ON ](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveCollection)
  - https://www-dev.wellcomecollection.org/works/aegabdcp has the new layout
  - https://www-dev.wellcomecollection.org/search/works?query=Surgeon+Captain+%27Peter%27+Thomas+Latimer First search result is identified as Archive Collection
  - https://www-dev.wellcomecollection.org/collections/archives 404s

- [The Cardigan story](https://62f13cdbd0ff140768a8d87b-iakpclfymp.chromatic.com/?path=/story/components-workssearchresults--basic) still works with all the settings

## Have we considered potential risks?
Don't think there are any?