### PR TITLE
IVR: `getCanvasesForPage` + No JS bug fix

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
@@ -4,11 +4,15 @@ import { IIIFUriProps } from '@weco/common/utils/convert-image-uri';
 import { imageSizes } from '@weco/common/utils/image-sizes';
 import LL from '@weco/common/views/components/styled/LL';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
-import { queryParamToArrayIndex } from '@weco/content/views/pages/works/work/work.helpers';
+import { getCanvasesForPage } from '@weco/content/views/pages/works/work/work.helpers';
 
 import { DelayVisibility } from '.';
 import IIIFViewerImage from './IIIFViewerImage';
-import { CanvasPaginator, ThumbnailsPaginator } from './Paginators';
+import {
+  CanvasPaginator,
+  thumbnailsPageSize,
+  ThumbnailsPaginator,
+} from './Paginators';
 import { Thumbnails } from './Thumbnails';
 
 const NoScriptImageWrapper = styled.div`
@@ -33,21 +37,18 @@ type Props = {
 
 export const NoScriptImage = ({ urlTemplate, canvasOcr }: Props) => {
   const { work, query, transformedManifest } = useItemViewerContext();
-  const { canvases } = { ...transformedManifest };
 
-  const pageSize = 4;
   const srcSet =
     urlTemplate &&
     imageSizes(2048)
       .map(width => `${urlTemplate({ size: `${width},` })} ${width}w`)
       .join(',');
   const imageUrl = urlTemplate && urlTemplate({ size: '800,' });
-  const navigationCanvases = canvases
-    ? [...Array(pageSize)]
-        .map((_, i) => pageSize * queryParamToArrayIndex(query.page) + i)
-        .map(i => canvases?.[i])
-        .filter(Boolean)
-    : [];
+  const navigationCanvases = getCanvasesForPage({
+    canvases: transformedManifest?.canvases,
+    page: query.page,
+    pageSize: thumbnailsPageSize,
+  });
   const thumbnailsRequired = Boolean(navigationCanvases.length);
 
   return (

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
@@ -4,7 +4,10 @@ import styled from 'styled-components';
 import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
-import { queryParamToArrayIndex } from '@weco/content/views/pages/works/work/work.helpers';
+import {
+  getCanvasesForPage,
+  queryParamToArrayIndex,
+} from '@weco/content/views/pages/works/work/work.helpers';
 
 import IIIFCanvasThumbnail from './IIIFCanvasThumbnail';
 import { thumbnailsPageSize } from './Paginators';
@@ -38,15 +41,11 @@ const ThumbnailLink = styled(NextLink)`
 export const Thumbnails = () => {
   const { work, query, transformedManifest } = useItemViewerContext();
   const { isKiosk, isTendernessAndRageKiosk } = useKiosk();
-  const { canvases } = { ...transformedManifest };
-  const navigationCanvases = canvases
-    ? [...Array(thumbnailsPageSize)]
-        .map(
-          (_, i) => thumbnailsPageSize * queryParamToArrayIndex(query.page) + i
-        )
-        .map(i => canvases?.[i])
-        .filter(Boolean)
-    : [];
+  const navigationCanvases = getCanvasesForPage({
+    canvases: transformedManifest?.canvases,
+    page: query.page,
+    pageSize: thumbnailsPageSize,
+  });
 
   return (
     <ThumbnailsContainer

--- a/content/webapp/views/pages/works/work/work.helpers.test.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.test.tsx
@@ -3,7 +3,7 @@ import {
   createMockManifest,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
 
-import { getCurrentCanvas } from './work.helpers';
+import { getCanvasesForPage, getCurrentCanvas } from './work.helpers';
 
 // getCurrentCanvas is the canonical way to work out which canvas is "current"
 // for a given 1-based canvas query param. Canvas order is determined by the
@@ -112,5 +112,50 @@ describe('getCurrentCanvas', () => {
         canvas: 9999,
       })
     ).toBeUndefined();
+  });
+});
+
+describe('getCanvasesForPage', () => {
+  const canvases = [
+    createMockCanvas({ id: '0' }),
+    createMockCanvas({ id: '1' }),
+    createMockCanvas({ id: '2' }),
+    createMockCanvas({ id: '3' }),
+    createMockCanvas({ id: '4' }),
+    createMockCanvas({ id: '5' }),
+    createMockCanvas({ id: '6' }),
+  ];
+
+  it('returns the first page of canvases', () => {
+    expect(getCanvasesForPage({ canvases, page: 1, pageSize: 3 })).toEqual([
+      canvases[0],
+      canvases[1],
+      canvases[2],
+    ]);
+  });
+
+  it('returns the requested page, offset by pageSize', () => {
+    expect(getCanvasesForPage({ canvases, page: 2, pageSize: 3 })).toEqual([
+      canvases[3],
+      canvases[4],
+      canvases[5],
+    ]);
+  });
+
+  it('returns a partial page when fewer canvases remain than pageSize', () => {
+    // 7 canvases, pageSize 3: page 3 only has canvases[6] left.
+    expect(getCanvasesForPage({ canvases, page: 3, pageSize: 3 })).toEqual([
+      canvases[6],
+    ]);
+  });
+
+  it('returns an empty array for a page beyond the last canvas', () => {
+    expect(getCanvasesForPage({ canvases, page: 4, pageSize: 3 })).toEqual([]);
+  });
+
+  it('returns an empty array when there are no canvases', () => {
+    expect(
+      getCanvasesForPage({ canvases: undefined, page: 1, pageSize: 3 })
+    ).toEqual([]);
   });
 });

--- a/content/webapp/views/pages/works/work/work.helpers.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.tsx
@@ -186,3 +186,27 @@ export function getCurrentCanvas({
     ? canvases?.find(c => c.id === currentCanvasId)
     : canvases?.[queryParamToArrayIndex(canvas)];
 }
+
+/**
+ * Returns the slice of canvases for a given page, shared by every paginated
+ * thumbnails view so they can't drift onto different page sizes and disagree
+ * about which canvases a given page number shows.
+ * @param canvases - The manifest's full canvas list.
+ * @param page - 1-based page number.
+ * @param pageSize - Canvases per page.
+ */
+export function getCanvasesForPage({
+  canvases,
+  page,
+  pageSize,
+}: {
+  canvases: TransformedCanvas[] | undefined;
+  page: number;
+  pageSize: number;
+}): TransformedCanvas[] {
+  const startIndex = pageSize * queryParamToArrayIndex(page);
+
+  return [...Array(pageSize)]
+    .map((_, i) => canvases?.[startIndex + i])
+    .filter((canvas): canvas is TransformedCanvas => Boolean(canvas));
+}

--- a/content/webapp/views/pages/works/work/work.helpers.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.tsx
@@ -24,8 +24,6 @@ export const controlDimensions = {
 // A smaller control for trees where the whole row - not just the chevron -
 // is already the click target (the archive collection contents table), so
 // the 44px touch-target padding around the icon isn't doing anything there.
-// Same shape as controlDimensions (see getControlDimensions below) so
-// callers don't need to know which fields exist on which variant.
 export const compactControlDimensions = {
   controlWidth: 30,
   controlHeight: 30,
@@ -35,9 +33,23 @@ export const compactControlDimensions = {
   iconSize: 16,
 };
 
+/**
+ * Returns the dimensions to use for a chevron/expand control.
+ * @param isCompact - Use the smaller compact variant instead of the default.
+ */
 export const getControlDimensions = (isCompact?: boolean) =>
   isCompact ? compactControlDimensions : controlDimensions;
 
+/**
+ * Recursively converts a manifest's IIIF `structures` (or, if there's no
+ * structure, its flat canvas list) into the UiTree shape used to render the
+ * archive/download tree.
+ * @param structures - The manifest's IIIF Range structures, if any.
+ * @param canvases - The manifest's transformed canvases, used to resolve
+ * each tree node's canvas data and downloads.
+ * @param parentId - The id of the parent node these items nest under.
+ * @param openByDefault - Whether tree nodes should start expanded.
+ */
 function convertStructuresToTree(
   structures: Manifest['structures'],
   canvases: TransformedCanvas[] | undefined,
@@ -90,6 +102,14 @@ function convertStructuresToTree(
   );
 }
 
+/**
+ * Builds the UiTree used to drive the downloads UI.
+ * @param structures - The manifest's IIIF Range structures, if any.
+ * @param canvases - The manifest's transformed canvases.
+ * @param options.skipObjectsNode - Return the tree without the wrapping
+ * top-level "objects" node.
+ * @param options.openByDefault - Whether tree nodes should start expanded.
+ */
 export function createDownloadTree(
   structures: Manifest['structures'],
   canvases: TransformedCanvas[] | undefined,
@@ -120,18 +140,32 @@ export function createDownloadTree(
   return [topLevelItem];
 }
 
-// Canvas and manifest params use 1-based indexing, but are used to access items in 0-indexed arrays,
-// so we need to convert them in various places
+/**
+ * Converts a 1-based canvas/manifest query param into a 0-based array index -
+ * the inverse of {@link arrayIndexToQueryParam}. Canvas and manifest params
+ * use 1-based indexing, but are used to access items in 0-indexed arrays, so
+ * we need to convert them in various places.
+ * @param canvas - The 1-based canvas or manifest number.
+ */
 export function queryParamToArrayIndex(canvas: number): number {
   return canvas - 1;
 }
 
+/**
+ * Converts a 0-based array index back into a 1-based canvas/manifest query
+ * param - the inverse of {@link queryParamToArrayIndex}.
+ * @param canvasIndex - The 0-based array index.
+ */
 export function arrayIndexToQueryParam(canvasIndex: number): number {
   return canvasIndex + 1;
 }
 
-// Traverse a UiTree and assign sequential canvas indices in tree order
-// This ensures that canvas indices match the visual order in the NestedList, including nested folders/ranges.
+/**
+ * Assigns each canvas in a UiTree a sequential 1-based index in tree order,
+ * so canvas order matches the visual order in the NestedList/archive tree -
+ * including nested folders/ranges - rather than the manifest's raw item order.
+ * @param tree - The UiTree to traverse.
+ */
 export function getTreeCanvasIndexById(tree: UiTree): Record<string, number> {
   let index = 1;
   const canvasIndexById: Record<string, number> = {};
@@ -154,10 +188,16 @@ export function getTreeCanvasIndexById(tree: UiTree): Record<string, number> {
   return canvasIndexById;
 }
 
-// Canvas order follows the manifest's structure when we have a complete one -
-// that's not always the same as the raw items array order. canvasIndexById
-// maps canvas id to structure position; we only trust it when it covers
-// every canvas, otherwise we just use the canvas's plain array position.
+/**
+ * Works out which canvas is "current" for a given 1-based canvas number.
+ * Canvas order follows the manifest's structure when we have a complete one -
+ * that's not always the same as the raw items array order. canvasIndexById
+ * maps canvas id to structure position; we only trust it when it covers
+ * every canvas, otherwise we just use the canvas's plain array position.
+ * @param transformedManifest - The manifest whose canvases to search.
+ * @param canvasIndexById - Map of canvas id to its 1-based structure position.
+ * @param canvas - The 1-based canvas number to resolve.
+ */
 export function getCurrentCanvas({
   transformedManifest,
   canvasIndexById,


### PR DESCRIPTION
- For #12986

## What does this change?

The No JS calculation for this was passing "4" as the amount of thumbnails shown per page, which must be drift, because it's 6. It didn't break anything per say, but it showed an empty "Thumbnails" component for longer than it should. e.g. if you went to https://www-dev.wellcomecollection.org/works/a2239muq/items?page=15, it would show the component as empty, because the work has 80 canvases, and `80/4 =20`, whereas it actually shows 6, meaning it's run out of canvases to show after page 14 (`80/6=13.3`). 

This change ensure `Thumbnails` (and its pagination) isn't shown now when it shouldn't.

Doesn't change "with JS" behaviour, but centralises it all.

I also did a pass of adding JSDoc comments across the helpers as I find it quite useful.


## How to test

With IVR toggle on
- No JS: Compare https://www-dev.wellcomecollection.org/works/a2239muq/items?page=15 with https://wellcomecollection.org/works/a2239muq/items?page=15. Our version shouldn't render an empty component and it's pagination
- JS behaviour should be the same as in prod

Without the toggle, nothing should have changed from prod.

## Have we considered potential risks?
N/A