### PR TITLE
Remove short description from Archive result card

### DIFF
--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -85,12 +85,6 @@ const WorkSearchResult: FunctionComponent<Props> = ({
               <WorkTitle title={work.title} />
             </WorkTitleHeading>
 
-            {shouldShowArchiveCollectionInfo && (
-              <Space $v={{ size: 'sm', properties: ['margin-bottom'] }}>
-                Lorem ipsum dolor sit amet.
-              </Space>
-            )}
-
             <WorkInformation>
               {shouldShowArchiveCollectionInfo && (
                 <>


### PR DESCRIPTION
## What does this change?

Removes lorem ipsum from Archive Collection level search result. Anna has approved the look already, so we can just bring it back when it's actually in the API response. In the meantime, removing it allows us to release an MVP.


## How to test

With [this toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveCollection)

- See first search result: https://www-dev.wellcomecollection.org/search/works?query=Cleave%2C+Surgeon+Captain+%27Peter%27+Thomas+Latimer
- See [Cardigan](https://62f13cdbd0ff140768a8d87b-jdejgyaeom.chromatic.com/?path=/story/components-workssearchresults--basic&args=isArchive:!true;isRootCollection:!true).


## Have we considered potential risks?
N/A