### PR TITLE
Add isCurrentCanvasRestricted to refactored ItemViewerContext

### DIFF
--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -36,6 +36,7 @@ export type ItemViewerContextProps = {
   setTree: (v: UiTree) => void;
   canvasIndexById: Record<string, number>;
   currentCanvas: TransformedCanvas | undefined;
+  isCurrentCanvasRestricted: boolean;
   totalCanvases: number;
   hasMultipleCanvases: boolean;
   mainImageService: PartialImageService;
@@ -111,6 +112,7 @@ export const defaultItemViewerContext: ItemViewerContextProps = {
   setTree: () => undefined,
   canvasIndexById: {},
   currentCanvas: undefined,
+  isCurrentCanvasRestricted: false,
   totalCanvases: 0,
   hasMultipleCanvases: false,
   mainImageService: { '@id': undefined },

--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -23,6 +23,7 @@ import ItemViewerContextRefactored, {
   defaultItemViewerContext as defaultItemViewerContextRefactored,
   ItemViewerContextProps as ItemViewerContextPropsRefactored,
 } from '@weco/content/contexts/ItemViewerContext/refactored';
+import { hasRestrictedItem } from '@weco/content/utils/iiif/v3';
 import { getCurrentCanvas } from '@weco/content/views/pages/works/work/work.helpers';
 
 import { createMockManifest } from './transformed-manifest';
@@ -89,6 +90,9 @@ function createMockRefactoredItemViewerContext(
     // goes on the context needs adding here too, or tests that override the
     // manifest will silently fall back to the default context's value.
     currentCanvas,
+    isCurrentCanvasRestricted: currentCanvas
+      ? hasRestrictedItem(currentCanvas)
+      : false,
     totalCanvases,
     hasMultipleCanvases: totalCanvases > 1,
     mainImageService: { '@id': currentCanvas?.imageServiceId },

--- a/content/webapp/test/fixtures/intersection-observer.ts
+++ b/content/webapp/test/fixtures/intersection-observer.ts
@@ -1,0 +1,18 @@
+// jsdom doesn't implement IntersectionObserver, which the image item's
+// scroll-to-url-update behaviour relies on via useOnScreen. Any test that
+// renders an image item (directly, or through the viewer) needs this
+// installed at module scope, before the component tree mounts.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds = [];
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+  takeRecords = jest.fn(() => []);
+}
+
+export function installMockIntersectionObserver(): void {
+  window.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+}

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/MainViewer.test.tsx
@@ -12,6 +12,7 @@ import {
   createOpenPainting,
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
+import { installMockIntersectionObserver } from '@weco/content/test/fixtures/intersection-observer';
 
 import MainViewer, { getOverlayTopLeft, RotationValue } from './MainViewer';
 
@@ -29,19 +30,7 @@ import MainViewer, { getOverlayTopLeft, RotationValue } from './MainViewer';
 // the right child component. Legacy has no child components to pick between -
 // it branches internally, which the two describes here cover between them.
 
-// jsdom doesn't implement IntersectionObserver, which the image item's
-// scroll-to-url-update behaviour relies on via useOnScreen.
-class MockIntersectionObserver implements IntersectionObserver {
-  readonly root = null;
-  readonly rootMargin = '';
-  readonly thresholds = [];
-  observe = jest.fn();
-  unobserve = jest.fn();
-  disconnect = jest.fn();
-  takeRecords = jest.fn(() => []);
-}
-window.IntersectionObserver =
-  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+installMockIntersectionObserver();
 
 // The FixedSizeList's outer element. Legacy renders it inside
 // MainViewerContainer, so it's one level down rather than at the root.

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
@@ -4,11 +4,17 @@ import {
   Work,
   WorkBasic,
 } from '@weco/content/services/wellcome/catalogue/types';
-import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+import {
+  renderWithContext,
+  RenderWithContextOptions,
+} from '@weco/content/test/fixtures/iiif/render';
 import {
   createMockCanvas,
   createMockManifest,
+  createOpenPainting,
+  createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
+import { installMockIntersectionObserver } from '@weco/content/test/fixtures/intersection-observer';
 import { TransformedManifest } from '@weco/content/types/manifest';
 
 import IIIFViewer from './IIIFViewer';
@@ -25,6 +31,14 @@ jest.mock('@weco/common/server-data/Context', () => ({
   ...jest.requireActual('@weco/common/server-data/Context'),
   useFeatureFlags: () => ({ itemViewerRefactor: true }),
 }));
+
+installMockIntersectionObserver();
+
+// GridViewer schedules a window.scrollTo(0, 0) 700ms after mount, which lands
+// while a later test in this file is still running. jsdom doesn't implement
+// scrollTo, so leaving it unstubbed fills the run with "Not implemented"
+// errors that have nothing to do with what's being asserted.
+window.scrollTo = jest.fn();
 
 // Must be prefixed `mock` to be referenced inside the hoisted jest.mock factory.
 let mockRouterQuery: Record<string, string> = {};
@@ -54,7 +68,10 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   isRootCollection: false,
 };
 
-const renderViewer = (transformedManifest: TransformedManifest) =>
+const renderViewer = (
+  transformedManifest: TransformedManifest,
+  options: RenderWithContextOptions = {}
+) =>
   renderWithContext(
     <IIIFViewer
       work={mockWork}
@@ -62,7 +79,10 @@ const renderViewer = (transformedManifest: TransformedManifest) =>
       searchResults={null}
       setSearchResults={() => undefined}
     />,
-    { appContext: { isEnhanced: true, isFullSupportBrowser: true } }
+    {
+      appContext: { isEnhanced: true, isFullSupportBrowser: true },
+      ...options,
+    }
   );
 
 beforeEach(() => {
@@ -105,6 +125,67 @@ describe('IIIFViewer', () => {
     );
 
     expect(screen.queryByTestId('active-index')).not.toBeInTheDocument();
+  });
+
+  // These exercise the real IIIFViewer -> context -> ViewerTopBar wiring for
+  // isCurrentCanvasRestricted, rather than ViewerTopBar.test.tsx's mocked
+  // context value (which derives the flag independently in the test fixture,
+  // and so wouldn't catch IIIFViewer deriving it from the wrong canvas or
+  // failing to put it on the provider).
+  describe('restricted current canvas', () => {
+    // A manifest-level rendering, so there are download options to hide.
+    const pdfRendering: TransformedManifest['rendering'] = [
+      {
+        id: 'https://example.com/whole.pdf',
+        type: 'Text',
+        format: 'application/pdf',
+      },
+    ];
+
+    // Only the second canvas is restricted, so a check against the wrong
+    // canvas (the first, say) gives the wrong answer for both cases below.
+    const mixedRestrictionManifest = createMockManifest({
+      canvases: [
+        createMockCanvas({
+          id: 'https://example.com/canvases/open',
+          painting: [createOpenPainting()],
+        }),
+        createMockCanvas({
+          id: 'https://example.com/canvases/restricted',
+          painting: [createRestrictedPainting()],
+        }),
+      ],
+      rendering: pdfRendering,
+    });
+
+    const downloadButton = (container: HTMLElement) =>
+      container.querySelector('[data-component="download-button"]');
+
+    it('hides the download button when the canvas in the URL is restricted', () => {
+      mockRouterQuery = { canvas: '2', manifest: '1' };
+
+      const { container } = renderViewer(mixedRestrictionManifest);
+
+      expect(downloadButton(container)).not.toBeInTheDocument();
+    });
+
+    it('shows the download button when the canvas in the URL is unrestricted', () => {
+      mockRouterQuery = { canvas: '1', manifest: '1' };
+
+      const { container } = renderViewer(mixedRestrictionManifest);
+
+      expect(downloadButton(container)).toBeInTheDocument();
+    });
+
+    it('shows the download button on a restricted canvas for a StaffWithRestricted user', () => {
+      mockRouterQuery = { canvas: '2', manifest: '1' };
+
+      const { container } = renderViewer(mixedRestrictionManifest, {
+        userContext: { userIsStaffWithRestricted: true },
+      });
+
+      expect(downloadButton(container)).toBeInTheDocument();
+    });
   });
 
   // These exercise the real IIIFViewer -> context -> ZoomedImage wiring for

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -20,7 +20,10 @@ import {
   PartialImageService,
 } from '@weco/content/types/item-viewer';
 import { TransformedManifest } from '@weco/content/types/manifest';
-import { hasNonImagesOrOriginals } from '@weco/content/utils/iiif/v3';
+import {
+  hasNonImagesOrOriginals,
+  hasRestrictedItem,
+} from '@weco/content/utils/iiif/v3';
 import { fromQuery } from '@weco/content/views/components/ItemLink';
 import {
   getCurrentCanvas,
@@ -294,6 +297,9 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
     canvasIndexById,
     canvas,
   });
+  const isCurrentCanvasRestricted = currentCanvas
+    ? hasRestrictedItem(currentCanvas)
+    : false;
   const totalCanvases = transformedManifest?.canvases.length || 0;
   const mainImageService: PartialImageService = {
     '@id': currentCanvas?.imageServiceId,
@@ -394,6 +400,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         setTree,
         canvasIndexById,
         currentCanvas,
+        isCurrentCanvasRestricted,
         totalCanvases,
         hasMultipleCanvases,
         mainImageService,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -26,7 +26,6 @@ import {
   getDownloadOptionsFromManifestRendering,
   getImageServiceFromItem,
   getVideoAudioDownloadOptions,
-  hasRestrictedItem,
   isChoiceBody,
 } from '@weco/content/utils/iiif/v3';
 import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
@@ -218,6 +217,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     showFullscreenControl,
     hasOnlyRenderableImages,
     currentCanvas,
+    isCurrentCanvasRestricted,
     hasMultipleCanvases,
   } = useItemViewerContext();
   const transformedIIIFImage = useTransformedIIIFImage(work);
@@ -236,7 +236,6 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     })
     .flat()
     .filter(Boolean) || []) as ImageService[];
-  const isRestricted = currentCanvas && hasRestrictedItem(currentCanvas);
   const currentPageLabel = currentCanvas?.label?.trim();
 
   const shouldShowViewToggle =
@@ -388,7 +387,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
           {isEnhanced && (
             <div style={{ display: 'flex', alignItems: 'center' }}>
               {downloadOptions.length > 0 &&
-                (!isRestricted || userIsStaffWithRestricted) &&
+                (!isCurrentCanvasRestricted || userIsStaffWithRestricted) &&
                 !isKiosk && (
                   <Space $h={{ size: 'xs', properties: ['margin-right'] }}>
                     <Download

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.test.tsx
@@ -11,6 +11,7 @@ import {
   createOpenPainting,
   createRestrictedPainting,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
+import { installMockIntersectionObserver } from '@weco/content/test/fixtures/intersection-observer';
 
 import VirtualizedImageViewer from './VirtualizedImageViewer';
 
@@ -22,19 +23,7 @@ jest.mock('@weco/common/server-data/Context', () => ({
   useFeatureFlags: () => ({ itemViewerRefactor: true }),
 }));
 
-// jsdom doesn't implement IntersectionObserver, which the image item's
-// scroll-to-url-update behaviour relies on via useOnScreen.
-class MockIntersectionObserver implements IntersectionObserver {
-  readonly root = null;
-  readonly rootMargin = '';
-  readonly thresholds = [];
-  observe = jest.fn();
-  unobserve = jest.fn();
-  disconnect = jest.fn();
-  takeRecords = jest.fn(() => []);
-}
-window.IntersectionObserver =
-  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+installMockIntersectionObserver();
 
 // The FixedSizeList's outer element. This viewer renders it as its own root,
 // so it's the first div in the tree.


### PR DESCRIPTION
- For #12988 

## What does this change?

`ViewerTopBar` was recalculating whether the current canvas is restricted (`hasRestrictedItem(currentCanvas)`) on every render, even though `currentCanvas` itself already lives in `ItemViewerContext` (refactored). This adds `isCurrentCanvasRestricted` to that context, derived once in `IIIFViewer.tsx` alongside `currentCanvas`, and updates `ViewerTopBar` to read it instead of recalculating it locally.

`IIIFCanvasThumbnail`, `IIIFItem`, and `VirtualizedImageViewer` keep their own `hasRestrictedItem` checks rather than switching to the context value — they check whichever canvas they're handed (a specific thumbnail or list row), which isn't always the current canvas, so centralising would give the wrong answer for those.

Also pulls the duplicated jsdom `IntersectionObserver` mock out of `VirtualizedImageViewer.test.tsx` and legacy `MainViewer.test.tsx` into a shared fixture (`test/fixtures/intersection-observer.ts`), used again by the new `IIIFViewer.test.tsx` coverage below.

## How to test

Open an [item viewer page for a restricted work](https://www-dev.wellcomecollection.org/works/pnud3fzb/items) as a logged out user and confirm the download button is hidden on the restricted canvas (2) and shown on unrestricted ones; as a StaffWithRestricted user, confirm it shows on the restricted canvas too. This should be identical to prod — the only change is where the restriction flag is computed.

Automated coverage: `IIIFViewer.test.tsx` has a new `restricted current canvas` block driving a two-canvas manifest (one restricted, one not) through the router's `canvas` query param, asserting the download button visibility in each case, including the StaffWithRestricted override.

## Have we considered potential risks?

Low risk — this is a refactor of where an existing boolean is computed.
