### PR TITLE
IVR: Centralise the full screen logic

### DIFF
--- a/content/webapp/hooks/useFullscreenToggle.ts
+++ b/content/webapp/hooks/useFullscreenToggle.ts
@@ -1,0 +1,59 @@
+import { RefObject } from 'react';
+
+type UseFullscreenToggleParams = {
+  viewerRef: RefObject<HTMLDivElement | null> | undefined;
+  setIsFullscreen: (isFullscreen: boolean) => void;
+};
+
+/**
+ * Shared by ViewerTopBar and ViewerBottomBar, which both used to reimplement
+ * this same request/exit fullscreen logic independently, and neither ever
+ * wrote to the isFullscreen context value that already existed for it.
+ *
+ * Takes viewerRef/setIsFullscreen as params rather than reading
+ * ItemViewerContext itself, so it isn't coupled to a particular context
+ * module and stays easy to unit-test in isolation.
+ *
+ * Still checks document.fullscreenElement directly to decide whether to
+ * request or exit, rather than trusting the stored isFullscreen value - so
+ * this doesn't yet handle fullscreen being exited some other way (Escape key,
+ * browser chrome), which would leave isFullscreen stale until next toggled
+ * here. That's a known, deliberately deferred gap, not an oversight - closing
+ * it will mean subscribing to the native fullscreenchange event with a
+ * useEffect, which is the reason this is a hook (called at each component's
+ * top level, like useIsFullscreenEnabled next to it) rather than a plain
+ * helper function, even though it doesn't call any React hooks internally
+ * yet.
+ * @param viewerRef - The element to request/exit fullscreen on.
+ * @param setIsFullscreen - Context setter to keep in sync with the toggle.
+ */
+export default function useFullscreenToggle({
+  viewerRef,
+  setIsFullscreen,
+}: UseFullscreenToggleParams): () => void {
+  function toggleFullscreen() {
+    if (!viewerRef?.current) return;
+
+    const isCurrentlyFullscreen = Boolean(
+      document.fullscreenElement || document['webkitFullscreenElement']
+    );
+
+    if (!isCurrentlyFullscreen) {
+      if (viewerRef.current.requestFullscreen) {
+        viewerRef.current.requestFullscreen();
+      } else if (viewerRef.current['webkitRequestFullscreen']) {
+        viewerRef.current['webkitRequestFullscreen']();
+      }
+      setIsFullscreen(true);
+    } else {
+      if (document.exitFullscreen) {
+        document.exitFullscreen();
+      } else if (document['webkitExitFullscreen']) {
+        document['webkitExitFullscreen']();
+      }
+      setIsFullscreen(false);
+    }
+  }
+
+  return toggleFullscreen;
+}

--- a/content/webapp/hooks/useFullscreenToggle.ts
+++ b/content/webapp/hooks/useFullscreenToggle.ts
@@ -44,20 +44,21 @@ export default function useFullscreenToggle({
       document.fullscreenElement || document['webkitFullscreenElement']
     );
 
+    // Don't set isFullscreen here - requestFullscreen()/exitFullscreen() are
+    // async and can be denied, in which case no fullscreenchange event
+    // follows. handleFullscreenChange above is the sole source of truth.
     if (!isCurrentlyFullscreen) {
       if (viewerRef.current.requestFullscreen) {
-        viewerRef.current.requestFullscreen();
+        viewerRef.current.requestFullscreen().catch(() => undefined);
       } else if (viewerRef.current['webkitRequestFullscreen']) {
         viewerRef.current['webkitRequestFullscreen']();
       }
-      setIsFullscreen(true);
     } else {
       if (document.exitFullscreen) {
-        document.exitFullscreen();
+        document.exitFullscreen().catch(() => undefined);
       } else if (document['webkitExitFullscreen']) {
         document['webkitExitFullscreen']();
       }
-      setIsFullscreen(false);
     }
   }
 

--- a/content/webapp/hooks/useFullscreenToggle.ts
+++ b/content/webapp/hooks/useFullscreenToggle.ts
@@ -5,6 +5,12 @@ type UseFullscreenToggleParams = {
   setIsFullscreen: (isFullscreen: boolean) => void;
 };
 
+function isDocumentFullscreen(): boolean {
+  return Boolean(
+    document.fullscreenElement || document['webkitFullscreenElement']
+  );
+}
+
 /**
  * Toggles fullscreen on viewerRef and keeps setIsFullscreen in sync - both
  * for our own toggle clicks and for fullscreen ending some other way
@@ -18,11 +24,7 @@ export default function useFullscreenToggle({
 }: UseFullscreenToggleParams): () => void {
   useEffect(() => {
     function handleFullscreenChange() {
-      setIsFullscreen(
-        Boolean(
-          document.fullscreenElement || document['webkitFullscreenElement']
-        )
-      );
+      setIsFullscreen(isDocumentFullscreen());
     }
 
     document.addEventListener('fullscreenchange', handleFullscreenChange);
@@ -40,9 +42,7 @@ export default function useFullscreenToggle({
   function toggleFullscreen() {
     if (!viewerRef?.current) return;
 
-    const isCurrentlyFullscreen = Boolean(
-      document.fullscreenElement || document['webkitFullscreenElement']
-    );
+    const isCurrentlyFullscreen = isDocumentFullscreen();
 
     // Don't set isFullscreen here - requestFullscreen()/exitFullscreen() are
     // async and can be denied, in which case no fullscreenchange event

--- a/content/webapp/hooks/useFullscreenToggle.ts
+++ b/content/webapp/hooks/useFullscreenToggle.ts
@@ -1,4 +1,4 @@
-import { RefObject } from 'react';
+import { RefObject, useEffect } from 'react';
 
 type UseFullscreenToggleParams = {
   viewerRef: RefObject<HTMLDivElement | null> | undefined;
@@ -6,24 +6,9 @@ type UseFullscreenToggleParams = {
 };
 
 /**
- * Shared by ViewerTopBar and ViewerBottomBar, which both used to reimplement
- * this same request/exit fullscreen logic independently, and neither ever
- * wrote to the isFullscreen context value that already existed for it.
- *
- * Takes viewerRef/setIsFullscreen as params rather than reading
- * ItemViewerContext itself, so it isn't coupled to a particular context
- * module and stays easy to unit-test in isolation.
- *
- * Still checks document.fullscreenElement directly to decide whether to
- * request or exit, rather than trusting the stored isFullscreen value - so
- * this doesn't yet handle fullscreen being exited some other way (Escape key,
- * browser chrome), which would leave isFullscreen stale until next toggled
- * here. That's a known, deliberately deferred gap, not an oversight - closing
- * it will mean subscribing to the native fullscreenchange event with a
- * useEffect, which is the reason this is a hook (called at each component's
- * top level, like useIsFullscreenEnabled next to it) rather than a plain
- * helper function, even though it doesn't call any React hooks internally
- * yet.
+ * Toggles fullscreen on viewerRef and keeps setIsFullscreen in sync - both
+ * for our own toggle clicks and for fullscreen ending some other way
+ * (Escape, F11, browser UI), via the native fullscreenchange event.
  * @param viewerRef - The element to request/exit fullscreen on.
  * @param setIsFullscreen - Context setter to keep in sync with the toggle.
  */
@@ -31,6 +16,27 @@ export default function useFullscreenToggle({
   viewerRef,
   setIsFullscreen,
 }: UseFullscreenToggleParams): () => void {
+  useEffect(() => {
+    function handleFullscreenChange() {
+      setIsFullscreen(
+        Boolean(
+          document.fullscreenElement || document['webkitFullscreenElement']
+        )
+      );
+    }
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    document.addEventListener('webkitfullscreenchange', handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+      document.removeEventListener(
+        'webkitfullscreenchange',
+        handleFullscreenChange
+      );
+    };
+  }, [setIsFullscreen]);
+
   function toggleFullscreen() {
     if (!viewerRef?.current) return;
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
@@ -39,22 +39,19 @@ describe('FullscreenToggleButton', () => {
     ).toBeInTheDocument();
   });
 
-  it('calls setIsFullscreen when clicked', () => {
-    const setIsFullscreen = jest.fn();
+  it('requests fullscreen on the viewer element when clicked', () => {
+    const viewerElement = document.createElement('div');
+    const requestFullscreen = jest.fn().mockResolvedValue(undefined);
+    viewerElement.requestFullscreen = requestFullscreen;
 
     renderButton(
       {},
-      {
-        contextProps: {
-          viewerRef: { current: document.createElement('div') },
-          setIsFullscreen,
-        },
-      }
+      { contextProps: { viewerRef: { current: viewerElement } } }
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Full screen' }));
 
-    expect(setIsFullscreen).toHaveBeenCalledWith(true);
+    expect(requestFullscreen).toHaveBeenCalled();
   });
 
   it('applies a given className to the button', () => {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
@@ -62,4 +62,35 @@ describe('FullscreenToggleButton', () => {
 
     expect(screen.getByRole('button')).toHaveClass('viewer-desktop');
   });
+
+  describe('when fullscreen is exited by something other than this button (Escape, F11, browser UI)', () => {
+    const originalFullscreenElement = document.fullscreenElement;
+
+    afterEach(() => {
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: originalFullscreenElement,
+        configurable: true,
+      });
+    });
+
+    it('syncs isFullscreen back to false via the native fullscreenchange event', () => {
+      const setIsFullscreen = jest.fn();
+
+      renderButton(
+        {},
+        { contextProps: { isFullscreen: true, setIsFullscreen } }
+      );
+
+      // The browser fires fullscreenchange for any exit, regardless of what
+      // triggered it - here we simulate document.fullscreenElement already
+      // having cleared by the time the event reaches us.
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: null,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      expect(setIsFullscreen).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import {
+  renderWithContext,
+  RenderWithRefactoredContextOptions,
+} from '@weco/content/test/fixtures/iiif/render';
+
+import FullscreenToggleButton from './FullscreenToggleButton';
+
+jest.mock('@weco/common/server-data/Context', () => ({
+  ...jest.requireActual('@weco/common/server-data/Context'),
+  useFeatureFlags: () => ({ itemViewerRefactor: true }),
+}));
+
+function renderButton(
+  props: { className?: string } = {},
+  options: RenderWithRefactoredContextOptions = {}
+) {
+  return renderWithContext(<FullscreenToggleButton {...props} />, {
+    useRefactoredContext: true,
+    ...options,
+  });
+}
+
+describe('FullscreenToggleButton', () => {
+  it('shows the "Full screen" label and maximise icon by default', () => {
+    renderButton();
+
+    expect(
+      screen.getByRole('button', { name: 'Full screen' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the "Exit full screen" label when isFullscreen is true', () => {
+    renderButton({}, { contextProps: { isFullscreen: true } });
+
+    expect(
+      screen.getByRole('button', { name: 'Exit full screen' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls setIsFullscreen when clicked', () => {
+    const setIsFullscreen = jest.fn();
+
+    renderButton(
+      {},
+      {
+        contextProps: {
+          viewerRef: { current: document.createElement('div') },
+          setIsFullscreen,
+        },
+      }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full screen' }));
+
+    expect(setIsFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  it('applies a given className to the button', () => {
+    renderButton({ className: 'viewer-desktop' });
+
+    expect(screen.getByRole('button')).toHaveClass('viewer-desktop');
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.tsx
@@ -5,7 +5,7 @@ import Icon from '@weco/common/views/components/Icon';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
 import useFullscreenToggle from '@weco/content/hooks/useFullscreenToggle';
 
-import { ViewerButton } from './ViewerTopBar';
+import { ViewerButton } from './ViewerButton.styles';
 
 type Props = {
   className?: string;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.tsx
@@ -1,0 +1,35 @@
+import { FunctionComponent } from 'react';
+
+import { maximise, minimise } from '@weco/common/icons';
+import Icon from '@weco/common/views/components/Icon';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
+import useFullscreenToggle from '@weco/content/hooks/useFullscreenToggle';
+
+import { ViewerButton } from './ViewerTopBar';
+
+type Props = {
+  className?: string;
+};
+
+const FullscreenToggleButton: FunctionComponent<Props> = ({ className }) => {
+  const { viewerRef, isFullscreen, setIsFullscreen } = useItemViewerContext();
+  const toggleFullscreen = useFullscreenToggle({ viewerRef, setIsFullscreen });
+
+  return (
+    <ViewerButton className={className} $isDark onClick={toggleFullscreen}>
+      {isFullscreen ? (
+        <>
+          <Icon icon={minimise} />
+          <span style={{ marginLeft: '7px' }}>Exit full screen</span>
+        </>
+      ) : (
+        <>
+          <Icon icon={maximise} />
+          <span style={{ marginLeft: '7px' }}>Full screen</span>
+        </>
+      )}
+    </ViewerButton>
+  );
+};
+
+export default FullscreenToggleButton;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 
 import {
@@ -305,45 +305,6 @@ describe('ViewerBottomBar fullscreen control', () => {
     expect(
       screen.queryByRole('button', { name: /full screen/i })
     ).not.toBeInTheDocument();
-  });
-
-  it('shows the exit-fullscreen label when isFullscreen is true', () => {
-    renderBottomBar({
-      appContext: { isEnhanced: true, isFullSupportBrowser: true },
-      contextProps: {
-        transformedManifest: createMockManifest({
-          canvases: [createMockCanvas()],
-        }),
-        hasOnlyRenderableImages: true,
-        showFullscreenControl: true,
-        isFullscreen: true,
-      },
-    });
-
-    expect(
-      screen.getByRole('button', { name: /exit full screen/i })
-    ).toBeInTheDocument();
-  });
-
-  it('calls setIsFullscreen when the fullscreen button is clicked', () => {
-    const setIsFullscreen = jest.fn();
-
-    renderBottomBar({
-      appContext: { isEnhanced: true, isFullSupportBrowser: true },
-      contextProps: {
-        transformedManifest: createMockManifest({
-          canvases: [createMockCanvas()],
-        }),
-        hasOnlyRenderableImages: true,
-        showFullscreenControl: true,
-        viewerRef: { current: document.createElement('div') },
-        setIsFullscreen,
-      },
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /full screen/i }));
-
-    expect(setIsFullscreen).toHaveBeenCalledWith(true);
   });
 });
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 
 import {
@@ -305,6 +305,45 @@ describe('ViewerBottomBar fullscreen control', () => {
     expect(
       screen.queryByRole('button', { name: /full screen/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('shows the exit-fullscreen label when isFullscreen is true', () => {
+    renderBottomBar({
+      appContext: { isEnhanced: true, isFullSupportBrowser: true },
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas()],
+        }),
+        hasOnlyRenderableImages: true,
+        showFullscreenControl: true,
+        isFullscreen: true,
+      },
+    });
+
+    expect(
+      screen.getByRole('button', { name: /exit full screen/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls setIsFullscreen when the fullscreen button is clicked', () => {
+    const setIsFullscreen = jest.fn();
+
+    renderBottomBar({
+      appContext: { isEnhanced: true, isFullSupportBrowser: true },
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas()],
+        }),
+        hasOnlyRenderableImages: true,
+        showFullscreenControl: true,
+        viewerRef: { current: document.createElement('div') },
+        setIsFullscreen,
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /full screen/i }));
+
+    expect(setIsFullscreen).toHaveBeenCalledWith(true);
   });
 });
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -3,24 +3,17 @@ import { FunctionComponent } from 'react';
 import styled, { css } from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import {
-  chevron,
-  gridView,
-  maximise,
-  minimise,
-  singlePage,
-} from '@weco/common/icons';
+import { chevron, gridView, singlePage } from '@weco/common/icons';
 import { LinkProps } from '@weco/common/model/link-props';
 import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
-import useFullscreenToggle from '@weco/content/hooks/useFullscreenToggle';
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 
+import FullscreenToggleButton from './FullscreenToggleButton';
 import ToolbarSegmentedControl from './ToolbarSegmentedControl';
-import { ViewerButton } from './ViewerTopBar';
 
 const BottomBar = styled.div`
   position: relative;
@@ -138,16 +131,12 @@ const ViewerBottomBar: FunctionComponent = () => {
     showZoomed,
     isMobileSidebarActive,
     showFullscreenControl,
-    viewerRef,
-    isFullscreen,
-    setIsFullscreen,
     work,
     query,
     totalCanvases,
     hasMultipleCanvases,
     hasOnlyRenderableImages,
   } = useItemViewerContext();
-  const toggleFullscreen = useFullscreenToggle({ viewerRef, setIsFullscreen });
 
   const { canvas } = query;
 
@@ -218,21 +207,7 @@ const ViewerBottomBar: FunctionComponent = () => {
             <RightZone>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Space $h={{ size: 'sm', properties: ['margin-right'] }}>
-                  <ViewerButton onClick={toggleFullscreen} $isDark>
-                    {isFullscreen ? (
-                      <>
-                        <Icon icon={minimise} />
-                        <span style={{ marginLeft: '7px' }}>
-                          Exit full screen
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <Icon icon={maximise} />
-                        <span style={{ marginLeft: '7px' }}>Full screen</span>
-                      </>
-                    )}
-                  </ViewerButton>
+                  <FullscreenToggleButton />
                 </Space>
               </div>
             </RightZone>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -3,12 +3,19 @@ import { FunctionComponent } from 'react';
 import styled, { css } from 'styled-components';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { chevron, gridView, maximise, singlePage } from '@weco/common/icons';
+import {
+  chevron,
+  gridView,
+  maximise,
+  minimise,
+  singlePage,
+} from '@weco/common/icons';
 import { LinkProps } from '@weco/common/model/link-props';
 import { typography } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
+import useFullscreenToggle from '@weco/content/hooks/useFullscreenToggle';
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 
@@ -132,12 +139,15 @@ const ViewerBottomBar: FunctionComponent = () => {
     isMobileSidebarActive,
     showFullscreenControl,
     viewerRef,
+    isFullscreen,
+    setIsFullscreen,
     work,
     query,
     totalCanvases,
     hasMultipleCanvases,
     hasOnlyRenderableImages,
   } = useItemViewerContext();
+  const toggleFullscreen = useFullscreenToggle({ viewerRef, setIsFullscreen });
 
   const { canvas } = query;
 
@@ -208,33 +218,20 @@ const ViewerBottomBar: FunctionComponent = () => {
             <RightZone>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <Space $h={{ size: 'sm', properties: ['margin-right'] }}>
-                  <ViewerButton
-                    onClick={() => {
-                      if (viewerRef?.current) {
-                        if (
-                          !document.fullscreenElement &&
-                          !document['webkitFullscreenElement']
-                        ) {
-                          if (viewerRef.current.requestFullscreen) {
-                            viewerRef.current.requestFullscreen();
-                          } else if (
-                            viewerRef.current['webkitRequestFullscreen']
-                          ) {
-                            viewerRef.current['webkitRequestFullscreen']();
-                          }
-                        } else {
-                          if (document.exitFullscreen) {
-                            document.exitFullscreen();
-                          } else if (document['webkitExitFullscreen']) {
-                            document['webkitExitFullscreen']();
-                          }
-                        }
-                      }
-                    }}
-                    $isDark
-                  >
-                    <Icon icon={maximise} />
-                    <span style={{ marginLeft: '7px' }}>Full screen</span>
+                  <ViewerButton onClick={toggleFullscreen} $isDark>
+                    {isFullscreen ? (
+                      <>
+                        <Icon icon={minimise} />
+                        <span style={{ marginLeft: '7px' }}>
+                          Exit full screen
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <Icon icon={maximise} />
+                        <span style={{ marginLeft: '7px' }}>Full screen</span>
+                      </>
+                    )}
                   </ViewerButton>
                 </Space>
               </div>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerButton.styles.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerButton.styles.tsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+
+import { typography } from '@weco/common/utils/classnames';
+
+export const ViewerButton = styled.button.attrs({
+  className: typography('body', 'md', 'strong'),
+})<{ $isDark?: boolean }>`
+  line-height: 1.5;
+  border-radius: ${props => props.theme.borderRadiusUnit}px;
+  text-decoration: none;
+  text-align: center;
+  white-space: nowrap;
+  padding: 6px 12px;
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  &:not([disabled]):hover {
+    cursor: pointer;
+  }
+
+  &[disabled],
+  &.disabled {
+    background: ${props => props.theme.color('neutral.600')};
+    border-color: ${props => props.theme.color('neutral.600')};
+    cursor: not-allowed;
+  }
+
+  &.disabled {
+    pointer-events: none;
+  }
+
+  .icon {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  overflow: hidden;
+
+  ${props =>
+    props.$isDark &&
+    `
+    border: 2px solid transparent;
+    color: ${props.theme.color('white')};
+    background: transparent;
+
+    &:not([disabled]):hover {
+      border: 2px solid ${props.theme.color('white')};
+    }
+  `}
+
+  ${props =>
+    !props.$isDark &&
+    `
+    background: ${props.theme.color('white')};
+    color: ${props.theme.color('accent.green')};
+    border: 1px solid ${props.theme.color('accent.green')};
+
+    &:not([disabled]):hover {
+      background: ${props.theme.color('accent.green')};
+      color: ${props.theme.color('white')};
+    }
+  `}
+`;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import {
   renderWithContext,
@@ -344,38 +344,33 @@ describe('ViewerTopBar edge cases', () => {
 });
 
 describe('ViewerTopBar fullscreen control', () => {
-  it('shows the exit-fullscreen label and icon when isFullscreen is true', () => {
+  it('shows the fullscreen toggle when showFullscreenControl is true', () => {
     renderTopBar({
       contextProps: {
         transformedManifest: createMockManifest({
           canvases: [createMockCanvas()],
         }),
         showFullscreenControl: true,
-        isFullscreen: true,
       },
     });
 
     expect(
-      screen.getByRole('button', { name: /exit full screen/i })
+      screen.getByRole('button', { name: /full screen/i })
     ).toBeInTheDocument();
   });
 
-  it('calls setIsFullscreen when the fullscreen button is clicked', () => {
-    const setIsFullscreen = jest.fn();
-
+  it('hides the fullscreen toggle when showFullscreenControl is false', () => {
     renderTopBar({
       contextProps: {
         transformedManifest: createMockManifest({
           canvases: [createMockCanvas()],
         }),
-        showFullscreenControl: true,
-        viewerRef: { current: document.createElement('div') },
-        setIsFullscreen,
+        showFullscreenControl: false,
       },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /full screen/i }));
-
-    expect(setIsFullscreen).toHaveBeenCalledWith(true);
+    expect(
+      screen.queryByRole('button', { name: /full screen/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import {
   renderWithContext,
@@ -20,6 +20,12 @@ import ViewerTopBar from './ViewerTopBar';
 jest.mock('@weco/common/server-data/Context', () => ({
   ...jest.requireActual('@weco/common/server-data/Context'),
   useFeatureFlags: () => ({ itemViewerRefactor: true }),
+}));
+
+// Mock the fullscreen hook since jsdom doesn't support fullscreen API
+jest.mock('@weco/content/hooks/useIsFullscreenEnabled', () => ({
+  __esModule: true,
+  default: () => true,
 }));
 
 // A manifest-level rendering that yields a non-empty downloadOptions list.
@@ -334,5 +340,42 @@ describe('ViewerTopBar edge cases', () => {
     // Shows the invalid canvas number (doesn't validate/filter it)
     expect(screen.getByTestId('active-index')).toHaveTextContent('0');
     expect(screen.getByTestId('topbar')).toHaveTextContent('/2');
+  });
+});
+
+describe('ViewerTopBar fullscreen control', () => {
+  it('shows the exit-fullscreen label and icon when isFullscreen is true', () => {
+    renderTopBar({
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas()],
+        }),
+        showFullscreenControl: true,
+        isFullscreen: true,
+      },
+    });
+
+    expect(
+      screen.getByRole('button', { name: /exit full screen/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls setIsFullscreen when the fullscreen button is clicked', () => {
+    const setIsFullscreen = jest.fn();
+
+    renderTopBar({
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [createMockCanvas()],
+        }),
+        showFullscreenControl: true,
+        viewerRef: { current: document.createElement('div') },
+        setIsFullscreen,
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /full screen/i }));
+
+    expect(setIsFullscreen).toHaveBeenCalledWith(true);
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -5,20 +5,13 @@ import styled from 'styled-components';
 import { useAppContext } from '@weco/common/contexts/AppContext';
 import { useKiosk } from '@weco/common/contexts/KioskContext';
 import { useUserContext } from '@weco/common/contexts/UserContext';
-import {
-  chevrons,
-  gridView,
-  maximise,
-  minimise,
-  singlePage,
-} from '@weco/common/icons';
+import { chevrons, gridView, singlePage } from '@weco/common/icons';
 import { DigitalLocation } from '@weco/common/model/catalogue';
 import { typography } from '@weco/common/utils/classnames';
 import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
-import useFullscreenToggle from '@weco/content/hooks/useFullscreenToggle';
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
 import useTransformedIIIFImage from '@weco/content/hooks/useTransformedIIIFImage';
 import {
@@ -33,6 +26,7 @@ import {
 import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
 
+import FullscreenToggleButton from './FullscreenToggleButton';
 import ToolbarSegmentedControl from './ToolbarSegmentedControl';
 
 export const ViewerButton = styled.button.attrs({
@@ -215,15 +209,11 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     isResizing,
     transformedManifest,
     query,
-    viewerRef,
     showFullscreenControl,
-    isFullscreen,
-    setIsFullscreen,
     hasOnlyRenderableImages,
     currentCanvas,
     hasMultipleCanvases,
   } = useItemViewerContext();
-  const toggleFullscreen = useFullscreenToggle({ viewerRef, setIsFullscreen });
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const { userIsStaffWithRestricted } = useUserContext();
 
@@ -405,25 +395,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                 )}
 
               {isFullscreenEnabled && showFullscreenControl && (
-                <ViewerButton
-                  className="viewer-desktop"
-                  $isDark
-                  onClick={toggleFullscreen}
-                >
-                  {isFullscreen ? (
-                    <>
-                      <Icon icon={minimise} />
-                      <span style={{ marginLeft: '7px' }}>
-                        Exit full screen
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <Icon icon={maximise} />
-                      <span style={{ marginLeft: '7px' }}>Full screen</span>
-                    </>
-                  )}
-                </ViewerButton>
+                <FullscreenToggleButton className="viewer-desktop" />
               )}
             </div>
           )}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -28,67 +28,7 @@ import Download from '@weco/content/views/components/Download';
 
 import FullscreenToggleButton from './FullscreenToggleButton';
 import ToolbarSegmentedControl from './ToolbarSegmentedControl';
-
-export const ViewerButton = styled.button.attrs({
-  className: typography('body', 'md', 'strong'),
-})<{ $isDark?: boolean }>`
-  line-height: 1.5;
-  border-radius: ${props => props.theme.borderRadiusUnit}px;
-  text-decoration: none;
-  text-align: center;
-  white-space: nowrap;
-  padding: 6px 12px;
-  position: relative;
-  display: flex;
-  align-items: center;
-
-  &:not([disabled]):hover {
-    cursor: pointer;
-  }
-
-  &[disabled],
-  &.disabled {
-    background: ${props => props.theme.color('neutral.600')};
-    border-color: ${props => props.theme.color('neutral.600')};
-    cursor: not-allowed;
-  }
-
-  &.disabled {
-    pointer-events: none;
-  }
-
-  .icon {
-    display: inline-block;
-    vertical-align: middle;
-  }
-
-  overflow: hidden;
-
-  ${props =>
-    props.$isDark &&
-    `
-    border: 2px solid transparent;
-    color: ${props.theme.color('white')};
-    background: transparent;
-
-    &:not([disabled]):hover {
-      border: 2px solid ${props.theme.color('white')};
-    }
-  `}
-
-  ${props =>
-    !props.$isDark &&
-    `
-    background: ${props.theme.color('white')};
-    color: ${props.theme.color('accent.green')};
-    border: 1px solid ${props.theme.color('accent.green')};
-
-    &:not([disabled]):hover {
-      background: ${props.theme.color('accent.green')};
-      color: ${props.theme.color('white')};
-    }
-  `}
-`;
+import { ViewerButton } from './ViewerButton.styles';
 
 const TopBar = styled.div<{
   $isZooming: boolean;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -18,6 +18,7 @@ import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
+import useFullscreenToggle from '@weco/content/hooks/useFullscreenToggle';
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
 import useTransformedIIIFImage from '@weco/content/hooks/useTransformedIIIFImage';
 import {
@@ -216,10 +217,13 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     query,
     viewerRef,
     showFullscreenControl,
+    isFullscreen,
+    setIsFullscreen,
     hasOnlyRenderableImages,
     currentCanvas,
     hasMultipleCanvases,
   } = useItemViewerContext();
+  const toggleFullscreen = useFullscreenToggle({ viewerRef, setIsFullscreen });
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const { userIsStaffWithRestricted } = useUserContext();
 
@@ -404,31 +408,9 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
                 <ViewerButton
                   className="viewer-desktop"
                   $isDark
-                  onClick={() => {
-                    if (viewerRef && viewerRef.current) {
-                      if (
-                        !document.fullscreenElement &&
-                        !document['webkitFullscreenElement']
-                      ) {
-                        if (viewerRef.current.requestFullscreen) {
-                          viewerRef.current.requestFullscreen();
-                        } else if (
-                          viewerRef.current['webkitRequestFullscreen']
-                        ) {
-                          viewerRef.current['webkitRequestFullscreen']();
-                        }
-                      } else {
-                        if (document.exitFullscreen) {
-                          document.exitFullscreen();
-                        } else if (document['webkitExitFullscreen']) {
-                          document['webkitExitFullscreen']();
-                        }
-                      }
-                    }
-                  }}
+                  onClick={toggleFullscreen}
                 >
-                  {document.fullscreenElement ||
-                  document['webkitFullscreenElement'] ? (
+                  {isFullscreen ? (
                     <>
                       <Icon icon={minimise} />
                       <span style={{ marginLeft: '7px' }}>


### PR DESCRIPTION
- For #12986

## What does this change?

- We were replicating the logic in Viewer's Top and Bottom bars (so one for mobile, one for desktop), so we centralised it. Claude also suggested two fixes that I liked
  - The label wasn't changing when on fullscreen in mobile to say "exit full screen" (but was in Desktop)
  - Add `fullscreenchange` event listener. We currently only listen to our button being clicked for changing the status, but fullscreen can be escaped other ways (e.g. `Esc`). This ensure the labels and states don't become stale. It's a bug fix but I though a simple enough one? Happy to revert if we'd like to keep it til later.
  - I split out the styled component `ViewerButton` from `ViewerTopbar` since it was also used in the bottom bar and that creates a bigger dependency than we need.

1. [These commits](https://github.com/wellcomecollection/wellcomecollection.org/pull/13415/changes/BASE..6dcdedcdb72985b049985b70728476c153611dc3) split the button out and puts the logic in a hook
2. [This commit](https://github.com/wellcomecollection/wellcomecollection.org/pull/13415/changes/6982145b7c84bdf70f1026dd50a2038cf552b925) adds the fullscreenchange event listener.

## How to test

[IVR toggle on](https://dash.wellcomecollection.org/toggles/?enableToggle=itemViewerRefactor)
- Check out https://www-dev.wellcomecollection.org/works/a2239muq/items on desktop and mobile format. 
- Inspect the button's label on both fullscreen/non-fullscreens mode.


## Have we considered potential risks?
Should only affect refactored