### PR TITLE
Rename ThemeCard to ImageGridCard

### DIFF
--- a/cardigan/stories/components/Cards/ImageGridCard/ImageGridCard.stories.tsx
+++ b/cardigan/stories/components/Cards/ImageGridCard/ImageGridCard.stories.tsx
@@ -2,16 +2,16 @@ import { Meta, StoryObj } from '@storybook/react';
 import { ComponentProps } from 'react';
 
 import { mockIIIFImagesUrls } from '@weco/cardigan/stories/data/mock-iiif-images';
-import ThemeCard from '@weco/common/views/components/ThemeCard';
+import ImageGridCard from '@weco/common/views/components/ImageGridCard';
 import { ConceptImagesArray } from '@weco/content/hooks/useConceptImageUrls';
 
-type StoryProps = ComponentProps<typeof ThemeCard> & {
+type StoryProps = ComponentProps<typeof ImageGridCard> & {
   imageCount: number;
 };
 
 const meta: Meta<StoryProps> = {
-  title: 'Components/Cards/ThemeCard',
-  component: ThemeCard,
+  title: 'Components/Cards/ImageGridCard',
+  component: ImageGridCard,
   argTypes: {
     images: { table: { disable: true } },
     linkProps: { table: { disable: true } },
@@ -36,7 +36,7 @@ export default meta;
 type Story = StoryObj<StoryProps>;
 
 export const Basic: Story = {
-  name: 'ThemeCard',
+  name: 'ImageGridCard',
   args: {
     title: 'Photography',
     description:
@@ -59,7 +59,7 @@ export const Basic: Story = {
     );
 
     return (
-      <ThemeCard
+      <ImageGridCard
         {...componentProps}
         images={selectedImages as ConceptImagesArray}
       />

--- a/cardigan/stories/components/Cards/ThemeCardsList/ThemeCardsList.stories.tsx
+++ b/cardigan/stories/components/Cards/ThemeCardsList/ThemeCardsList.stories.tsx
@@ -2,8 +2,8 @@ import { Meta, StoryObj } from '@storybook/react';
 import { ComponentProps } from 'react';
 
 import { mockIIIFImagesUrls } from '@weco/cardigan/stories/data/mock-iiif-images';
+import ImageGridCard from '@weco/common/views/components/ImageGridCard';
 import { gridSize12 } from '@weco/common/views/components/Layout';
-import ThemeCard from '@weco/common/views/components/ThemeCard';
 import { ConceptImagesArray } from '@weco/content/hooks/useConceptImageUrls';
 import ScrollContainer from '@weco/content/views/components/ScrollContainer';
 import { ListItem } from '@weco/content/views/components/ScrollContainer/ScrollContainer.styles';
@@ -47,7 +47,7 @@ const meta: Meta<StoryProps> = {
     useShim: { table: { disable: true } },
     scrollButtonsAfter: { table: { disable: true } },
     cols: {
-      name: 'ThemeCard columns',
+      name: 'ImageGridCard columns',
       control: 'inline-radio',
       options: [3, 4],
     },
@@ -69,7 +69,7 @@ export const InScrollContainer: Story = {
     <ScrollContainer gridSizes={gridSize12()} useShim={args.useShim}>
       {cards.map((card, i) => (
         <ListItem key={i} $usesShim={args.useShim} $cols={args.cols}>
-          <ThemeCard
+          <ImageGridCard
             title={card.title}
             description={card.description}
             images={mockIIIFImagesUrls as ConceptImagesArray}

--- a/common/views/components/ImageGridCard/index.tsx
+++ b/common/views/components/ImageGridCard/index.tsx
@@ -160,7 +160,7 @@ const ImageGridCard: FunctionComponent<ImageGridCardProps> = ({
       {...linkProps}
       {...dataGtmPropsToAttributes(dataGtmProps)}
     >
-      <CardWrapper data-component="theme-promo">
+      <CardWrapper data-component="image-grid-card">
         <CompositeGrid $isSingleImage={isSingleImage}>
           {slots.map((slot, index) => (
             <ImageContainer key={index}>

--- a/common/views/components/ImageGridCard/index.tsx
+++ b/common/views/components/ImageGridCard/index.tsx
@@ -111,7 +111,7 @@ const Description = styled.p.attrs({
   margin-bottom: 0;
 `;
 
-export type ThemeCardProps = {
+export type ImageGridCardProps = {
   images: ConceptImagesArray;
   title: string;
   description?: string;
@@ -119,7 +119,7 @@ export type ThemeCardProps = {
   dataGtmProps?: DataGtmProps;
 };
 
-const ThemeCard: FunctionComponent<ThemeCardProps> = ({
+const ImageGridCard: FunctionComponent<ImageGridCardProps> = ({
   images,
   title,
   description,
@@ -197,4 +197,4 @@ const ThemeCard: FunctionComponent<ThemeCardProps> = ({
   );
 };
 
-export default ThemeCard;
+export default ImageGridCard;

--- a/content/webapp/services/wellcome/catalogue/archiveCategories.ts
+++ b/content/webapp/services/wellcome/catalogue/archiveCategories.ts
@@ -36,7 +36,7 @@ const ARCHIVE_CATEGORY_DESCRIPTIONS: Record<string, string> = {
 // Composite images we make ourselves and uploaded hosted,
 // keyed by the same IDs
 // An ID with no entry here renders with a colour placeholder instead
-// - see ThemeCard.
+// - see ImageGridCard.
 const ARCHIVE_CATEGORY_IMAGES: Record<string, string> = {};
 
 export async function fetchArchiveCategories(): Promise<ArchiveCategory[]> {

--- a/content/webapp/services/wellcome/catalogue/archiveCategories.ts
+++ b/content/webapp/services/wellcome/catalogue/archiveCategories.ts
@@ -33,7 +33,7 @@ const ARCHIVE_CATEGORY_DESCRIPTIONS: Record<string, string> = {
   WF: 'Records of the Wellcome Foundation, the pharmaceutical company founded by Henry Wellcome.',
 };
 
-// Composite images we make ourselves and uploaded hosted,
+// Composite images we make ourselves,
 // keyed by the same IDs
 // An ID with no entry here renders with a colour placeholder instead
 // - see ImageGridCard.

--- a/content/webapp/views/components/ThemeCardsList/index.tsx
+++ b/content/webapp/views/components/ThemeCardsList/index.tsx
@@ -2,10 +2,10 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 
 import { useFeatureFlags } from '@weco/common/server-data/Context';
 import { DataGtmProps } from '@weco/common/utils/gtm';
+import ImageGridCard from '@weco/common/views/components/ImageGridCard';
 import { gridSize12 } from '@weco/common/views/components/Layout';
 import { SizeMap } from '@weco/common/views/components/styled/Grid';
 import LL from '@weco/common/views/components/styled/LL';
-import ThemeCard from '@weco/common/views/components/ThemeCard';
 import { useConceptImageUrls } from '@weco/content/hooks/useConceptImageUrls';
 import { getConceptsByIds } from '@weco/content/services/wellcome/catalogue/concepts';
 import {
@@ -32,7 +32,7 @@ const Theme: FunctionComponent<{
       : undefined;
 
   return linkProps && concept.displayLabel ? (
-    <ThemeCard
+    <ImageGridCard
       images={images}
       title={concept.displayLabel}
       description={description}

--- a/content/webapp/views/pages/collections/archives/archives.ArchiveCategoriesList.tsx
+++ b/content/webapp/views/pages/collections/archives/archives.ArchiveCategoriesList.tsx
@@ -1,8 +1,8 @@
 import { pluralize } from '@weco/common/utils/grammar';
+import ImageGridCard from '@weco/common/views/components/ImageGridCard';
 import { Container } from '@weco/common/views/components/styled/Container';
 import { Grid, GridCell } from '@weco/common/views/components/styled/Grid';
 import Space from '@weco/common/views/components/styled/Space';
-import ThemeCard from '@weco/common/views/components/ThemeCard';
 import type { ConceptImagesArray } from '@weco/content/hooks/useConceptImageUrls';
 import type { ArchiveCategory } from '@weco/content/services/wellcome/catalogue/archiveCategories';
 
@@ -17,7 +17,7 @@ const ArchiveCategoriesList = ({
         <Grid>
           {archiveCategories.map(archiveCategory => {
             // The eventual real image will be a composite made of 4 combined
-            // photos. Until then, ThemeCard fills any empty slot with a
+            // photos. Until then, ImageGridCard fills any empty slot with a
             // placeholder colour block itself.
             const images: ConceptImagesArray = [
               archiveCategory.image,
@@ -31,7 +31,7 @@ const ArchiveCategoriesList = ({
                 key={archiveCategory.id}
                 $sizeMap={{ s: [12], m: [6], l: [4], xl: [3] }}
               >
-                <ThemeCard
+                <ImageGridCard
                   images={images}
                   title={`${archiveCategory.label} (${archiveCategory.id})`}
                   description={`${archiveCategory.description} ${pluralize(archiveCategory.count, 'archive')}.`}


### PR DESCRIPTION
For #13324

## What does this change?
`ThemeCard` was named for what it was first built for, but it's now reused for the archive category listing too so this renames it to `ImageGridCard`, along with its Cardigan story and call sites (ThemeCardsList, archives.ArchiveCategoriesList.tsx, and a comment that needed updating).

## How to test
- Check the ImageGridCard and ThemeCardsList Cardigan stories
- [Enable archiveBrowsing toggle](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveBrowsing)
- confirm https://www-dev.wellcomecollection.org/collections and https://www-dev.wellcomecollection.org/collections/archives still render unchanged.

## Have we considered potential risks?

None — mechanical rename, no behaviour change.

It's a bit of a change from naming things by purpose. We _could_ create `ThemeCard` and `ArchiveCard` wrapper components, but that seemed overly complicated.