### PR TITLE
IVR: unify the canvas position label

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.test.tsx
@@ -17,7 +17,7 @@ const threeCanvases = createMockManifest({
 });
 
 const render = (
-  ui: React.ReactElement,
+  ui: JSX.Element,
   contextProps: Partial<ItemViewerContextProps> = {}
 ) =>
   renderWithContext(ui, {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.test.tsx
@@ -1,0 +1,74 @@
+import { screen } from '@testing-library/react';
+
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
+import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+import {
+  createMockCanvas,
+  createMockManifest,
+  createMockQuery,
+} from '@weco/content/test/fixtures/iiif/transformed-manifest';
+
+import CanvasPositionIndicator, {
+  useCanvasPositionLabel,
+} from './CanvasPositionIndicator';
+
+const threeCanvases = createMockManifest({
+  canvases: [createMockCanvas(), createMockCanvas(), createMockCanvas()],
+});
+
+const render = (
+  ui: React.ReactElement,
+  contextProps: Partial<ItemViewerContextProps> = {}
+) =>
+  renderWithContext(ui, {
+    contextProps: { transformedManifest: threeCanvases, ...contextProps },
+    useRefactoredContext: true,
+  });
+
+describe('CanvasPositionIndicator', () => {
+  it('renders the 1-based canvas position and the total', () => {
+    const { container } = render(<CanvasPositionIndicator />, {
+      query: createMockQuery({ canvas: 2 }),
+    });
+
+    expect(container).toHaveTextContent('2/3');
+  });
+
+  it('puts positionTestId on the position alone, without the separator or total', () => {
+    // Playwright asserts this element's exact text, so the position can't be
+    // rolled into the same node as the rest of the label.
+    render(<CanvasPositionIndicator positionTestId="active-index" />, {
+      query: createMockQuery({ canvas: 2 }),
+    });
+
+    expect(screen.getByTestId('active-index')).toHaveTextContent(/^2$/);
+  });
+
+  it('renders no test id when positionTestId is omitted, so two indicators can coexist', () => {
+    // The top bar and the bottom bar both render one; a shared id would match
+    // twice and break getByTestId.
+    const { container } = render(<CanvasPositionIndicator />);
+
+    expect(container.querySelector('[data-testid]')).not.toBeInTheDocument();
+  });
+
+  it('shows an out-of-range canvas number as-is rather than clamping it', () => {
+    const { container } = render(<CanvasPositionIndicator />, {
+      query: createMockQuery({ canvas: 9999 }),
+    });
+
+    expect(container).toHaveTextContent('9999/3');
+  });
+});
+
+describe('useCanvasPositionLabel', () => {
+  const ShowLabel = () => <>{useCanvasPositionLabel()}</>;
+
+  it('returns the same label the indicator renders', () => {
+    const { container } = render(<ShowLabel />, {
+      query: createMockQuery({ canvas: 2 }),
+    });
+
+    expect(container).toHaveTextContent('2/3');
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import { ReactElement } from 'react';
 
 import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
 import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
@@ -17,7 +18,7 @@ const threeCanvases = createMockManifest({
 });
 
 const render = (
-  ui: JSX.Element,
+  ui: ReactElement,
   contextProps: Partial<ItemViewerContextProps> = {}
 ) =>
   renderWithContext(ui, {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.tsx
@@ -2,11 +2,6 @@ import { FunctionComponent } from 'react';
 
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
 
-// The current canvas's position within the manifest - "3/48" - is shown in the
-// top bar's page indicator, the bottom bar's canvas navigation, and as the
-// fallback caption for an audio item with no label of its own. This module owns
-// both where the two values come from and the format they're rendered in.
-
 /**
  * The label in two pieces, split where the top bar needs an element boundary
  * so it can put a test id on the position alone. Callers either concatenate
@@ -20,11 +15,6 @@ function useCanvasPositionParts(): { position: string; suffix: string } {
   return { position: `${query.canvas}`, suffix: `/${totalCanvases}` };
 }
 
-/**
- * The current canvas's position as a plain string, e.g. "3/48", for the places
- * that need a value rather than markup - the audio player takes its fallback
- * title as a string prop.
- */
 export function useCanvasPositionLabel(): string {
   const { position, suffix } = useCanvasPositionParts();
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/CanvasPositionIndicator.tsx
@@ -1,0 +1,63 @@
+import { FunctionComponent } from 'react';
+
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
+
+// The current canvas's position within the manifest - "3/48" - is shown in the
+// top bar's page indicator, the bottom bar's canvas navigation, and as the
+// fallback caption for an audio item with no label of its own. This module owns
+// both where the two values come from and the format they're rendered in.
+
+/**
+ * The label in two pieces, split where the top bar needs an element boundary
+ * so it can put a test id on the position alone. Callers either concatenate
+ * them (useCanvasPositionLabel) or render them either side of that boundary
+ * (CanvasPositionIndicator) - so this is the only place the format lives, and
+ * changing it can't leave one of them behind.
+ */
+function useCanvasPositionParts(): { position: string; suffix: string } {
+  const { query, totalCanvases } = useItemViewerContext();
+
+  return { position: `${query.canvas}`, suffix: `/${totalCanvases}` };
+}
+
+/**
+ * The current canvas's position as a plain string, e.g. "3/48", for the places
+ * that need a value rather than markup - the audio player takes its fallback
+ * title as a string prop.
+ */
+export function useCanvasPositionLabel(): string {
+  const { position, suffix } = useCanvasPositionParts();
+
+  return `${position}${suffix}`;
+}
+
+type Props = {
+  /**
+   * Applied to a span wrapping the position on its own, without the suffix.
+   * Playwright asserts this element's exact text, so the two halves can't be
+   * collapsed into a single node. Optional because only one indicator can
+   * carry a given id - the top bar and bottom bar both render one, and a
+   * shared id would match twice.
+   */
+  positionTestId?: string;
+};
+
+/**
+ * The current canvas's position, for display. Reads the values off
+ * ItemViewerContext rather than taking them as props, so callers can't
+ * substitute a different source.
+ */
+const CanvasPositionIndicator: FunctionComponent<Props> = ({
+  positionTestId,
+}) => {
+  const { position, suffix } = useCanvasPositionParts();
+
+  return (
+    <>
+      <span data-testid={positionTestId}>{position}</span>
+      {suffix}
+    </>
+  );
+};
+
+export default CanvasPositionIndicator;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import {
   Work,
@@ -160,5 +160,35 @@ describe('IIIFViewer', () => {
       expect(await screen.findByTestId('zoomed-image')).toBeInTheDocument();
       expect(fetchMock).not.toHaveBeenCalled();
     });
+  });
+
+  // VirtualizedImageViewer relies on this: it passes no titleOverride because
+  // IIIFItem only reads it for audio. MainViewer.test.tsx covers the other
+  // direction, given the flag.
+  it('routes an audio canvas to the paginated viewer, not the fixed list', async () => {
+    const { container } = renderViewer(
+      createMockManifest({
+        canvases: [
+          createMockCanvas({
+            painting: [
+              {
+                id: 'https://example.com/audio.mp3',
+                type: 'Sound',
+                format: 'audio/mp3',
+              },
+            ] as never,
+          }),
+        ],
+      })
+    );
+
+    // As above: MainViewer only renders once IIIFViewer's mount-time resizing
+    // state settles.
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-component="paginated"]')
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('image-item')).not.toBeInTheDocument();
   });
 });

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.test.tsx
@@ -149,6 +149,30 @@ describe('PaginatedItemViewer', () => {
     ).toBeInTheDocument();
   });
 
+  // titleOverride is IIIFItem's fallback for an item whose canvas has no label
+  // of its own - getFileLabel treats "-" as no label - and only the audio
+  // player reads it.
+  it('captions a label-less audio item with the current canvas position', () => {
+    const createLabellessAudioCanvas = (id: string) =>
+      createMockCanvas({
+        id,
+        label: '-',
+        painting: [{ id, type: 'Sound', format: 'audio/mp3' }] as never,
+      });
+
+    renderViewer({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createLabellessAudioCanvas('https://example.com/audio-1.mp3'),
+          createLabellessAudioCanvas('https://example.com/audio-2.mp3'),
+        ],
+      }),
+      query: createMockQuery({ canvas: 2 }),
+    });
+
+    expect(screen.getByText('2/2')).toBeInTheDocument();
+  });
+
   it('renders nothing when the current canvas cannot be resolved', () => {
     const { container } = renderViewer({
       transformedManifest: createMockManifest({

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/PaginatedItemViewer.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
 import { getDisplayItems } from '@weco/content/utils/iiif/v3/canvas';
 
+import { useCanvasPositionLabel } from './CanvasPositionIndicator';
 import IIIFItem from './IIIFItem';
 
 const ItemWrapper = styled.div`
@@ -25,16 +26,13 @@ const ItemWrapper = styled.div`
 `;
 
 const PaginatedItemViewer: FunctionComponent = () => {
-  const {
-    transformedManifest,
-    query,
-    setShowFullscreenControl,
-    currentCanvas,
-  } = useItemViewerContext();
-  const { canvases, auth, placeholderId } = {
+  const { transformedManifest, setShowFullscreenControl, currentCanvas } =
+    useItemViewerContext();
+  const { auth, placeholderId } = {
     ...transformedManifest,
   };
   const externalAccessService = auth?.externalAccessService;
+  const canvasPositionLabel = useCanvasPositionLabel();
 
   useEffect(() => {
     setShowFullscreenControl(false);
@@ -51,7 +49,7 @@ const PaginatedItemViewer: FunctionComponent = () => {
         item={item}
         i={i}
         canvas={currentCanvas}
-        titleOverride={`${query.canvas}/${canvases?.length}`}
+        titleOverride={canvasPositionLabel}
         exclude={[]}
         externalAccessService={externalAccessService}
         showVideoTranscript={false}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
@@ -133,7 +133,9 @@ describe('ViewerBottomBar navigation (non-image works)', () => {
       },
     });
 
-    expect(screen.getByText('2/3')).toBeInTheDocument();
+    // CanvasPositionIndicator splits the position into its own span so the top
+    // bar can put a test id on it, which breaks up the text for getByText.
+    expect(screen.getByTestId('bottombar')).toHaveTextContent('2/3');
   });
 
   it('does not show navigation for single-canvas works', () => {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.test.tsx
@@ -133,8 +133,6 @@ describe('ViewerBottomBar navigation (non-image works)', () => {
       },
     });
 
-    // CanvasPositionIndicator splits the position into its own span so the top
-    // bar can put a test id on it, which breaks up the text for getByText.
     expect(screen.getByTestId('bottombar')).toHaveTextContent('2/3');
   });
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -12,6 +12,7 @@ import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/r
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 
+import CanvasPositionIndicator from './CanvasPositionIndicator';
 import ToolbarSegmentedControl from './ToolbarSegmentedControl';
 import { ViewerButton } from './ViewerTopBar';
 
@@ -168,7 +169,7 @@ const ViewerBottomBar: FunctionComponent = () => {
             className={typography('body', 'md', 'regular')}
             style={{ color: 'white' }}
           >
-            {canvas}/{totalCanvases}
+            <CanvasPositionIndicator />
           </span>
 
           <CanvasNavButton link={nextCanvasLink} direction="next" />

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -32,6 +32,7 @@ import {
 import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
 
+import CanvasPositionIndicator from './CanvasPositionIndicator';
 import ToolbarSegmentedControl from './ToolbarSegmentedControl';
 
 export const ViewerButton = styled.button.attrs({
@@ -213,7 +214,6 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
     showZoomed,
     isResizing,
     transformedManifest,
-    query,
     viewerRef,
     showFullscreenControl,
     hasOnlyRenderableImages,
@@ -223,7 +223,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
   const transformedIIIFImage = useTransformedIIIFImage(work);
   const { userIsStaffWithRestricted } = useUserContext();
 
-  const { canvases, rendering } = { ...transformedManifest };
+  const { rendering } = { ...transformedManifest };
   const imageServices = (currentCanvas?.painting
     .map(p => {
       if (isChoiceBody(p)) {
@@ -375,8 +375,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
         <MiddleZone className="viewer-desktop">
           {shouldShowPageIndicator && (
             <>
-              <span data-testid="active-index">{`${query.canvas || 0}`}</span>
-              {`/${canvases?.length || ''}`}{' '}
+              <CanvasPositionIndicator positionTestId="active-index" />{' '}
               {currentPageLabel !== '-' &&
                 hasOnlyRenderableImages &&
                 `page ${currentPageLabel}`}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
@@ -74,11 +74,14 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
                   data-testid="image-item"
                   $isFirstItemRestricted={!!isFirstItemRestricted}
                 >
+                  {/*
+                    No titleOverride: IIIFItem only reads it for audio, and
+                    this viewer never renders audio - see IIIFViewer.test.tsx.
+                  */}
                   <IIIFItem
                     placeholderId={placeholderId}
                     item={item}
                     canvas={currentCanvas}
-                    titleOverride={`${index}/${canvases.length}`}
                     i={index}
                     exclude={[]}
                     setImageRect={setImageRect}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
@@ -74,10 +74,6 @@ const ItemRenderer = memo(({ style, index, data }: ItemRendererProps) => {
                   data-testid="image-item"
                   $isFirstItemRestricted={!!isFirstItemRestricted}
                 >
-                  {/*
-                    No titleOverride: IIIFItem only reads it for audio, and
-                    this viewer never renders audio - see IIIFViewer.test.tsx.
-                  */}
                   <IIIFItem
                     placeholderId={placeholderId}
                     item={item}


### PR DESCRIPTION
- For #12986

## What does this change?

The "3/48" canvas position indicator was built four different ways. `ViewerTopBar` and `ViewerBottomBar` both render it, `PaginatedItemViewer` passes it to `IIIFItem` as a fallback caption, and `VirtualizedImageViewer` did the same using a 0-based `react-window` row index. Three of the four recalculated the total from `transformedManifest.canvases.length` even though `totalCanvases` is already on `ItemViewerContext`.

A new `CanvasPositionIndicator` owns both where the two values come from and the format they're rendered in. It reads `query.canvas` and `totalCanvases` off context itself rather than taking them as props, so callers can't substitute a different source. The format lives in one private hook, returned pre-split at the point the top bar needs an element boundary for its `active-index` test id — so a format change can't update the markup and quietly leave the string version behind.

`VirtualizedImageViewer`'s `titleOverride` is **deleted rather than corrected**. Tests-first turned up that the prop was unreachable there: `IIIFItem` only reads it as the audio player's fallback title, and that viewer never renders audio. See the inline comments for the full derivation and for what the characterisation test actually rendered before the deletion.

Two dead fallbacks in `ViewerTopBar` went with it (`query.canvas || 0` and `canvases?.length || ''`) — details inline.

`IIIFSearchWithin.tsx:128` renders the same two values as `Found on image 3 / 48 (page 3)`. Left alone deliberately: different wording and spacing, and unifying it would change visible text in search results, so it wants its own review and probably a design opinion.

## How to test

No user-visible change is expected, so this is mostly a confirm-nothing-moved exercise.

With the IVR toggle on, compare against prod:
- A multi-canvas image work, e.g. [b/a2239muq](https://www-dev.wellcomecollection.org/works/a2239muq/items?canvas=15) — the top bar should read `15/80 page 15` exactly as prod does, and paging should keep it in step.
- A non-image work (video/audio/born-digital) — the bottom bar's `Previous 2/3 Next` counter should be unchanged.
- An audio work whose canvas has no label of its own — the audio player's caption should show the 1-based position (`2/2`, not `0/2`).

Without the toggle, nothing should have changed from prod.

## Have we considered potential risks?

Low risk — this moves where an existing string is built, and the values it's built from are the same ones the bottom bar already used.

Two things worth a reviewer's eye:

The deletion rests on an invariant that spans four files rather than anything local, so `IIIFViewer.test.tsx` pins it by driving a real audio manifest through the real `IIIFViewer`. If you disagree that deleting beats fixing, that's the decision to push back on.

The bottom bar's counter gains a nested span, which is the one DOM change. It breaks up the text for testing-library's `getByText`, so one assertion moved to `toHaveTextContent`. Playwright is unaffected — its text engine matches the smallest element containing the text, so the outer span still resolves uniquely for `5/27`, and `active-index` still holds only the bare number.

Merge-tested against the two sibling PRs on this issue, #13409 and #13412: both merge clean pairwise and combined, with the full `content/webapp` suite passing on the combined tree (83 suites, 641 tests).