### PR TITLE
Add a JS challenge on works item pages (WAF)

### DIFF
--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -47,6 +47,9 @@ module "prod_wc_org_cloudfront_distribution" {
   # is high-risk.
   enable_search_challenge = true
 
+  # Checked on stage 2026-08-27 (see the items-challenge rule in the module).
+  enable_items_challenge = true
+
   # Blocks fabricated legacy-Chrome UAs before the challenge, cutting billed
   # challenge responses by roughly a third at 2026-07 flood volumes.
   enable_search_legacy_ua_block = true

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -42,9 +42,7 @@ module "stage_wc_org_cloudfront_distribution" {
   # rule in the module for why this is high-risk).
   enable_search_challenge = true
 
-  # Trialling the /works/<id>/items challenge here before prod: a headless
-  # fleet on residential proxies is loading items pages from 200k+ IPs a day
-  # and no header or IP rule catches it. Shares the 4h token immunity below.
+  # Trialling the /works/<id>/items challenge here before prod (see the items-challenge rule in the module).
   enable_items_challenge = true
 
   # Cuts billed challenge responses by blocking provably fabricated user

--- a/cache/cloudfront_stage.tf
+++ b/cache/cloudfront_stage.tf
@@ -42,6 +42,11 @@ module "stage_wc_org_cloudfront_distribution" {
   # rule in the module for why this is high-risk).
   enable_search_challenge = true
 
+  # Trialling the /works/<id>/items challenge here before prod: a headless
+  # fleet on residential proxies is loading items pages from 200k+ IPs a day
+  # and no header or IP rule catches it. Shares the 4h token immunity below.
+  enable_items_challenge = true
+
   # Cuts billed challenge responses by blocking provably fabricated user
   # agents first. Matches prod.
   enable_search_legacy_ua_block = true

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -123,7 +123,7 @@ variable "bot_control_inspection_level" {
 variable "search_challenge_immunity_seconds" {
   type        = number
   default     = 300
-  description = "How long a solved search challenge token stays valid. 300 is the AWS default; longer values mean fewer billed re-challenges for real users but a longer window for a token-holding client before it is re-challenged."
+  description = "How long a solved challenge token stays valid; applies to both the search and items challenge rules, since tokens are per web ACL. 300 is the AWS default; longer values mean fewer billed re-challenges for real users but a longer window for a token-holding client before it is re-challenged."
 
   validation {
     condition     = var.search_challenge_immunity_seconds >= 60 && var.search_challenge_immunity_seconds <= 259200 && floor(var.search_challenge_immunity_seconds) == var.search_challenge_immunity_seconds

--- a/cache/modules/wc_org_cloudfront/variables.tf
+++ b/cache/modules/wc_org_cloudfront/variables.tf
@@ -85,6 +85,12 @@ variable "enable_search_challenge" {
   description = "Serve a silent JS challenge to token-less clients on /search* pages. High-risk: prove on stage before enabling elsewhere."
 }
 
+variable "enable_items_challenge" {
+  type        = bool
+  default     = false
+  description = "Serve a silent JS challenge to token-less clients on /works/<id>/items pages, reusing search_challenge_immunity_seconds. High-risk: prove on stage before enabling elsewhere."
+}
+
 variable "enable_search_legacy_ua_block" {
   type        = bool
   default     = false

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -902,6 +902,8 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // residential proxies (few requests per IP, current browser UAs and headers)
   // loads these pages, so nothing keyed on IP, UA or headers catches it.
   // Page URL only, never assets or /_next data routes; prove on stage first.
+  // As with search-challenge, non-Google crawlers and link-preview fetchers
+  // receive the challenge instead of the page.
   dynamic "rule" {
     for_each = var.enable_items_challenge ? [1] : []
     content {
@@ -920,16 +922,15 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
       statement {
         regex_match_statement {
-          regex_string = "^/works/[^/]+/items"
+          regex_string = "^/works/[^/]+/items$"
 
           field_to_match {
             uri_path {}
           }
 
-          # Decoded so a percent-encoded path segment can't sidestep the match.
           text_transformation {
             priority = 0
-            type     = "URL_DECODE"
+            type     = "NONE"
           }
         }
       }

--- a/cache/modules/wc_org_cloudfront/waf.tf
+++ b/cache/modules/wc_org_cloudfront/waf.tf
@@ -898,9 +898,53 @@ resource "aws_wafv2_web_acl" "wc_org" {
     }
   }
 
+  // JS challenge on /works/<id>/items: since 2026-08-18 a headless fleet on
+  // residential proxies (few requests per IP, current browser UAs and headers)
+  // loads these pages, so nothing keyed on IP, UA or headers catches it.
+  // Page URL only, never assets or /_next data routes; prove on stage first.
+  dynamic "rule" {
+    for_each = var.enable_items_challenge ? [1] : []
+    content {
+      name     = "items-challenge"
+      priority = 16
+
+      action {
+        challenge {}
+      }
+
+      challenge_config {
+        immunity_time_property {
+          immunity_time = var.search_challenge_immunity_seconds
+        }
+      }
+
+      statement {
+        regex_match_statement {
+          regex_string = "^/works/[^/]+/items"
+
+          field_to_match {
+            uri_path {}
+          }
+
+          # Decoded so a percent-encoded path segment can't sidestep the match.
+          text_transformation {
+            priority = 0
+            type     = "URL_DECODE"
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        sampled_requests_enabled   = true
+        metric_name                = "items-challenge-${var.namespace}"
+      }
+    }
+  }
+
   rule {
     name     = "geo-rate-limit-USA"
-    priority = 16
+    priority = 17
 
     action {
       block {
@@ -935,7 +979,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-APAC"
-    priority = 17
+    priority = 18
 
     action {
       block {
@@ -975,7 +1019,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "geo-rate-limit-LATAM"
-    priority = 18
+    priority = 19
 
     action {
       block {
@@ -1012,7 +1056,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "blanket-rate-limiting"
-    priority = 19
+    priority = 20
 
     action {
       block {}
@@ -1034,7 +1078,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
 
   rule {
     name     = "restrictive-rate-limiting"
-    priority = 20
+    priority = 21
 
     action {
       block {}
@@ -1072,7 +1116,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
   rule {
     name     = "core-rule-group"
-    priority = 21
+    priority = 22
 
     override_action {
       none {}
@@ -1095,7 +1139,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-use-case.html#aws-managed-rule-groups-use-case-sql-db
   rule {
     name     = "sqli-rule-group"
-    priority = 22
+    priority = 23
 
     override_action {
       none {}
@@ -1118,7 +1162,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // See: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs
   rule {
     name     = "known-bad-inputs-rule-group"
-    priority = 23
+    priority = 24
 
     override_action {
       none {}
@@ -1216,7 +1260,7 @@ resource "aws_wafv2_web_acl" "wc_org" {
   // /search once the group is scoped down for targeted inspection.
   rule {
     name     = "seo-user-agent-block"
-    priority = 24
+    priority = 25
 
     action {
       block {}


### PR DESCRIPTION
- For https://github.com/wellcomecollection/platform-infrastructure/issues/527 (item 1 of the plan there)

## What does this change?

Adds an `items-challenge` rule to the wc.org CloudFront web ACL: a silent JS challenge on `^/works/[^/]+/items$`, matched against the raw URI path with no text transformation, reusing the existing 4 hour token immunity. It sits at priority 16, directly after `search-challenge`, and the rules below it are renumbered in the same way #13247 did. A new `enable_items_challenge` variable gates it, defaulting to false. It is on for stage and prod; e2e keeps the default of false.

Since 2026-08-18 a headless browser fleet on residential proxy IPs has been loading items pages: 200k to 330k distinct IPs a day at 6 to 50 requests each, with current Chrome and Firefox user agents and valid `Accept-Language` headers. Nothing keyed on IP, user agent or headers catches it. `works-fabricated-ua-block` matched it three times on the peak day, the per-IP rate limits never fire at that request-per-IP rate, and Bot Control is scoped to /search. The traffic doubles load on iiif.wellcomecollection.org and lifts the content origin by 35 to 55%. A challenge is the same lever that ended the July fleet on /search.

## How to test

Apply to stage, then:

- `curl https://www-stage.wellcomecollection.org/works/mg56yqa4/items` with a browser user agent returns 202 with `x-amzn-waf-action: challenge`.
- `/works/mg56yqa4` and `/_next/data/.../items.json` still return 200, confirming the rule matches the page URL only and not assets or data routes.
- Adapt the `waf-challenge-check.mjs` real-browser script from the July /search work (locale en-GB, CookieControl cookie) to an items flow and expect no responses at 400 or above.
- Run the `view-items` Playwright tests against stage.
- Watch the `AWS/WAFV2` metrics for `items-challenge-stage`: `ChallengeRequests`, `ChallengesSolved` and `RequestsWithValidChallengeToken`.

## Rollout so far

- 2026-08-27, stage: applied with a targeted plan on the stage ACL. Items page and `?canvas=` variant return 202 with `x-amzn-waf-action: challenge`; the work page, `_next/data` items route and homepage return 200; the trailing-slash form gets Next's 308 first. Real-browser flow (fresh browser, canvas change, work page and back, second tab) passed with one challenge served and no responses at 400 or above. `view-items` Playwright suite against stage: 89 of 90, the one failure (scroll to last slide) is flaky independent of the WAF. ACL capacity 1380 of 1500 WCU.
- 2026-08-27 08:57Z, prod: same targeted apply on the prod ACL, same checks passed, capacity 1403 of 1500 WCU. First 15 minutes: 500 to 700 challenge requests a minute, of which 220 to 280 a minute are attempted and every attempt solved; content ALB requests fell from about 1,900 to 2,300 a minute to 1,200 to 1,400 a minute at the switch, and iiif.wellcomecollection.org requests from 6 to 7k a minute to about 5.2k, with no change in wc.org or origin 5xx. Soak continues through the day against an hourly baseline recorded on wellcomecollection/platform-infrastructure#527.
- 2026-08-27 12:30Z, four hours in: steady 40 to 44k challenge requests an hour, 11 to 13k attempted and every attempt solved (about 30% of challenged loads), so the fleet is not passing it. 11:00Z hour against yesterday and the three-day same-hour mean: content ALB 71k (131k, 84k), wc.org CloudFront 240k (374k, 262k), iiif requests 279k (835k, 436k). wc.org 5xx 0 throughout, ALB target 5xx at normal noise, content CPU 8 to 10%.

## Have we considered potential risks?

The first is accepted for the prod soak and should be revisited after it.

- **Non-Google crawlers and link-preview fetchers get the challenge page instead of the item.** Bing, DuckDuckGo, Slack, Facebook and iMessage are all affected, as they already are on /search. Items pages are indexable, so this is a product call rather than a purely technical one.




