### PR TITLE
Stop fetching aggregation collections as parent manifests on item pages

### DIFF
--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -248,7 +248,7 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 async function getParentManifest(
   parentManifestUrl: string | undefined
 ): Promise<Manifest | undefined> {
-  // The helper logs and rethrows non-404 errors; a missing parent is not fatal here.
+  // The helper returns undefined on 404 and throws on fetch/parse errors; neither is fatal here.
   try {
     return parentManifestUrl
       ? await fetchIIIFPresentationManifest({ location: parentManifestUrl })

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -253,7 +253,11 @@ async function getParentManifest(
     return parentManifestUrl
       ? await fetchJson<Manifest>(parentManifestUrl)
       : undefined;
-  } catch {
+  } catch (error) {
+    console.error(
+      `Error fetching parent manifest ${parentManifestUrl}:`,
+      error
+    );
     return undefined;
   }
 }

--- a/content/webapp/pages/works/[workId]/items.tsx
+++ b/content/webapp/pages/works/[workId]/items.tsx
@@ -30,7 +30,6 @@ import {
 import { getWork } from '@weco/content/services/wellcome/catalogue/works';
 import { toCompressedTransformedManifest } from '@weco/content/types/compressed-manifest';
 import { TransformedManifest } from '@weco/content/types/manifest';
-import { fetchJson } from '@weco/content/utils/http';
 import {
   getCollectionManifests,
   hasNonImagesOrOriginals,
@@ -249,15 +248,12 @@ export const getServerSideProps: ServerSidePropsOrAppError<
 async function getParentManifest(
   parentManifestUrl: string | undefined
 ): Promise<Manifest | undefined> {
+  // The helper logs and rethrows non-404 errors; a missing parent is not fatal here.
   try {
     return parentManifestUrl
-      ? await fetchJson<Manifest>(parentManifestUrl)
+      ? await fetchIIIFPresentationManifest({ location: parentManifestUrl })
       : undefined;
-  } catch (error) {
-    console.error(
-      `Error fetching parent manifest ${parentManifestUrl}:`,
-      error
-    );
+  } catch {
     return undefined;
   }
 }

--- a/content/webapp/services/iiif/transformers/manifest.ts
+++ b/content/webapp/services/iiif/transformers/manifest.ts
@@ -12,6 +12,7 @@ import {
   getIIIFPresentationCredit,
   getItemsStatus,
   getManifestAccessRequirements,
+  getParentManifestUrl,
   getSearchService,
   getStructures,
   getTitle,
@@ -30,7 +31,7 @@ export function transformManifest(
   const title = getTitle(manifestV3.label);
   const iiifCredit = getIIIFPresentationCredit(manifestV3);
   const id = manifestV3.id || '';
-  const parentManifestUrl = manifestV3.partOf?.[0].id;
+  const parentManifestUrl = getParentManifestUrl(manifestV3);
   const manifests = getCollectionManifests(manifestV3);
   const collectionManifestsCount = manifests.length;
   const transformedCanvases = getTransformedCanvases(manifestV3);

--- a/content/webapp/utils/iiif/v3/index.test.ts
+++ b/content/webapp/utils/iiif/v3/index.test.ts
@@ -22,6 +22,7 @@ import {
   getItemsStatus,
   getManifestAccessRequirements,
   getOriginalFiles,
+  getParentManifestUrl,
   getProbeServiceId,
   getVideoAudioDownloadOptions,
   hasItemType,
@@ -1037,6 +1038,41 @@ describe('isCollection', () => {
       isCollection(createTestManifest({ type: 'Collection' } as never))
     ).toBe(true);
     expect(isCollection(createTestManifest())).toBe(false);
+  });
+});
+
+describe('getParentManifestUrl', () => {
+  const genre = {
+    id: 'https://iiif.wellcomecollection.org/presentation/collections/genres/Annual_reports',
+    type: 'Collection' as const,
+  };
+  const contributor = {
+    id: 'https://iiif.wellcomecollection.org/presentation/collections/contributors/ew9rzxst',
+    type: 'Collection' as const,
+  };
+  const multiPartParent = {
+    id: 'https://iiif.wellcomecollection.org/presentation/b2178081x',
+    type: 'Collection' as const,
+  };
+
+  it('is undefined when partOf only contains aggregation collections', () => {
+    expect(
+      getParentManifestUrl(createTestManifest({ partOf: [genre, contributor] }))
+    ).toBeUndefined();
+  });
+
+  it('is undefined when there is no partOf', () => {
+    expect(
+      getParentManifestUrl(createTestManifest({ partOf: undefined }))
+    ).toBeUndefined();
+  });
+
+  it('returns the b-number parent regardless of its position', () => {
+    expect(
+      getParentManifestUrl(
+        createTestManifest({ partOf: [genre, multiPartParent, contributor] })
+      )
+    ).toBe(multiPartParent.id);
   });
 });
 

--- a/content/webapp/utils/iiif/v3/index.test.ts
+++ b/content/webapp/utils/iiif/v3/index.test.ts
@@ -1067,6 +1067,25 @@ describe('getParentManifestUrl', () => {
     ).toBeUndefined();
   });
 
+  it('skips a versioned aggregation collection id', () => {
+    const versionedGenre = {
+      id: 'https://iiif.wellcomecollection.org/presentation/v3/collections/genres/Annual_reports',
+      type: 'Collection' as const,
+    };
+    expect(
+      getParentManifestUrl(createTestManifest({ partOf: [versionedGenre] }))
+    ).toBeUndefined();
+  });
+
+  it('skips entries whose id is not a string', () => {
+    const noId = { type: 'Collection' as const } as NonNullable<
+      Manifest['partOf']
+    >[number];
+    expect(
+      getParentManifestUrl(createTestManifest({ partOf: [noId] }))
+    ).toBeUndefined();
+  });
+
   it('returns the b-number parent regardless of its position', () => {
     expect(
       getParentManifestUrl(

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -691,14 +691,15 @@ export function isCollection(
   return manifest.type === 'Collection';
 }
 
-// Only a b-number Collection can be a multi-part parent. The other partOf
-// entries (/presentation/collections/{contributors,genres,...}) are
-// aggregations that we never render, so don't fetch them.
+// Skip aggregation collections (/presentation/[vN/]collections/{genres,...});
+// they are never rendered, so fetching them on every render is wasted work.
+const aggregationCollectionPath = /\/presentation\/(v\d+\/)?collections\//;
+
 export function getParentManifestUrl(
   manifest: Manifest | Collection
 ): string | undefined {
   return manifest.partOf?.find(
-    p => p.id && !p.id.includes('/presentation/collections/')
+    p => typeof p.id === 'string' && !aggregationCollectionPath.test(p.id)
   )?.id;
 }
 

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -691,6 +691,17 @@ export function isCollection(
   return manifest.type === 'Collection';
 }
 
+// Only a b-number Collection can be a multi-part parent. The other partOf
+// entries (/presentation/collections/{contributors,genres,...}) are
+// aggregations that we never render, so don't fetch them.
+export function getParentManifestUrl(
+  manifest: Manifest | Collection
+): string | undefined {
+  return manifest.partOf?.find(
+    p => p.id && !p.id.includes('/presentation/collections/')
+  )?.id;
+}
+
 // We sometimes want to offer the original file for download.
 // There are 4 potential sources for this, checked in priority order.
 // 1) Content resources with a behavior value that includes 'original'.

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -691,8 +691,8 @@ export function isCollection(
   return manifest.type === 'Collection';
 }
 
-// Skip aggregation collections (/presentation/[vN/]collections/{genres,...});
-// they are never rendered, so fetching them on every render is wasted work.
+// Skip anything under /presentation/[vN/]collections/ (genre, contributor and
+// similar aggregations); they are never rendered, so fetching them is wasted work.
 const aggregationCollectionPath = /\/presentation\/(v\d+\/)?collections\//;
 
 export function getParentManifestUrl(


### PR DESCRIPTION
- For wellcomecollection/platform-infrastructure#527 (item 2 of the plan there)

## What does this change?

Every server render of an item page fetched `manifest.partOf[0]` looking for a multi-part parent. For an ordinary work that first entry is a genre, contributor or subject aggregation Collection (see the `b2846235x` and `b28462270` fixtures), which iiif-builder answers with a 503 around 90% of the time, and which the page discarded anyway unless its `behavior[0]` was `multi-part`. CloudFront logs for `iiif.wellcomecollection.org` show 600k to 1.4M of these requests a day coming from our SSR, accounting for the 5 to 9% 5xx baseline on that distribution.

We now select the first `partOf` entry that is not an aggregation collection, so a work with only aggregations fetches nothing. Checked against live manifests: `b2178081x_0002` lists `/presentation/b2178081x` first, so multi-volume works still get their parent, and `b18245274` lists only `/presentation/collections/...` entries, so it no longer fetches at all. The fetch also goes through the existing `fetchIIIFPresentationManifest` helper, so failures are logged rather than swallowed.

## How to test

- Unit tests in `content/webapp/utils/iiif/v3/index.test.ts`.
- On stage, load the items page for a multi-volume work (`b2178081x` is a multi-part parent) and confirm the volume list still renders in the sidebar.
- After deploy, check that the 503 rate on `/presentation/collections/` in the CloudFront logs for the iiif distribution drops.

## Have we considered potential risks?

Low. Archive manifests sit under `/presentation/collections/archives/` and so are skipped as well, but the page only ever used the parent to build the multi-part volume sidebar, and an archive collection is never a multi-part parent.

Two pre-existing issues came up in review and are left out of scope: the sequential awaits in `getServerSideProps`, and `fetchJson` in `utils/http.ts` not checking `response.ok`.
