### PR TITLE
Revert "Modify `isArchive` check, gate new work behind it"

### DIFF
--- a/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
+++ b/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentProps } from 'react';
 
 import {
   archiveCollectionWork,
-  nonArchiveCollectionWork,
   workBasic,
 } from '@weco/cardigan/stories/data/work';
 import { ServerDataContext } from '@weco/common/server-data/Context';
@@ -64,7 +63,7 @@ export const Basic: Story = {
   render: ({ isArchive, isRootCollection, works }) => {
     const resolvedWorks = isArchive
       ? [{ ...archiveCollectionWork, isRootCollection }]
-      : [isRootCollection ? nonArchiveCollectionWork : works[0]];
+      : works;
 
     return (
       <>

--- a/cardigan/stories/data/work.ts
+++ b/cardigan/stories/data/work.ts
@@ -27,49 +27,10 @@ export const workBasic: WorkBasic = {
   primaryContributorLabel: 'Mannel, Wilhelm, 1870-1935.',
   physicalDescription: '3 boxes',
   referenceNumber: 'B30609446',
-  isArchive: false,
   isRootCollection: false,
   notes: [],
   languageId: 'ger',
   archiveLabels: { reference: 'B30609446' },
-};
-
-// A work that is the root of its own collection but isn't part of a
-// categorised archive (no `archive.category` from the API) - e.g. a
-// standalone manuscript. See https://api.wellcomecollection.org/catalogue/v2/works/k3gfstaz
-export const nonArchiveCollectionWork: WorkBasic = {
-  id: 'k3gfstaz',
-  title: 'MS.632',
-  workTypeId: 'h',
-  productionDates: [],
-  cardLabels: [
-    { text: 'Archives and manuscripts' },
-    { text: 'Online', labelColor: 'white' },
-  ],
-  primaryContributorLabel: undefined,
-  physicalDescription: workBasic.physicalDescription,
-  referenceNumber: undefined,
-  isArchive: false,
-  isRootCollection: true,
-  notes: [],
-  languageId: undefined,
-  archiveLabels: undefined,
-  thumbnail: {
-    url: 'https://iiif.wellcomecollection.org/thumbs/b19695639_0001.jp2/full/!200,200/0/default.jpg',
-    license: {
-      id: 'pdm',
-      label: 'Public Domain Mark',
-      url: 'https://creativecommons.org/share-your-work/public-domain/pdm/',
-      type: 'License',
-    },
-    accessConditions: [],
-    locationType: {
-      id: 'thumbnail-image',
-      label: 'Thumbnail image',
-      type: 'LocationType',
-    },
-    type: 'DigitalLocation',
-  },
 };
 
 export const contentAPILinkedWork: ContentApiLinkedWork = {
@@ -104,7 +65,6 @@ export const archiveCollectionWork: WorkBasic = {
       labelColor: 'white',
     },
   ],
-  isArchive: true,
   isRootCollection: true,
   physicalDescription: '3 boxes',
   languageId: undefined,

--- a/content/webapp/contexts/ItemViewerContext/legacy.tsx
+++ b/content/webapp/contexts/ItemViewerContext/legacy.tsx
@@ -87,7 +87,6 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   notes: [],
   physicalDescription: '',
   isRootCollection: false,
-  isArchive: false,
 };
 
 export const defaultItemViewerContext: ItemViewerContextProps = {

--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -95,7 +95,6 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   notes: [],
   physicalDescription: '',
   isRootCollection: false,
-  isArchive: false,
 };
 
 export const defaultItemViewerContext: ItemViewerContextProps = {

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -25,7 +25,6 @@ export type WorkBasic = OptionalToUndefined<{
   primaryContributorLabel?: string;
   notes: Note[];
   isRootCollection: boolean;
-  isArchive: boolean;
   physicalDescription: string;
 }>;
 
@@ -57,7 +56,6 @@ export function toWorkBasic(work: Work): WorkBasic {
     )?.agent.label,
     notes,
     isRootCollection: !!work.collection?.isRoot,
-    isArchive: !!work.archive,
     physicalDescription,
   };
 }

--- a/content/webapp/services/wellcome/catalogue/works.ts
+++ b/content/webapp/services/wellcome/catalogue/works.ts
@@ -37,13 +37,7 @@ type GetWorkProps = {
   include?: string[];
 };
 
-const worksIncludes = [
-  'production',
-  'contributors',
-  'partOf',
-  'collection',
-  'archive',
-];
+const worksIncludes = ['production', 'contributors', 'partOf', 'collection'];
 
 const workIncludes = [
   ...worksIncludes,

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -36,7 +36,6 @@ const WorkSearchResult: FunctionComponent<Props> = ({
   const { archiveCollection } = useFeatureFlags();
   const {
     isRootCollection,
-    isArchive,
     archiveLabels,
     cardLabels,
     physicalDescription,
@@ -44,8 +43,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
     productionDates,
   } = work;
 
-  const shouldShowArchiveCollectionInfo =
-    archiveCollection && isRootCollection && isArchive;
+  const shouldShowArchiveCollectionInfo = archiveCollection && isRootCollection;
 
   return (
     <NextLink

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.test.tsx
@@ -44,7 +44,6 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   notes: [],
   physicalDescription: '',
   isRootCollection: false,
-  isArchive: false,
 };
 
 const renderViewer = (transformedManifest: TransformedManifest) =>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
@@ -52,7 +52,6 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   notes: [],
   physicalDescription: '',
   isRootCollection: false,
-  isArchive: false,
 };
 
 const renderViewer = (transformedManifest: TransformedManifest) =>

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -21,6 +21,7 @@ import { workLd } from '@weco/content/utils/json-ld';
 import { removeDisplayMarkupTags } from '@weco/content/utils/string';
 import {
   createApiToolbarWorkLinks,
+  getArchiveAncestorArray,
   getDigitalLocationInfo,
   getDigitalLocationOfType,
   showItemLink,
@@ -64,7 +65,9 @@ export const WorkPage: NextPage<Props> = ({
   const { isKiosk } = useKiosk();
   const { archiveCollection } = useFeatureFlags();
   const { userIsStaffWithRestricted } = useUserContext();
-  const isArchive = !!work.archive;
+  const isArchive = !!(
+    work.parts.length || getArchiveAncestorArray(work).length > 0
+  );
   const displayCollectionRoot = !!work.collection?.isRoot && archiveCollection;
 
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');


### PR DESCRIPTION
Reverts wellcomecollection/wellcomecollection.org#13401
https://github.com/wellcomecollection/wellcomecollection.org/issues/13421


I thought the Archive tree was broken but actually it never had chevrons on that page (https://web.archive.org/web/20260123203757/https://wellcomecollection.org/works/dte7ws4x)

As long as:
https://www-dev.wellcomecollection.org/works/dte7ws4x
https://www-dev.wellcomecollection.org/works/jwrujzgn
https://www-dev.wellcomecollection.org/works/aegabdcp
https://www-dev.wellcomecollection.org/works/k3gfstaz

Look like they used to without the toggle on, I think we're good