### PR TITLE
Bring back an archive-category check alongside the hierarchy check

### DIFF
--- a/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
+++ b/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from 'react';
 
 import {
   archiveCollectionWork,
+  nonArchiveCollectionWork,
   workBasic,
 } from '@weco/cardigan/stories/data/work';
 import { ServerDataContext } from '@weco/common/server-data/Context';
@@ -10,7 +11,7 @@ import { defaultServerData } from '@weco/common/server-data/types';
 import WorksSearchResults from '@weco/content/views/components/WorksSearchResults';
 
 type StoryProps = ComponentProps<typeof WorksSearchResults> & {
-  isArchive: boolean;
+  isBrowsingArchive: boolean;
   isRootCollection: boolean;
 };
 
@@ -19,13 +20,13 @@ const meta: Meta<StoryProps> = {
   component: WorksSearchResults,
   args: {
     works: [workBasic],
-    isArchive: false,
+    isBrowsingArchive: false,
     isRootCollection: false,
   },
   argTypes: {
     works: { table: { disable: true } },
-    isArchive: {
-      name: 'Is archive',
+    isBrowsingArchive: {
+      name: 'Is browsing archive',
       control: 'boolean',
     },
     isRootCollection: {
@@ -60,16 +61,16 @@ type Story = StoryObj<StoryProps>;
 
 export const Basic: Story = {
   name: 'WorksSearchResults',
-  render: ({ isArchive, isRootCollection, works }) => {
-    const resolvedWorks = isArchive
+  render: ({ isBrowsingArchive, isRootCollection, works }) => {
+    const resolvedWorks = isBrowsingArchive
       ? [{ ...archiveCollectionWork, isRootCollection }]
-      : works;
+      : [isRootCollection ? nonArchiveCollectionWork : works[0]];
 
     return (
       <>
         <WorksSearchResults works={resolvedWorks} />
 
-        {isRootCollection && isArchive && (
+        {isRootCollection && isBrowsingArchive && (
           <div
             style={{
               padding: '1rem',

--- a/cardigan/stories/data/work.ts
+++ b/cardigan/stories/data/work.ts
@@ -27,10 +27,49 @@ export const workBasic: WorkBasic = {
   primaryContributorLabel: 'Mannel, Wilhelm, 1870-1935.',
   physicalDescription: '3 boxes',
   referenceNumber: 'B30609446',
+  isBrowsingArchive: false,
   isRootCollection: false,
   notes: [],
   languageId: 'ger',
   archiveLabels: { reference: 'B30609446' },
+};
+
+// A work that is the root of its own collection but isn't part of a
+// categorised archive (no `archive.category` from the API) - e.g. a
+// standalone manuscript. See https://api.wellcomecollection.org/catalogue/v2/works/k3gfstaz
+export const nonArchiveCollectionWork: WorkBasic = {
+  id: 'k3gfstaz',
+  title: 'MS.632',
+  workTypeId: 'h',
+  productionDates: [],
+  cardLabels: [
+    { text: 'Archives and manuscripts' },
+    { text: 'Online', labelColor: 'white' },
+  ],
+  primaryContributorLabel: undefined,
+  physicalDescription: workBasic.physicalDescription,
+  referenceNumber: undefined,
+  isBrowsingArchive: false,
+  isRootCollection: true,
+  notes: [],
+  languageId: undefined,
+  archiveLabels: undefined,
+  thumbnail: {
+    url: 'https://iiif.wellcomecollection.org/thumbs/b19695639_0001.jp2/full/!200,200/0/default.jpg',
+    license: {
+      id: 'pdm',
+      label: 'Public Domain Mark',
+      url: 'https://creativecommons.org/share-your-work/public-domain/pdm/',
+      type: 'License',
+    },
+    accessConditions: [],
+    locationType: {
+      id: 'thumbnail-image',
+      label: 'Thumbnail image',
+      type: 'LocationType',
+    },
+    type: 'DigitalLocation',
+  },
 };
 
 export const contentAPILinkedWork: ContentApiLinkedWork = {
@@ -65,6 +104,7 @@ export const archiveCollectionWork: WorkBasic = {
       labelColor: 'white',
     },
   ],
+  isBrowsingArchive: true,
   isRootCollection: true,
   physicalDescription: '3 boxes',
   languageId: undefined,

--- a/content/webapp/contexts/ItemViewerContext/legacy.tsx
+++ b/content/webapp/contexts/ItemViewerContext/legacy.tsx
@@ -86,6 +86,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
+  isBrowsingArchive: false,
   isRootCollection: false,
 };
 

--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -95,6 +95,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
+  isBrowsingArchive: false,
   isRootCollection: false,
 };
 

--- a/content/webapp/services/wellcome/catalogue/types/index.ts
+++ b/content/webapp/services/wellcome/catalogue/types/index.ts
@@ -43,7 +43,7 @@ export type Work = {
     isRoot?: boolean;
   };
   archive?: {
-    category: {
+    category?: {
       id: string;
       type: 'ArchiveCategory';
       label: string;

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -56,7 +56,7 @@ export function toWorkBasic(work: Work): WorkBasic {
       contributor => contributor.primary
     )?.agent.label,
     notes,
-    isBrowsingArchive: !!work.archive,
+    isBrowsingArchive: !!work.archive?.category,
     isRootCollection: !!work.collection?.isRoot,
     physicalDescription,
   };

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -24,6 +24,7 @@ export type WorkBasic = OptionalToUndefined<{
   cardLabels: Label[];
   primaryContributorLabel?: string;
   notes: Note[];
+  isBrowsingArchive: boolean;
   isRootCollection: boolean;
   physicalDescription: string;
 }>;
@@ -55,6 +56,7 @@ export function toWorkBasic(work: Work): WorkBasic {
       contributor => contributor.primary
     )?.agent.label,
     notes,
+    isBrowsingArchive: !!work.archive,
     isRootCollection: !!work.collection?.isRoot,
     physicalDescription,
   };

--- a/content/webapp/services/wellcome/catalogue/works.ts
+++ b/content/webapp/services/wellcome/catalogue/works.ts
@@ -37,7 +37,13 @@ type GetWorkProps = {
   include?: string[];
 };
 
-const worksIncludes = ['production', 'contributors', 'partOf', 'collection'];
+const worksIncludes = [
+  'production',
+  'contributors',
+  'partOf',
+  'collection',
+  'archive',
+];
 
 const workIncludes = [
   ...worksIncludes,

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.test.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+import * as Context from '@weco/common/server-data/Context';
+import theme from '@weco/common/views/themes/default';
+import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+
+import WorkSearchResult from './WorksSearchResults.Result';
+
+const baseWork: WorkBasic = {
+  id: 'abcd1234',
+  title: 'A test work',
+  workTypeId: undefined,
+  languageId: undefined,
+  thumbnail: undefined,
+  referenceNumber: undefined,
+  productionDates: [],
+  archiveLabels: undefined,
+  cardLabels: [],
+  primaryContributorLabel: undefined,
+  notes: [],
+  physicalDescription: '',
+  isBrowsingArchive: false,
+  isRootCollection: false,
+};
+
+const mockFeatureFlags = (archiveCollection: boolean) =>
+  jest
+    .spyOn(Context, 'useFeatureFlags')
+    .mockImplementation(
+      () =>
+        ({ archiveCollection }) as unknown as ReturnType<
+          typeof Context.useFeatureFlags
+        >
+    );
+
+const renderResult = (work: WorkBasic) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <WorkSearchResult work={work} resultPosition={0} />
+    </ThemeProvider>
+  );
+
+describe('WorkSearchResult', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not show "Archive Collection" for an ordinary work, even with the flag on', () => {
+    mockFeatureFlags(true);
+    renderResult(baseWork);
+    expect(screen.queryByText('Archive Collection')).not.toBeInTheDocument();
+  });
+
+  it('does not show "Archive Collection" for a collection root that is not itself an archive', () => {
+    // e.g. a Pictures/Sierra host-constituent root, or an archive workType
+    // missing a categorised `archive.category` - collection.isRoot alone
+    // isn't a safe signal, see fetchArchiveCategories' workType filter.
+    mockFeatureFlags(true);
+    renderResult({
+      ...baseWork,
+      isRootCollection: true,
+      isBrowsingArchive: false,
+    });
+    expect(screen.queryByText('Archive Collection')).not.toBeInTheDocument();
+  });
+
+  it('shows "Archive Collection" for an archive collection root when the flag is on', () => {
+    mockFeatureFlags(true);
+    renderResult({
+      ...baseWork,
+      isRootCollection: true,
+      isBrowsingArchive: true,
+    });
+    expect(screen.getByText('Archive Collection')).toBeInTheDocument();
+  });
+
+  it('does not show "Archive Collection" for an archive collection root when the flag is off', () => {
+    mockFeatureFlags(false);
+    renderResult({
+      ...baseWork,
+      isRootCollection: true,
+      isBrowsingArchive: true,
+    });
+    expect(screen.queryByText('Archive Collection')).not.toBeInTheDocument();
+  });
+});

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -41,9 +41,11 @@ const WorkSearchResult: FunctionComponent<Props> = ({
     physicalDescription,
     primaryContributorLabel,
     productionDates,
+    isBrowsingArchive,
   } = work;
 
-  const shouldShowArchiveCollectionInfo = archiveCollection && isRootCollection;
+  const shouldShowArchiveCollectionInfo =
+    archiveCollection && isBrowsingArchive && isRootCollection;
 
   return (
     <NextLink

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.test.tsx
@@ -43,6 +43,7 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
+  isBrowsingArchive: false,
   isRootCollection: false,
 };
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
@@ -65,6 +65,7 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
+  isBrowsingArchive: false,
   isRootCollection: false,
 };
 

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -69,7 +69,7 @@ export const WorkPage: NextPage<Props> = ({
     work.parts.length || getArchiveAncestorArray(work).length > 0
   );
   const displayCollectionRoot =
-    !!work.collection?.isRoot && !!work.archive && archiveCollection;
+    !!work.collection?.isRoot && !!work.archive?.category && archiveCollection;
 
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
   const iiifPresentationLocation = getDigitalLocationOfType(

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -68,7 +68,8 @@ export const WorkPage: NextPage<Props> = ({
   const isArchive = !!(
     work.parts.length || getArchiveAncestorArray(work).length > 0
   );
-  const displayCollectionRoot = !!work.collection?.isRoot && archiveCollection;
+  const displayCollectionRoot =
+    !!work.collection?.isRoot && !!work.archive && archiveCollection;
 
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
   const iiifPresentationLocation = getDigitalLocationOfType(


### PR DESCRIPTION
- For #13423 

See Slack thread for what is considered correct for this PR: https://wellcome.slack.com/archives/CUA669WHH/p1787825666459249

## What does this change?

#13422 correctly reverted #13401's `isArchive` change (it broke the tree/breadcrumb for ~69,777 works with uncategorised archive data, #13421). But it also deleted the only signal for "is this collection root actually a categorised archive" - leaving `isRootCollection` alone driving two archive-only features, even though it's true for any collection root, archival or not (see the workType filter in `fetchArchiveCategories`).

Affected:
- `WorksSearchResults.Result.tsx` → `shouldShowArchiveCollectionInfo` (the "Archive Collection" badge on search cards)
- `work/index.tsx` → `displayCollectionRoot` (picks the new tab-based `ArchiveCollectionLayout` over the plain breadcrumb + tree)

With the `archiveCollection` feature flag on, both mislabel non-archival roots (Pictures, Sierra host/constituent, etc.) as archives.

Re-adds the check as `isBrowsingArchive` (`!!work.archive?.category`), kept distinct from the hierarchy-based `isArchive` used for the tree/breadcrumb:

| | driven by | used for |
|---|---|---|
| `isArchive` | `parts`/`partOf` ancestors | tree + breadcrumb |
| `isBrowsingArchive` | `archive.category` | archive-collection page/label |

These can genuinely disagree (that's #13421), and should stay separate: a missing tree is worse than no tree, but a wrongly-labelled "Archive Collection" is actively misleading. So the archive-collection-page/label decision now requires both `isRootCollection` and `isBrowsingArchive`.

Checks `archive?.category` rather than just `archive` - the generated API contract allows `archive` to be present with `category` absent, which would otherwise recreate the same mislabelling one level deeper. Our own `Work` type had narrowed `category` to required, hiding that; also loosened it back to optional to match the real contract.

Also restores the Cardigan mock/story #13422 deleted (`nonArchiveCollectionWork`) and adds a unit test for `shouldShowArchiveCollectionInfo`.

## How to test

Turn `archiveCollection` on via the [toggles dashboard](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveCollection) to see the difference the flag makes below - with it off, every link below shows the same plain/breadcrumb+tree page as it does on PROD today.

1. **Plain work, no archive hierarchy at all** - no tree, no breadcrumb, unaffected by anything here: https://www-dev.wellcomecollection.org/works/guuf553j

2. **Real archive item, not a collection root** - shows the breadcrumb + sidebar tree, same on this branch as on PROD: https://www-dev.wellcomecollection.org/works/vhse6wqd *("Fugitive pieces", a Series within the Lettsom collection.)*

3. **Real, properly-categorised archive collection root** (`archive.category` = "Personal papers") - with the flag **on**, shows the new tab-based collection page; with it **off**, falls back to breadcrumb + tree: https://www-dev.wellcomecollection.org/works/hz43r7re *(Francis Crick's archive, PP/CRI.)*

4. **Collection root that is *not* a categorised archive** - this is the bug this PR fixes. On `main` (post-#13422, pre-this-PR), with the flag on, this incorrectly gets the "Archive Collection" treatment. On this branch it correctly falls back to the plain breadcrumb + tree, flag on or off: https://www-dev.wellcomecollection.org/works/dte7ws4x *(A hand-sewn bag containing 14 zines - `collection.isRoot: true`, but workType is "Books", not an archive.)*

   Same check, one level up in the search results list - search for `"holding title"` with the flag on (it's the top result): on `main` the card says "Archive Collection", on this branch it doesn't. https://www-dev.wellcomecollection.org/search/works?query=%22holding%20title%22

Also worth spot-checking https://www-dev.wellcomecollection.org/works/psyccrys (Lettsom collection) - it's `collection.isRoot: true` but has no `archive.category` populated (the exact #13421 gap), so it's a second real example of case 4, just with an archival workType instead of an obviously-unrelated one like zines.

## Have we considered potential risks?

- Only manifests once `archiveCollection` is rolled out beyond its current cohort - with the flag off (PROD default), nothing here is user-visible.
- `isBrowsingArchive` needs the `archive` include on the catalogue API request (re-added to `worksIncludes`), which now runs on every work request again, not just for flagged-in users, since `toWorkBasic` always computes it. Same include #13401 added and #13422 removed, so it already ran in prod for a while - flagging in case the catalogue API side wants to weigh in, given search-results pages fetch it per result.
