### PR TITLE
Add more instructions for writing PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,4 +161,4 @@ Our PR template (configured in GitHub's interface) asks for:
 
 When writing PR descriptions, follow this structure and provide enough detail for the PR to be understandable in the future.
 
-When referencing GitHub issues in PR descriptions, use 'For #123' or 'Refs #123', not 'Closes #123', so merging doesn't auto-close the ticket.
+When referencing GitHub issues in PR descriptions, use '- For #123' or '- Refs #123', not 'Closes #123', so merging doesn't auto-close the ticket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,5 @@ Our PR template (configured in GitHub's interface) asks for:
 - **Have we considered potential risks?** - Potential risks, mitigations, and whether alarms are needed
 
 When writing PR descriptions, follow this structure and provide enough detail for the PR to be understandable in the future.
+
+When referencing GitHub issues in PR descriptions, use 'For #123' or 'Refs #123', not 'Closes #123', so merging doesn't auto-close the ticket.


### PR DESCRIPTION
## What does this change?

Adds another instruction in AGENTS.md regarding writing PR descriptions, specifying that the closes keyword shouldn't be use when referencing issues, as we don't want them to auto close on merge.