### PR TITLE
IVR: Share the thumbnails-page-for-canvas formula across the refactored viewer

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -21,9 +21,10 @@ import {
   ItemProps,
   toWorksItemLink,
 } from '@weco/content/views/components/ItemLink';
-import { arrayIndexToQueryParam } from '@weco/content/views/pages/works/work/work.helpers';
-
-import { thumbnailsPageSize } from './Paginators';
+import {
+  arrayIndexToQueryParam,
+  getThumbnailsPageForCanvas,
+} from '@weco/content/views/pages/works/work/work.helpers';
 
 const SearchForm = styled.form`
   position: relative;
@@ -295,9 +296,9 @@ const IIIFSearchWithin: FunctionComponent = () => {
                       manifest: query.manifest,
                       query: query.query,
                       canvas: arrayIndexToQueryParam(index || 0),
-                      page: Math.ceil(
-                        arrayIndexToQueryParam(index || 0) / thumbnailsPageSize
-                      ),
+                      page: getThumbnailsPageForCanvas({
+                        canvasNumber: arrayIndexToQueryParam(index || 0),
+                      }),
                     },
                   })}
                   onClick={() => setIsMobileSidebarActive(false)}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/NoScriptImage.tsx
@@ -8,11 +8,7 @@ import { getCanvasesForPage } from '@weco/content/views/pages/works/work/work.he
 
 import { DelayVisibility } from '.';
 import IIIFViewerImage from './IIIFViewerImage';
-import {
-  CanvasPaginator,
-  thumbnailsPageSize,
-  ThumbnailsPaginator,
-} from './Paginators';
+import { CanvasPaginator, ThumbnailsPaginator } from './Paginators';
 import { Thumbnails } from './Thumbnails';
 
 const NoScriptImageWrapper = styled.div`
@@ -47,7 +43,6 @@ export const NoScriptImage = ({ urlTemplate, canvasOcr }: Props) => {
   const navigationCanvases = getCanvasesForPage({
     canvases: transformedManifest?.canvases,
     page: query.page,
-    pageSize: thumbnailsPageSize,
   });
   const thumbnailsRequired = Boolean(navigationCanvases.length);
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Paginators.tsx
@@ -8,6 +8,10 @@ import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
 import { ItemViewerQuery } from '@weco/content/types/item-viewer';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
+import {
+  getThumbnailsPageForCanvas,
+  thumbnailsPageSize,
+} from '@weco/content/views/pages/works/work/work.helpers';
 
 const PaginatorWrapper = styled.div`
   display: flex;
@@ -62,8 +66,6 @@ const PaginatorButtons = ({
     </PaginatorWrapper>
   );
 };
-
-export const thumbnailsPageSize = 6;
 
 const getLink = ({
   pageNumber,
@@ -140,7 +142,8 @@ export const CanvasPaginator = () => {
   const { prevLink, nextLink } = usePaginatorLinks({
     getCurrentPage: query => query.canvas,
     pageSize: 1,
-    getMatchingPage: pageNumber => Math.ceil(pageNumber / thumbnailsPageSize),
+    getMatchingPage: pageNumber =>
+      getThumbnailsPageForCanvas({ canvasNumber: pageNumber }),
   });
 
   return (

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
@@ -7,10 +7,10 @@ import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
 import {
   getCanvasesForPage,
   queryParamToArrayIndex,
+  thumbnailsPageSize,
 } from '@weco/content/views/pages/works/work/work.helpers';
 
 import IIIFCanvasThumbnail from './IIIFCanvasThumbnail';
-import { thumbnailsPageSize } from './Paginators';
 
 const ThumbnailsContainer = styled.div<{
   $isTRKiosk?: boolean;
@@ -44,7 +44,6 @@ export const Thumbnails = () => {
   const navigationCanvases = getCanvasesForPage({
     canvases: transformedManifest?.canvases,
     page: query.page,
-    pageSize: thumbnailsPageSize,
   });
 
   return (

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerStructures.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerStructures.tsx
@@ -20,9 +20,10 @@ import {
   isRange,
 } from '@weco/content/utils/iiif/v3';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
-import { arrayIndexToQueryParam } from '@weco/content/views/pages/works/work/work.helpers';
-
-import { thumbnailsPageSize } from './Paginators';
+import {
+  arrayIndexToQueryParam,
+  getThumbnailsPageForCanvas,
+} from '@weco/content/views/pages/works/work/work.helpers';
 
 export const List = styled(PlainList)`
   border-left: 1px solid ${props => props.theme.color('neutral.600')};
@@ -100,9 +101,9 @@ const Structures: FunctionComponent<Props> = ({
                       manifest: query.manifest,
                       query: query.query,
                       canvas: arrayIndexToQueryParam(canvasIndex),
-                      page: Math.ceil(
-                        arrayIndexToQueryParam(canvasIndex) / thumbnailsPageSize
-                      ),
+                      page: getThumbnailsPageForCanvas({
+                        canvasNumber: arrayIndexToQueryParam(canvasIndex),
+                      }),
                     },
                   })}
                   data-gtm-trigger="contents_nav"

--- a/content/webapp/views/pages/works/work/work.helpers.test.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.test.tsx
@@ -3,7 +3,11 @@ import {
   createMockManifest,
 } from '@weco/content/test/fixtures/iiif/transformed-manifest';
 
-import { getCanvasesForPage, getCurrentCanvas } from './work.helpers';
+import {
+  getCanvasesForPage,
+  getCurrentCanvas,
+  getThumbnailsPageForCanvas,
+} from './work.helpers';
 
 // getCurrentCanvas is the canonical way to work out which canvas is "current"
 // for a given 1-based canvas query param. Canvas order is determined by the
@@ -157,5 +161,36 @@ describe('getCanvasesForPage', () => {
     expect(
       getCanvasesForPage({ canvases: undefined, page: 1, pageSize: 3 })
     ).toEqual([]);
+  });
+
+  it('defaults to thumbnailsPageSize when pageSize is omitted', () => {
+    expect(getCanvasesForPage({ canvases, page: 2 })).toEqual([canvases[6]]);
+  });
+});
+
+describe('getThumbnailsPageForCanvas', () => {
+  it('returns the first page for canvas numbers within the first page size', () => {
+    expect(getThumbnailsPageForCanvas({ canvasNumber: 1, pageSize: 6 })).toBe(
+      1
+    );
+    expect(getThumbnailsPageForCanvas({ canvasNumber: 6, pageSize: 6 })).toBe(
+      1
+    );
+  });
+
+  it('returns the next page once the canvas number crosses a page boundary', () => {
+    expect(getThumbnailsPageForCanvas({ canvasNumber: 7, pageSize: 6 })).toBe(
+      2
+    );
+  });
+
+  it('uses the given pageSize rather than a hardcoded one', () => {
+    expect(getThumbnailsPageForCanvas({ canvasNumber: 5, pageSize: 4 })).toBe(
+      2
+    );
+  });
+
+  it('defaults to thumbnailsPageSize when pageSize is omitted', () => {
+    expect(getThumbnailsPageForCanvas({ canvasNumber: 7 })).toBe(2);
   });
 });

--- a/content/webapp/views/pages/works/work/work.helpers.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.tsx
@@ -12,6 +12,8 @@ import {
 
 import { TreeDataRange, UiTree } from './work.types';
 
+export const thumbnailsPageSize = 6;
+
 export const controlDimensions = {
   controlWidth: 44,
   controlHeight: 44,
@@ -233,20 +235,36 @@ export function getCurrentCanvas({
  * about which canvases a given page number shows.
  * @param canvases - The manifest's full canvas list.
  * @param page - 1-based page number.
- * @param pageSize - Canvases per page.
+ * @param pageSize - Canvases per page, defaults to {@link thumbnailsPageSize}.
  */
 export function getCanvasesForPage({
   canvases,
   page,
-  pageSize,
+  pageSize = thumbnailsPageSize,
 }: {
   canvases: TransformedCanvas[] | undefined;
   page: number;
-  pageSize: number;
+  pageSize?: number;
 }): TransformedCanvas[] {
   const startIndex = pageSize * queryParamToArrayIndex(page);
 
   return [...Array(pageSize)]
     .map((_, i) => canvases?.[startIndex + i])
     .filter((canvas): canvas is TransformedCanvas => Boolean(canvas));
+}
+
+/**
+ * Works out which thumbnails page a given canvas number falls on, so links
+ * that jump to a canvas can land on the thumbnails page that contains it.
+ * @param canvasNumber - The 1-based canvas number.
+ * @param pageSize - Canvases per thumbnails page, defaults to {@link thumbnailsPageSize}.
+ */
+export function getThumbnailsPageForCanvas({
+  canvasNumber,
+  pageSize = thumbnailsPageSize,
+}: {
+  canvasNumber: number;
+  pageSize?: number;
+}): number {
+  return Math.ceil(canvasNumber / pageSize);
 }


### PR DESCRIPTION
- For #12986

## What does this change?

The "which thumbnails page contains canvas N" formula — `Math.ceil(canvasNumber / thumbnailsPageSize)` — was inlined identically in three places in the refactored item viewer: `Paginators.tsx`, `IIIFSearchWithin.tsx`, and `ViewerStructures.tsx`. Extracted it into a single `getThumbnailsPageForCanvas` helper in `work.helpers.tsx`, alongside the other canvas-pagination helpers from earlier steps.

Two related cleanups while in there:
- `thumbnailsPageSize` itself was defined in `Paginators.tsx` (a components file), even though four other, unrelated files imported it just to get the number. Moved it to `work.helpers.tsx`, next to the helpers that actually use it.
- No caller has ever passed anything other than `thumbnailsPageSize` to `getThumbnailsPageForCanvas` or `getCanvasesForPage` ([step 6](https://github.com/wellcomecollection/wellcomecollection.org/pull/13409)) — only tests use other values, deliberately, to prove the maths isn't hardcoded. Defaulted `pageSize` to `thumbnailsPageSize` on both helpers, so callers no longer need to pass it explicitly, and a future caller can't accidentally repeat step 6's original bug (two components silently using different page sizes).

Scoped to the refactored viewer only, same as every other step — legacy is untouched.

## How to test

This is a pure refactor — no behaviour change, just deduplication. Test work: [wfvttd2h](https://www-dev.wellcomecollection.org/works/wfvttd2h/items) — Gray's *Anatomy: Descriptive and Surgical*, 828 canvases, has both a contents structure and a "search within" service, so it exercises all three call sites in one work. With the `itemViewerRefactor` flag on:

- **Sidebar contents:** open the sidebar ("Show info"), go to the contents tab, click an entry — confirm it jumps to the right canvas *and* the thumbnails grid/page updates to match.
- **Search within:** use the sidebar's search box, click a result — same check, lands on the right canvas and thumbnails page.
- **No-JS fallback:** `Paginators.tsx` and `Thumbnails.tsx` only render via `NoScriptImage`, which requires `isFullSupportBrowser` to be `false` — not something you'll see with JS on. Disable JavaScript for the page (e.g. Chrome DevTools → Cmd+Shift+P → "Disable JavaScript") and reload, then use the canvas/thumbnails paginator arrows and confirm they land on the expected canvas/page.
- `yarn tsc`, `yarn eslint` on the changed files, and `yarn jest "views/pages/works/work/(IIIFViewer|work.helpers)" test/fixtures/iiif hooks/useIIIFProbeService` from `content/webapp` — all green (197 tests).

## Have we considered potential risks?

Low risk: no logic changed, just moved and deduplicated, with tests-first on the new helper and the full existing suite re-run unchanged. Confirmed no file overlap with the other two open item-viewer PRs in flight ([#13415](https://github.com/wellcomecollection/wellcomecollection.org/pull/13415), [#13417](https://github.com/wellcomecollection/wellcomecollection.org/pull/13417)), so no conflict risk there.
