### PR TITLE
Check the viewer element specifically for fullscreen, not just any element

### DIFF
--- a/content/webapp/hooks/useFullscreenToggle.ts
+++ b/content/webapp/hooks/useFullscreenToggle.ts
@@ -5,9 +5,11 @@ type UseFullscreenToggleParams = {
   setIsFullscreen: (isFullscreen: boolean) => void;
 };
 
-function isDocumentFullscreen(): boolean {
-  return Boolean(
-    document.fullscreenElement || document['webkitFullscreenElement']
+function isElementFullscreen(element: Element | null | undefined): boolean {
+  if (!element) return false;
+  return (
+    document.fullscreenElement === element ||
+    document['webkitFullscreenElement'] === element
   );
 }
 
@@ -24,7 +26,7 @@ export default function useFullscreenToggle({
 }: UseFullscreenToggleParams): () => void {
   useEffect(() => {
     function handleFullscreenChange() {
-      setIsFullscreen(isDocumentFullscreen());
+      setIsFullscreen(isElementFullscreen(viewerRef?.current));
     }
 
     document.addEventListener('fullscreenchange', handleFullscreenChange);
@@ -42,7 +44,7 @@ export default function useFullscreenToggle({
   function toggleFullscreen() {
     if (!viewerRef?.current) return;
 
-    const isCurrentlyFullscreen = isDocumentFullscreen();
+    const isCurrentlyFullscreen = isElementFullscreen(viewerRef.current);
 
     // Don't set isFullscreen here - requestFullscreen()/exitFullscreen() are
     // async and can be denied, in which case no fullscreenchange event

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/FullscreenToggleButton.test.tsx
@@ -90,4 +90,39 @@ describe('FullscreenToggleButton', () => {
       expect(setIsFullscreen).toHaveBeenCalledWith(false);
     });
   });
+
+  describe('when a different element on the page goes fullscreen (e.g. a native video player)', () => {
+    const originalFullscreenElement = document.fullscreenElement;
+
+    afterEach(() => {
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: originalFullscreenElement,
+        configurable: true,
+      });
+    });
+
+    it('does not report the viewer itself as fullscreen', () => {
+      const viewerElement = document.createElement('div');
+      const otherElement = document.createElement('video');
+      const setIsFullscreen = jest.fn();
+
+      renderButton(
+        {},
+        {
+          contextProps: {
+            viewerRef: { current: viewerElement },
+            setIsFullscreen,
+          },
+        }
+      );
+
+      Object.defineProperty(document, 'fullscreenElement', {
+        value: otherElement,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+
+      expect(setIsFullscreen).toHaveBeenCalledWith(false);
+    });
+  });
 });


### PR DESCRIPTION
## What does this change?

Follow-up to [this review comment](https://github.com/wellcomecollection/wellcomecollection.org/pull/13415#discussion_r3871514787) on #13415.

`useFullscreenToggle`'s fullscreen check only asked "is *anything* on the page fullscreen", not "is the viewer specifically fullscreen". A native `<video>` going fullscreen via its own controls (AV works render a plain `<video>`) would set `document.fullscreenElement` to that video and incorrectly flip our button to "Exit full screen".

Fixed by comparing `document.fullscreenElement`/`webkitFullscreenElement` against `viewerRef.current` specifically, not just checking truthiness.

**Legacy has the same latent bug** (`legacy/ViewerTopBar.tsx`, `legacy/ViewerBottomBar.tsx` — same unguarded `document.fullscreenElement` check), so it's pre-existing everywhere, not something #13415 introduced. Also equally unreachable there for the same reason as below (legacy's `MainViewer.tsx` disables `showFullscreenControl` for non-image-only works too), so there's nothing to manually verify on legacy either — noted for parity, not fixed here (same "refactored only" scope as the rest of this plan).

## How to test

**Not currently reproducible live:** `PaginatedItemViewer` force-disables `showFullscreenControl` for any work containing a video/audio/non-image canvas (`hasOnlyRenderableImages` is work-wide, not per-canvas), so our fullscreen button never renders on a video work today — there's no UI path where our button and a native video's fullscreen coexist. The bug is real at the code level, just not currently reachable; the added unit test (`FullscreenToggleButton.test.tsx`) simulates it directly since there's no live repro. This fix is defensive: correct now, and prevents a bug resurfacing if that gating ever changes.

- With the `itemViewerRefactor` flag on, on any image-only work (e.g. [wfvttd2h](https://www-dev.wellcomecollection.org/works/wfvttd2h/items)), confirm our own fullscreen button still enters/exits fullscreen and labels correctly — this fix shouldn't change that path at all.
- `yarn tsc`, `yarn eslint`, and `yarn jest "views/pages/works/work/(IIIFViewer|work.helpers)" test/fixtures/iiif hooks/useIIIFProbeService` from `content/webapp` — all green (200 tests).

## Have we considered potential risks?

Low risk, narrow fix scoped to one function. Also, doesn't currently happen.