### PR TITLE
Gate the archive collection layout on hierarchy

### DIFF
--- a/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
+++ b/cardigan/stories/components/WorksSearchResults/WorksSearchResults.stories.tsx
@@ -3,15 +3,33 @@ import type { ComponentProps } from 'react';
 
 import {
   archiveCollectionWork,
+  nonArchiveCollectionWork,
   workBasic,
 } from '@weco/cardigan/stories/data/work';
 import { ServerDataContext } from '@weco/common/server-data/Context';
 import { defaultServerData } from '@weco/common/server-data/types';
+import type { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
 import WorksSearchResults from '@weco/content/views/components/WorksSearchResults';
 
+const workVariants = {
+  ordinary: {
+    label: 'An ordinary work',
+    work: workBasic,
+  },
+  collectionRootManuscript: {
+    label: 'A collection root that is a manuscript',
+    work: nonArchiveCollectionWork,
+  },
+  archiveCollectionRoot: {
+    label: 'An archive collection root',
+    work: archiveCollectionWork,
+  },
+} satisfies Record<string, { label: string; work: WorkBasic }>;
+
+type WorkVariant = keyof typeof workVariants;
+
 type StoryProps = ComponentProps<typeof WorksSearchResults> & {
-  isArchive: boolean;
-  isRootCollection: boolean;
+  workVariant: WorkVariant;
 };
 
 const meta: Meta<StoryProps> = {
@@ -19,18 +37,21 @@ const meta: Meta<StoryProps> = {
   component: WorksSearchResults,
   args: {
     works: [workBasic],
-    isArchive: false,
-    isRootCollection: false,
+    workVariant: 'ordinary',
   },
   argTypes: {
     works: { table: { disable: true } },
-    isArchive: {
-      name: 'Is archive',
-      control: 'boolean',
-    },
-    isRootCollection: {
-      name: 'Is collection root',
-      control: 'boolean',
+    workVariant: {
+      name: 'Work',
+      control: {
+        type: 'radio',
+        labels: Object.fromEntries(
+          Object.entries(workVariants).map(([id, { label }]) => [id, label])
+        ),
+      },
+      options: Object.keys(workVariants) as WorkVariant[],
+      description:
+        'Only an archive collection root gets the "Archive Collection" treatment. A collection root that is a manuscript does not.',
     },
   },
   // TODO remove once archiveCollection is fully rolled out
@@ -60,28 +81,22 @@ type Story = StoryObj<StoryProps>;
 
 export const Basic: Story = {
   name: 'WorksSearchResults',
-  render: ({ isArchive, isRootCollection, works }) => {
-    const resolvedWorks = isArchive
-      ? [{ ...archiveCollectionWork, isRootCollection }]
-      : works;
+  render: ({ workVariant }) => (
+    <>
+      <WorksSearchResults works={[workVariants[workVariant].work]} />
 
-    return (
-      <>
-        <WorksSearchResults works={resolvedWorks} />
-
-        {isRootCollection && isArchive && (
-          <div
-            style={{
-              padding: '1rem',
-              backgroundColor: '#b8b8b8',
-              marginTop: '1rem',
-            }}
-          >
-            This is currently behind the <code>archiveCollection</code> feature
-            flag
-          </div>
-        )}
-      </>
-    );
-  },
+      {workVariant === 'archiveCollectionRoot' && (
+        <div
+          style={{
+            padding: '1rem',
+            backgroundColor: '#b8b8b8',
+            marginTop: '1rem',
+          }}
+        >
+          This is currently behind the <code>archiveCollection</code> feature
+          flag
+        </div>
+      )}
+    </>
+  ),
 };

--- a/cardigan/stories/data/work.ts
+++ b/cardigan/stories/data/work.ts
@@ -27,10 +27,48 @@ export const workBasic: WorkBasic = {
   primaryContributorLabel: 'Mannel, Wilhelm, 1870-1935.',
   physicalDescription: '3 boxes',
   referenceNumber: 'B30609446',
-  isRootCollection: false,
+  isArchiveCollectionRoot: false,
   notes: [],
   languageId: 'ger',
   archiveLabels: { reference: 'B30609446' },
+};
+
+// A work that is the root of its own collection, and has the "Archives and
+// manuscripts" format, but is a manuscript rather than an archive - it has a
+// `tei-manuscript-id` identifier. So it gets no archive-collection treatment.
+// See https://api.wellcomecollection.org/catalogue/v2/works/k3gfstaz
+export const nonArchiveCollectionWork: WorkBasic = {
+  id: 'k3gfstaz',
+  title: 'MS.632',
+  workTypeId: 'h',
+  productionDates: [],
+  cardLabels: [
+    { text: 'Archives and manuscripts' },
+    { text: 'Online', labelColor: 'white' },
+  ],
+  primaryContributorLabel: undefined,
+  physicalDescription: workBasic.physicalDescription,
+  referenceNumber: undefined,
+  isArchiveCollectionRoot: false,
+  notes: [],
+  languageId: undefined,
+  archiveLabels: undefined,
+  thumbnail: {
+    url: 'https://iiif.wellcomecollection.org/thumbs/b19695639_0001.jp2/full/!200,200/0/default.jpg',
+    license: {
+      id: 'pdm',
+      label: 'Public Domain Mark',
+      url: 'https://creativecommons.org/share-your-work/public-domain/pdm/',
+      type: 'License',
+    },
+    accessConditions: [],
+    locationType: {
+      id: 'thumbnail-image',
+      label: 'Thumbnail image',
+      type: 'LocationType',
+    },
+    type: 'DigitalLocation',
+  },
 };
 
 export const contentAPILinkedWork: ContentApiLinkedWork = {
@@ -65,10 +103,10 @@ export const archiveCollectionWork: WorkBasic = {
       labelColor: 'white',
     },
   ],
-  isRootCollection: true,
+  isArchiveCollectionRoot: true,
   physicalDescription: '3 boxes',
   languageId: undefined,
   notes: [],
-  thumbnail: undefined,
+  thumbnail: workBasic.thumbnail,
   primaryContributorLabel: undefined,
 };

--- a/content/webapp/contexts/ItemViewerContext/legacy.tsx
+++ b/content/webapp/contexts/ItemViewerContext/legacy.tsx
@@ -86,7 +86,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
-  isRootCollection: false,
+  isArchiveCollectionRoot: false,
 };
 
 export const defaultItemViewerContext: ItemViewerContextProps = {

--- a/content/webapp/contexts/ItemViewerContext/refactored.tsx
+++ b/content/webapp/contexts/ItemViewerContext/refactored.tsx
@@ -95,7 +95,7 @@ const work: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
-  isRootCollection: false,
+  isArchiveCollectionRoot: false,
 };
 
 export const defaultItemViewerContext: ItemViewerContextProps = {

--- a/content/webapp/services/wellcome/catalogue/types/work.ts
+++ b/content/webapp/services/wellcome/catalogue/types/work.ts
@@ -8,6 +8,7 @@ import {
   getCardLabels,
   getLanguageId,
   getProductionDates,
+  isArchiveCollectionRoot,
 } from '@weco/content/utils/works';
 
 import { Work } from '.';
@@ -24,7 +25,7 @@ export type WorkBasic = OptionalToUndefined<{
   cardLabels: Label[];
   primaryContributorLabel?: string;
   notes: Note[];
-  isRootCollection: boolean;
+  isArchiveCollectionRoot: boolean;
   physicalDescription: string;
 }>;
 
@@ -55,7 +56,7 @@ export function toWorkBasic(work: Work): WorkBasic {
       contributor => contributor.primary
     )?.agent.label,
     notes,
-    isRootCollection: !!work.collection?.isRoot,
+    isArchiveCollectionRoot: isArchiveCollectionRoot(work),
     physicalDescription,
   };
 }

--- a/content/webapp/services/wellcome/catalogue/works.ts
+++ b/content/webapp/services/wellcome/catalogue/works.ts
@@ -37,11 +37,19 @@ type GetWorkProps = {
   include?: string[];
 };
 
-const worksIncludes = ['production', 'contributors', 'partOf', 'collection'];
+// `identifiers` is here rather than in `workIncludes` because
+// `isArchiveCollectionRoot` needs it to spot TEI manuscripts, and that runs on
+// search results too.
+const worksIncludes = [
+  'production',
+  'contributors',
+  'partOf',
+  'collection',
+  'identifiers',
+];
 
 const workIncludes = [
   ...worksIncludes,
-  'identifiers',
   'images',
   'items',
   'subjects',

--- a/content/webapp/utils/works.test.ts
+++ b/content/webapp/utils/works.test.ts
@@ -1,0 +1,103 @@
+import { Work } from '@weco/content/services/wellcome/catalogue/types';
+
+import { isArchiveCollectionRoot } from './works';
+
+type PredicateWork = Pick<Work, 'collection' | 'workType' | 'identifiers'>;
+
+const teiIdentifier: Work['identifiers'][number] = {
+  value: 'MS_632',
+  identifierType: {
+    id: 'tei-manuscript-id',
+    label: 'TEI manuscript id',
+    type: 'IdentifierType',
+  },
+  type: 'Identifier',
+};
+
+const calmIdentifier: Work['identifiers'][number] = {
+  value: 'RAMC',
+  identifierType: {
+    id: 'calm-ref-no',
+    label: 'Calm RefNo',
+    type: 'IdentifierType',
+  },
+  type: 'Identifier',
+};
+
+const work = ({
+  isRoot = true,
+  totalParts = 5,
+  workTypeId = 'h',
+  identifiers = [calmIdentifier],
+}: {
+  isRoot?: boolean;
+  totalParts?: number;
+  workTypeId?: string;
+  identifiers?: Work['identifiers'];
+} = {}): PredicateWork => ({
+  collection: {
+    root: {
+      id: 'abcd1234',
+      title: 'A collection',
+      alternativeTitles: [],
+      totalParts,
+      type: 'Collection',
+    },
+    ...(isRoot ? { isRoot: true } : {}),
+  },
+  workType: { id: workTypeId, label: 'A format', type: 'Format' },
+  identifiers,
+});
+
+describe('isArchiveCollectionRoot', () => {
+  it('is true for an archive collection root with children', () => {
+    expect(isArchiveCollectionRoot(work())).toBe(true);
+  });
+
+  it('is true for a born-digital archive', () => {
+    expect(isArchiveCollectionRoot(work({ workTypeId: 'hdig' }))).toBe(true);
+  });
+
+  it('is true for an archive with no recognised archive category', () => {
+    // e.g. RAMC - `archive.category` is absent, but it is still an archive.
+    // This is the case the old `archive.category` check wrongly excluded.
+    expect(isArchiveCollectionRoot(work({ totalParts: 1507 }))).toBe(true);
+  });
+
+  it('is false for a singleton, i.e. a root with no children', () => {
+    expect(isArchiveCollectionRoot(work({ totalParts: 0 }))).toBe(false);
+  });
+
+  it('is false for a work that is not a collection root', () => {
+    expect(isArchiveCollectionRoot(work({ isRoot: false }))).toBe(false);
+  });
+
+  it('is false for a work with no collection at all', () => {
+    expect(isArchiveCollectionRoot({ ...work(), collection: undefined })).toBe(
+      false
+    );
+  });
+
+  it('is false for a TEI manuscript, even though its format is "Archives and manuscripts"', () => {
+    expect(
+      isArchiveCollectionRoot(
+        work({ totalParts: 1, identifiers: [teiIdentifier, calmIdentifier] })
+      )
+    ).toBe(false);
+  });
+
+  it('is false for a Manuscripts-format collection root', () => {
+    expect(isArchiveCollectionRoot(work({ workTypeId: 'b' }))).toBe(false);
+  });
+
+  it('is false for a collection root that is not an archive format', () => {
+    // e.g. a Pictures or Books root - a collection, but not an archive.
+    expect(isArchiveCollectionRoot(work({ workTypeId: 'a' }))).toBe(false);
+  });
+
+  it('is false when the work has no format', () => {
+    expect(isArchiveCollectionRoot({ ...work(), workType: undefined })).toBe(
+      false
+    );
+  });
+});

--- a/content/webapp/utils/works.test.ts
+++ b/content/webapp/utils/works.test.ts
@@ -50,18 +50,15 @@ const work = ({
 });
 
 describe('isArchiveCollectionRoot', () => {
+  // Nothing here has an `archive.category`, which is the point: an archive
+  // whose collection path prefix isn't one of the 16 recognised types (e.g.
+  // RAMC) has no category, and the old check wrongly excluded it.
   it('is true for an archive collection root with children', () => {
     expect(isArchiveCollectionRoot(work())).toBe(true);
   });
 
   it('is true for a born-digital archive', () => {
     expect(isArchiveCollectionRoot(work({ workTypeId: 'hdig' }))).toBe(true);
-  });
-
-  it('is true for an archive with no recognised archive category', () => {
-    // e.g. RAMC - `archive.category` is absent, but it is still an archive.
-    // This is the case the old `archive.category` check wrongly excluded.
-    expect(isArchiveCollectionRoot(work({ totalParts: 1507 }))).toBe(true);
   });
 
   it('is false for a singleton, i.e. a root with no children', () => {

--- a/content/webapp/utils/works.ts
+++ b/content/webapp/utils/works.ts
@@ -203,10 +203,6 @@ export function getArchiveAncestorArray(work: Work): RelatedWork[] {
   return [...(work.partOf || []).filter(item => item.totalParts)].reverse();
 }
 
-/**
- * Builds the archive reference/partOf labels for a work, if it has a
- * reference number.
- */
 // Formats that can be archives. `b` (Manuscripts) is deliberately absent:
 // everything with that format is a manuscript.
 const archiveFormatIds = ['h', 'hdig'];
@@ -217,12 +213,15 @@ const teiManuscriptIdentifierTypeId = 'tei-manuscript-id';
  * Whether a work is the root of an archive collection we can display a
  * hierarchy for, i.e. an archive (not a manuscript) that has children.
  *
- * `archive.category` is deliberately not used here. It only covers the 16
- * recognised archive types, so it wrongly excludes archives whose collection
- * path prefix isn't one of them (e.g. RAMC). It also isn't an
- * archive/manuscript discriminator - it excludes manuscripts only incidentally.
- * The TEI identifier is, on the basis that all manuscripts come from TEI and
- * all TEI works are manuscripts.
+ * Not `archive.category`: that covers only the 16 recognised archive types, so
+ * it excludes archives whose collection path prefix isn't one of them (e.g.
+ * RAMC), and it isn't an archive/manuscript discriminator anyway.
+ *
+ * The TEI check is a heuristic, and an imperfect one. A TEI work is always a
+ * manuscript, but not all manuscripts come from TEI - ones catalogued in CALM
+ * have no TEI identifier and so still come through here as archives. It's the
+ * best signal available while the catalogue API doesn't model the distinction,
+ * and should give way to a real one when it does.
  */
 export function isArchiveCollectionRoot(
   work: Pick<Work, 'collection' | 'workType' | 'identifiers'>
@@ -239,6 +238,10 @@ export function isArchiveCollectionRoot(
   return isRootWithChildren && hasArchiveFormat && !isTeiManuscript;
 }
 
+/**
+ * Builds the archive reference/partOf labels for a work, if it has a
+ * reference number.
+ */
 export const getArchiveLabels = (work: Work): ArchiveLabels | undefined => {
   if (work.referenceNumber) {
     const root = getArchiveAncestorArray(work)[0] || work;

--- a/content/webapp/utils/works.ts
+++ b/content/webapp/utils/works.ts
@@ -207,6 +207,38 @@ export function getArchiveAncestorArray(work: Work): RelatedWork[] {
  * Builds the archive reference/partOf labels for a work, if it has a
  * reference number.
  */
+// Formats that can be archives. `b` (Manuscripts) is deliberately absent:
+// everything with that format is a manuscript.
+const archiveFormatIds = ['h', 'hdig'];
+
+const teiManuscriptIdentifierTypeId = 'tei-manuscript-id';
+
+/**
+ * Whether a work is the root of an archive collection we can display a
+ * hierarchy for, i.e. an archive (not a manuscript) that has children.
+ *
+ * `archive.category` is deliberately not used here. It only covers the 16
+ * recognised archive types, so it wrongly excludes archives whose collection
+ * path prefix isn't one of them (e.g. RAMC). It also isn't an
+ * archive/manuscript discriminator - it excludes manuscripts only incidentally.
+ * The TEI identifier is, on the basis that all manuscripts come from TEI and
+ * all TEI works are manuscripts.
+ */
+export function isArchiveCollectionRoot(
+  work: Pick<Work, 'collection' | 'workType' | 'identifiers'>
+): boolean {
+  const isRootWithChildren =
+    !!work.collection?.isRoot && (work.collection.root.totalParts ?? 0) > 0;
+
+  const hasArchiveFormat = archiveFormatIds.includes(work.workType?.id ?? '');
+
+  const isTeiManuscript = (work.identifiers ?? []).some(
+    ({ identifierType }) => identifierType.id === teiManuscriptIdentifierTypeId
+  );
+
+  return isRootWithChildren && hasArchiveFormat && !isTeiManuscript;
+}
+
 export const getArchiveLabels = (work: Work): ArchiveLabels | undefined => {
   if (work.referenceNumber) {
     const root = getArchiveAncestorArray(work)[0] || work;

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.test.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+import * as Context from '@weco/common/server-data/Context';
+import theme from '@weco/common/views/themes/default';
+import { WorkBasic } from '@weco/content/services/wellcome/catalogue/types';
+
+import WorkSearchResult from './WorksSearchResults.Result';
+
+const baseWork: WorkBasic = {
+  id: 'abcd1234',
+  title: 'A test work',
+  workTypeId: undefined,
+  languageId: undefined,
+  thumbnail: undefined,
+  referenceNumber: undefined,
+  productionDates: [],
+  archiveLabels: undefined,
+  cardLabels: [],
+  primaryContributorLabel: undefined,
+  notes: [],
+  physicalDescription: '',
+  isArchiveCollectionRoot: false,
+};
+
+const mockFeatureFlags = (archiveCollection: boolean) =>
+  jest
+    .spyOn(Context, 'useFeatureFlags')
+    .mockImplementation(
+      () =>
+        ({ archiveCollection }) as unknown as ReturnType<
+          typeof Context.useFeatureFlags
+        >
+    );
+
+const renderResult = (work: WorkBasic) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <WorkSearchResult work={work} resultPosition={0} />
+    </ThemeProvider>
+  );
+
+describe('WorkSearchResult', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not show "Archive Collection" for an ordinary work, even with the flag on', () => {
+    mockFeatureFlags(true);
+    renderResult(baseWork);
+    expect(screen.queryByText('Archive Collection')).not.toBeInTheDocument();
+  });
+
+  // The "is this actually an archive collection root" decision lives in
+  // `isArchiveCollectionRoot` - see its tests in utils/works.test.ts for the
+  // cases (a manuscript, a non-archive format, a childless root) that get
+  // `false` here.
+  it('does not show "Archive Collection" for a collection root that is not itself an archive', () => {
+    mockFeatureFlags(true);
+    renderResult({ ...baseWork, isArchiveCollectionRoot: false });
+    expect(screen.queryByText('Archive Collection')).not.toBeInTheDocument();
+  });
+
+  it('shows "Archive Collection" for an archive collection root when the flag is on', () => {
+    mockFeatureFlags(true);
+    renderResult({ ...baseWork, isArchiveCollectionRoot: true });
+    expect(screen.getByText('Archive Collection')).toBeInTheDocument();
+  });
+
+  it('does not show "Archive Collection" for an archive collection root when the flag is off', () => {
+    mockFeatureFlags(false);
+    renderResult({ ...baseWork, isArchiveCollectionRoot: true });
+    expect(screen.queryByText('Archive Collection')).not.toBeInTheDocument();
+  });
+});

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.Result.tsx
@@ -35,15 +35,16 @@ const WorkSearchResult: FunctionComponent<Props> = ({
 }) => {
   const { archiveCollection } = useFeatureFlags();
   const {
-    isRootCollection,
     archiveLabels,
     cardLabels,
     physicalDescription,
     primaryContributorLabel,
     productionDates,
+    isArchiveCollectionRoot,
   } = work;
 
-  const shouldShowArchiveCollectionInfo = archiveCollection && isRootCollection;
+  const shouldShowArchiveCollectionInfo =
+    archiveCollection && isArchiveCollectionRoot;
 
   return (
     <NextLink
@@ -78,7 +79,7 @@ const WorkSearchResult: FunctionComponent<Props> = ({
             )}
 
             <WorkTitleHeading
-              $isRootCollection={shouldShowArchiveCollectionInfo}
+              $isArchiveCollectionRoot={shouldShowArchiveCollectionInfo}
             >
               <WorkTitle title={work.title} />
             </WorkTitleHeading>

--- a/content/webapp/views/components/WorksSearchResults/WorksSearchResults.styles.tsx
+++ b/content/webapp/views/components/WorksSearchResults/WorksSearchResults.styles.tsx
@@ -89,7 +89,7 @@ export const WorkInformationItemSeparator = styled.span`
 export const WorkTitleHeading = styled.h3.attrs({
   className: typography('body', 'lg', 'strong'),
 })<{
-  $isRootCollection?: boolean;
+  $isArchiveCollectionRoot?: boolean;
 }>`
-  margin-bottom: ${props => props.theme.spacingUnits[props.$isRootCollection ? '050' : '100']};
+  margin-bottom: ${props => props.theme.spacingUnits[props.$isArchiveCollectionRoot ? '050' : '100']};
 `;

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFViewer.test.tsx
@@ -43,7 +43,7 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
-  isRootCollection: false,
+  isArchiveCollectionRoot: false,
 };
 
 const renderViewer = (transformedManifest: TransformedManifest) =>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.test.tsx
@@ -65,7 +65,7 @@ const mockWork: WorkBasic & Pick<Work, 'description'> = {
   primaryContributorLabel: undefined,
   notes: [],
   physicalDescription: '',
-  isRootCollection: false,
+  isArchiveCollectionRoot: false,
 };
 
 const renderViewer = (

--- a/content/webapp/views/pages/works/work/index.tsx
+++ b/content/webapp/views/pages/works/work/index.tsx
@@ -24,6 +24,7 @@ import {
   getArchiveAncestorArray,
   getDigitalLocationInfo,
   getDigitalLocationOfType,
+  isArchiveCollectionRoot,
   showItemLink,
 } from '@weco/content/utils/works';
 import CataloguePageLayout from '@weco/content/views/layouts/CataloguePageLayout';
@@ -68,7 +69,8 @@ export const WorkPage: NextPage<Props> = ({
   const isArchive = !!(
     work.parts.length || getArchiveAncestorArray(work).length > 0
   );
-  const displayCollectionRoot = !!work.collection?.isRoot && archiveCollection;
+  const displayCollectionRoot =
+    isArchiveCollectionRoot(work) && archiveCollection;
 
   const iiifImageLocation = getDigitalLocationOfType(work, 'iiif-image');
   const iiifPresentationLocation = getDigitalLocationOfType(


### PR DESCRIPTION
- For #13423

Alternative to #13425 — same bug, different rule. We should pick one and close the other.

Would strongly recommend getting acquainted with [this Slack thread](https://wellcome.slack.com/archives/CUA669WHH/p1788254094238039).

## What does this change?

#13425 gates the archive collection layout on `archive.category`. Per the catalogue team ([Slack](https://wellcome.slack.com/archives/CUA669WHH/p1787825666459249)) that isn't an archive/manuscript discriminator:

- it only covers the 16 recognised archive types, so an archive whose collection path prefix isn't one of them (RAMC, 1,507 works) has no category and gets wrongly excluded
- it lets childless roots through, and those shouldn't get the layout either

So it's wrong in both directions. This swaps it for `isArchiveCollectionRoot` in `content/webapp/utils/works.ts`, which is true when a work:

- is a collection root (`collection.isRoot`)
- has children (`collection.root.totalParts > 0`)
- has format Archives and manuscripts (`h`) or Born-digital archives (`hdig`)
- has no `tei-manuscript-id` identifier

The TEI identifier is what separates archives from manuscripts. It's a heuristic and it's imperfect: a TEI work is always a manuscript, but not all manuscripts come from TEI, so manuscripts catalogued in CALM (e.g. [trbbzdqk](https://wellcomecollection.org/works/trbbzdqk), MSS.3238) have no TEI identifier and still come through as archives. It's the best signal we have while the API doesn't model the difference — see the risks below.

`totalParts` rides along with the `collection` include, so search results don't need the much heavier `parts`. The `archive` include is dropped (nothing reads it any more) and `identifiers` added in its place.

`WorkBasic` loses `isBrowsingArchive` and `isRootCollection` in favour of the one boolean — the work page layout and the "Archive Collection" search card always agree, so they can't drift apart.

## How to test

Turn on `archiveCollection` via the [toggles dashboard](https://dash.wellcomecollection.org/toggles/?enableToggle=archiveCollection). With it off, every link below shows the plain breadcrumb + tree page, same as PROD.

Tab = the new tab-based collection layout. Tree = the old breadcrumb + sidebar tree.

| Work | What it is | `main` | #13425 | This branch |
|---|---|---|---|---|
| [xqc9qs4x](https://www-dev.wellcomecollection.org/works/xqc9qs4x) | RAMC, 1,507 children, no archive category | Tab | Tree | **Tab** |
| [psyccrys](https://www-dev.wellcomecollection.org/works/psyccrys) | Lettsom, 5 children, no archive category | Tab | Tree | **Tab** |
| [hz43r7re](https://www-dev.wellcomecollection.org/works/hz43r7re) | Crick, PP/CRI, 14 children | Tab | Tab | Tab |
| [a25y97mq](https://www-dev.wellcomecollection.org/works/a25y97mq) | Categorised (PP) but no children | Tab | Tab | **Tree** |
| [b74me3gw](https://www-dev.wellcomecollection.org/works/b74me3gw) | Aids Archive UK, no children | Tab | Tab | **Tree** |
| [k3gfstaz](https://www-dev.wellcomecollection.org/works/k3gfstaz) | MS.632, a TEI manuscript | Tab | Tree | Tree |
| [dte7ws4x](https://www-dev.wellcomecollection.org/works/dte7ws4x) | 14 zines — a collection, but Books | Tab | Tree | Tree |
| [y2a5g34q](https://www-dev.wellcomecollection.org/works/y2a5g34q) | Manuscripts format | Tab | Tree | Tree |
| [vhse6wqd](https://www-dev.wellcomecollection.org/works/vhse6wqd) | An item inside a collection, not a root | Tree | Tree | Tree |

The four bold rows are what this branch changes relative to #13425. The two singletons (`a25y97mq`, `b74me3gw`) are the cases #13425 gets wrong that `main` also gets wrong.

Search cards follow the same rule — with the flag on:

- ["Royal Army Medical Corps Muniments"](https://www-dev.wellcomecollection.org/search/works?query=%22Royal%20Army%20Medical%20Corps%20Muniments%22) — top result says "Archive Collection" here, doesn't on #13425
- ["Lund, Helmut Christian"](https://www-dev.wellcomecollection.org/search/works?query=%22Lund%2C%20Helmut%20Christian%22) — the reverse: says "Archive Collection" on `main` and #13425, doesn't here
- ["holding title"](https://www-dev.wellcomecollection.org/search/works?query=%22holding%20title%22) — the zines, no badge on this branch or #13425

Cardigan has a `WorksSearchResults` story with a three-way work picker if you want to eyeball the card without the API.

## Have we considered potential risks?

- Flag-gated. With `archiveCollection` off (PROD default) nothing here is user-visible.
- The known hole: the TEI filter can't be fully accurate. Cites the audit (most size-2 manuscripts carry a TEI id and are filtered; a fair number at size 3 are CALM and aren't), notes the MS/MSS reference-number alternative was floated and is hackier, and says this ships knowingly imperfect.
- Collection size is no help as a proxy — txvpkkxh (PP/BOY) and m7awxnw4 (GP/11) are real archives with one item, so raising the totalParts threshold above 0 would exclude genuine archives.
- The broken large TEI manuscripts (cd8dfbeq, j3y7r4ux) are correctly filtered out here, so not a regression, but worth their own ticket.
- Works search requests now ask for `identifiers`. That's a few small objects per result across 25 results — a bit more than the single `archive` object #13425 adds, and more than `main` sends today. Probably noise, but it's on every works search, so worth a catalogue API opinion.
- `totalParts` is the only signal for "has children". If the API ever stopped populating it on `collection.root`, every collection root would silently fall back to the tree rather than erroring.
- Not carried over from #13425: that PR also loosens `archive.category` to optional in our `Work` type to match the real contract. This branch doesn't touch the `archive` field at all, but that fix is still worth landing whichever way we go.
- Happy to be told whether any of this warrants an alarm.
