### PR TITLE
IVR: disambiguate canvas (a number) from currentCanvas (an object)

### DIFF
--- a/content/webapp/test/fixtures/iiif/render.tsx
+++ b/content/webapp/test/fixtures/iiif/render.tsx
@@ -78,7 +78,7 @@ function createMockRefactoredItemViewerContext(
   const currentCanvas = getCurrentCanvas({
     transformedManifest,
     canvasIndexById,
-    canvas: query.canvas,
+    canvasNumber: query.canvas,
   });
 
   return {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -108,14 +108,14 @@ const Loading = () => (
 type HitProps = {
   hit: SearchResults['hits'][0];
   matchingCanvas: TransformedCanvas | undefined;
-  matchingCanvasParam: number;
+  matchingCanvasNumber: number;
   totalCanvases: number | undefined;
 };
 
 const Hit: FunctionComponent<HitProps> = ({
   hit,
   matchingCanvas,
-  matchingCanvasParam,
+  matchingCanvasNumber,
   totalCanvases,
 }: HitProps) => {
   const label =
@@ -125,7 +125,7 @@ const Hit: FunctionComponent<HitProps> = ({
   return (
     <>
       <HitData $v={{ size: 'xs', properties: ['margin-bottom'] }}>
-        {`Found on image ${matchingCanvasParam}${
+        {`Found on image ${matchingCanvasNumber}${
           totalCanvases ? ` / ${totalCanvases}` : ''
         }`}
         {label}
@@ -307,7 +307,7 @@ const IIIFSearchWithin: FunctionComponent = () => {
                   <Hit
                     hit={hit}
                     matchingCanvas={matchingCanvas}
-                    matchingCanvasParam={arrayIndexToQueryParam(index || 0)}
+                    matchingCanvasNumber={arrayIndexToQueryParam(index || 0)}
                     totalCanvases={canvases?.length}
                   />
                 </NextLink>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFViewer.tsx
@@ -264,7 +264,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const router = useRouter();
   const {
     page = 1,
-    canvas = 1,
+    canvas: canvasNumber = 1,
     manifest = 1,
     shouldScrollToCanvas = true,
     query = '',
@@ -295,7 +295,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
   const currentCanvas = getCurrentCanvas({
     transformedManifest,
     canvasIndexById,
-    canvas,
+    canvasNumber,
   });
   const isCurrentCanvasRestricted = currentCanvas
     ? hasRestrictedItem(currentCanvas)
@@ -386,7 +386,7 @@ const IIIFViewer: FunctionComponent<IIIFViewerProps> = ({
         // DATA props:
         query: {
           page,
-          canvas,
+          canvas: canvasNumber,
           manifest,
           shouldScrollToCanvas,
           query,

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewerControls.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ImageViewerControls.tsx
@@ -35,13 +35,13 @@ const ImageViewerControlsWrapper = styled.div<{ $showControls?: boolean }>`
 
 function updateRotatedImages({
   rotatedImages,
-  canvasParam,
+  canvasNumber,
 }: {
   rotatedImages: CanvasRotatedImage[];
-  canvasParam: number;
+  canvasNumber: number;
 }): CanvasRotatedImage[] {
   const matchingIndex = rotatedImages.findIndex(
-    rotatedImage => rotatedImage.canvas === canvasParam
+    rotatedImage => rotatedImage.canvas === canvasNumber
   );
   if (matchingIndex >= 0) {
     return rotatedImages.map((rotatedImage, i) => {
@@ -61,7 +61,7 @@ function updateRotatedImages({
     return [
       ...rotatedImages,
       {
-        canvas: canvasParam,
+        canvas: canvasNumber,
         rotation: 90,
       },
     ];
@@ -104,7 +104,7 @@ const ImageViewerControls: FunctionComponent = () => {
             setRotatedImages(
               updateRotatedImages({
                 rotatedImages,
-                canvasParam: query.canvas,
+                canvasNumber: query.canvas,
               })
             );
           }}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/Thumbnails.tsx
@@ -53,16 +53,16 @@ export const Thumbnails = () => {
     >
       {navigationCanvases &&
         navigationCanvases.map((canvas, i) => {
-          const canvasParam =
+          const canvasNumber =
             thumbnailsPageSize * queryParamToArrayIndex(query.page) + (i + 1);
           return (
             <ThumbnailLink
               key={canvas.id}
-              aria-current={canvasParam === query.canvas}
+              aria-current={canvasNumber === query.canvas}
               {...toWorksItemLink({
                 workId: work.id,
                 props: {
-                  canvas: canvasParam,
+                  canvas: canvasNumber,
                   page: query.page,
                   manifest: query.manifest,
                   query: query.query,
@@ -71,7 +71,7 @@ export const Thumbnails = () => {
               scroll={false}
               replace
             >
-              <IIIFCanvasThumbnail canvas={canvas} thumbNumber={canvasParam} />
+              <IIIFCanvasThumbnail canvas={canvas} thumbNumber={canvasNumber} />
             </ThumbnailLink>
           );
         })}

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerBottomBar.tsx
@@ -139,16 +139,16 @@ const ViewerBottomBar: FunctionComponent = () => {
     hasOnlyRenderableImages,
   } = useItemViewerContext();
 
-  const { canvas } = query;
+  const { canvas: canvasNumber } = query;
 
-  const canNavigatePrevious = canvas > 1;
-  const canNavigateNext = canvas < totalCanvases;
+  const canNavigatePrevious = canvasNumber > 1;
+  const canNavigateNext = canvasNumber < totalCanvases;
 
   const previousCanvasLink = canNavigatePrevious
-    ? toWorksItemLink({ workId: work.id, props: { canvas: canvas - 1 } })
+    ? toWorksItemLink({ workId: work.id, props: { canvas: canvasNumber - 1 } })
     : null;
   const nextCanvasLink = canNavigateNext
-    ? toWorksItemLink({ workId: work.id, props: { canvas: canvas + 1 } })
+    ? toWorksItemLink({ workId: work.id, props: { canvas: canvasNumber + 1 } })
     : null;
 
   const shouldShowCanvasNavigation =

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
@@ -8,8 +8,9 @@ import { TransformedCanvas } from '@weco/content/types/manifest';
 import { queryParamToArrayIndex } from '@weco/content/views/pages/works/work/work.helpers';
 
 type OverlayPositionData = {
-  // 0-based array index, matching the FixedSizeList row index the overlay
-  // belongs to - not the 1-based ?canvas= number.
+  // Which canvas this overlay sits on, as a 0-based index into `canvases` -
+  // not the 1-based ?canvas= number. The list renders one row per canvas, so
+  // this is compared directly against the FixedSizeList row index.
   canvasIndex: number;
   overlayTop: number;
   overlayLeft: number;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.SearchHighlights.tsx
@@ -8,7 +8,9 @@ import { TransformedCanvas } from '@weco/content/types/manifest';
 import { queryParamToArrayIndex } from '@weco/content/views/pages/works/work/work.helpers';
 
 type OverlayPositionData = {
-  canvasNumber: number;
+  // 0-based array index, matching the FixedSizeList row index the overlay
+  // belongs to - not the 1-based ?canvas= number.
+  canvasIndex: number;
   overlayTop: number;
   overlayLeft: number;
   highlight: {
@@ -127,11 +129,11 @@ function getPositionData({
     // on: "https://wellcomelibrary.org/iiif/b30330002/canvas/c55#xywh=2301,662,157,47"
     // OR
     // on: https://iiif.wellcomecollection.org/presentation/b29338062/canvases/b29338062_0031.jp2#xywh=148,2277,259,59"
-    const canvasNumber = canvases.findIndex(canvas => {
+    const canvasIndex = canvases.findIndex(canvas => {
       return new URL(resource.on).pathname === new URL(canvas.id).pathname;
     });
     const matchingRotation = rotatedImages.find(image => {
-      return queryParamToArrayIndex(image.canvas) === canvasNumber;
+      return queryParamToArrayIndex(image.canvas) === canvasIndex;
     });
     const scale = getScale({
       imageRect,
@@ -153,7 +155,7 @@ function getPositionData({
     });
 
     return {
-      canvasNumber: Number(canvasNumber),
+      canvasIndex,
       overlayTop,
       overlayLeft,
       highlight: {
@@ -213,7 +215,7 @@ export function useSearchTermHighlights({
     if (searchHitsPositioningData) {
       setOverlayPositionData(
         searchHitsPositioningData.filter(item => {
-          return item.canvasNumber === index;
+          return item.canvasIndex === index;
         })
       );
     }

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/VirtualizedImageViewer.tsx
@@ -99,12 +99,12 @@ ItemRenderer.displayName = 'ItemRenderer';
 
 function scrollViewer({
   currentCanvas,
-  canvas,
+  canvasNumber,
   viewer,
   mainAreaWidth,
 }: {
   currentCanvas: TransformedCanvas | undefined;
-  canvas: number;
+  canvasNumber: number;
   viewer: FixedSizeList | null;
   mainAreaWidth: number;
 }): void {
@@ -127,14 +127,14 @@ function scrollViewer({
         : 1;
     const renderedHeight = mainAreaWidth * ratio * 0.8; // 0.8 = 80% max-width image in container. Variable.
     const heightOfPreviousItems =
-      queryParamToArrayIndex(canvas) * (viewer?.props.itemSize || 0);
+      queryParamToArrayIndex(canvasNumber) * (viewer?.props.itemSize || 0);
     const distanceToScroll =
       heightOfPreviousItems +
       ((viewer?.props.itemSize || 0) - renderedHeight) / 2;
     viewer?.scrollTo(distanceToScroll);
   } else {
     // 4. Otherwise, if it's portrait, we go to the start of the image
-    viewer?.scrollToItem(queryParamToArrayIndex(canvas), 'start');
+    viewer?.scrollToItem(queryParamToArrayIndex(canvasNumber), 'start');
   }
 }
 
@@ -185,13 +185,13 @@ const VirtualizedImageViewer: FunctionComponent = () => {
     }, 500);
   }
 
-  // We display the canvas indicated by the canvas (index) when the page first loads
+  // We display the canvas indicated by the ?canvas= number when the page first loads
   function handleOnItemsRendered() {
     if (firstRenderRef.current) {
       const viewer = mainViewerRef?.current;
       scrollViewer({
         currentCanvas,
-        canvas: query.canvas,
+        canvasNumber: query.canvas,
         viewer,
         mainAreaWidth,
       });
@@ -206,7 +206,7 @@ const VirtualizedImageViewer: FunctionComponent = () => {
     if (query.shouldScrollToCanvas) {
       scrollViewer({
         currentCanvas,
-        canvas: query.canvas,
+        canvasNumber: query.canvas,
         viewer: mainViewerRef?.current,
         mainAreaWidth,
       });

--- a/content/webapp/views/pages/works/work/work.helpers.test.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.test.tsx
@@ -21,7 +21,7 @@ describe('getCurrentCanvas', () => {
       getCurrentCanvas({
         transformedManifest: undefined,
         canvasIndexById: {},
-        canvas: 1,
+        canvasNumber: 1,
       })
     ).toBeUndefined();
   });
@@ -30,7 +30,11 @@ describe('getCurrentCanvas', () => {
     const transformedManifest = createMockManifest({ canvases: [] });
 
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById: {}, canvas: 1 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById: {},
+        canvasNumber: 1,
+      })
     ).toBeUndefined();
   });
 
@@ -42,7 +46,11 @@ describe('getCurrentCanvas', () => {
     });
 
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById: {}, canvas: 2 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById: {},
+        canvasNumber: 2,
+      })
     ).toBe(canvasB);
   });
 
@@ -57,7 +65,11 @@ describe('getCurrentCanvas', () => {
     const canvasIndexById = { b: 1 };
 
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById, canvas: 1 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById,
+        canvasNumber: 1,
+      })
     ).toBe(canvasA);
   });
 
@@ -71,10 +83,18 @@ describe('getCurrentCanvas', () => {
     const canvasIndexById = { b: 1, a: 2 };
 
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById, canvas: 1 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById,
+        canvasNumber: 1,
+      })
     ).toBe(canvasB);
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById, canvas: 2 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById,
+        canvasNumber: 2,
+      })
     ).toBe(canvasA);
   });
 
@@ -90,7 +110,11 @@ describe('getCurrentCanvas', () => {
     const canvasIndexById = { a: 5, b: 7 };
 
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById, canvas: 1 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById,
+        canvasNumber: 1,
+      })
     ).toBe(canvasA);
   });
 
@@ -100,7 +124,11 @@ describe('getCurrentCanvas', () => {
     });
 
     expect(
-      getCurrentCanvas({ transformedManifest, canvasIndexById: {}, canvas: 0 })
+      getCurrentCanvas({
+        transformedManifest,
+        canvasIndexById: {},
+        canvasNumber: 0,
+      })
     ).toBeUndefined();
   });
 
@@ -113,7 +141,7 @@ describe('getCurrentCanvas', () => {
       getCurrentCanvas({
         transformedManifest,
         canvasIndexById: {},
-        canvas: 9999,
+        canvasNumber: 9999,
       })
     ).toBeUndefined();
   });

--- a/content/webapp/views/pages/works/work/work.helpers.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.tsx
@@ -154,8 +154,8 @@ export function queryParamToArrayIndex(queryParam: number): number {
 }
 
 /**
- * Converts a 0-based array index back into a 1-based canvas/manifest query
- * param - the inverse of {@link queryParamToArrayIndex}.
+ * Converts a 0-based array index back into a 1-based canvas/manifest/page
+ * query param - the inverse of {@link queryParamToArrayIndex}.
  * @param arrayIndex - The 0-based array index.
  */
 export function arrayIndexToQueryParam(arrayIndex: number): number {

--- a/content/webapp/views/pages/works/work/work.helpers.tsx
+++ b/content/webapp/views/pages/works/work/work.helpers.tsx
@@ -143,23 +143,23 @@ export function createDownloadTree(
 }
 
 /**
- * Converts a 1-based canvas/manifest query param into a 0-based array index -
- * the inverse of {@link arrayIndexToQueryParam}. Canvas and manifest params
- * use 1-based indexing, but are used to access items in 0-indexed arrays, so
- * we need to convert them in various places.
- * @param canvas - The 1-based canvas or manifest number.
+ * Converts a 1-based canvas/manifest/page query param into a 0-based array
+ * index - the inverse of {@link arrayIndexToQueryParam}. These params use
+ * 1-based numbering, but are used to access items in 0-indexed arrays, so we
+ * need to convert them in various places.
+ * @param queryParam - The 1-based canvas, manifest or page number.
  */
-export function queryParamToArrayIndex(canvas: number): number {
-  return canvas - 1;
+export function queryParamToArrayIndex(queryParam: number): number {
+  return queryParam - 1;
 }
 
 /**
  * Converts a 0-based array index back into a 1-based canvas/manifest query
  * param - the inverse of {@link queryParamToArrayIndex}.
- * @param canvasIndex - The 0-based array index.
+ * @param arrayIndex - The 0-based array index.
  */
-export function arrayIndexToQueryParam(canvasIndex: number): number {
-  return canvasIndex + 1;
+export function arrayIndexToQueryParam(arrayIndex: number): number {
+  return arrayIndex + 1;
 }
 
 /**
@@ -198,16 +198,16 @@ export function getTreeCanvasIndexById(tree: UiTree): Record<string, number> {
  * every canvas, otherwise we just use the canvas's plain array position.
  * @param transformedManifest - The manifest whose canvases to search.
  * @param canvasIndexById - Map of canvas id to its 1-based structure position.
- * @param canvas - The 1-based canvas number to resolve.
+ * @param canvasNumber - The 1-based canvas number to resolve.
  */
 export function getCurrentCanvas({
   transformedManifest,
   canvasIndexById,
-  canvas,
+  canvasNumber,
 }: {
   transformedManifest: { canvases: TransformedCanvas[] } | undefined;
   canvasIndexById: Record<string, number>;
-  canvas: number;
+  canvasNumber: number;
 }): TransformedCanvas | undefined {
   const canvases = transformedManifest?.canvases;
   const canvasIds = Object.keys(canvasIndexById);
@@ -221,12 +221,12 @@ export function getCurrentCanvas({
   // fallback as-is rather than adding a branch for it.
   // https://github.com/wellcomecollection/wellcomecollection.org/pull/13346#discussion_r3714090012
   const currentCanvasId = hasCompleteStructure
-    ? canvasIds.find(id => canvasIndexById[id] === canvas)
+    ? canvasIds.find(id => canvasIndexById[id] === canvasNumber)
     : undefined;
 
   return currentCanvasId
     ? canvases?.find(c => c.id === currentCanvasId)
-    : canvases?.[queryParamToArrayIndex(canvas)];
+    : canvases?.[queryParamToArrayIndex(canvasNumber)];
 }
 
 /**


### PR DESCRIPTION
- For #12986
- Refs #12990, #13273

## What does this change?

Step 11 (RFC 086, Phase 3). Within `content/webapp/views/pages/works/work/IIIFViewer/refactored/`, `canvas` was being used for two different things: the 1-based canvas number that comes from the `?canvas=` query param, and the `TransformedCanvas` object itself. They sat close together in several files — `getCurrentCanvas({ ..., canvas })` returning a `currentCanvas` being the clearest example — which is easy to conflate, especially for anyone new to this code.

This renames the number to `canvasNumber`, so within `refactored/` `canvas` now consistently means the object.

Two things came up while scoping that are worth calling out:

**`queryParamToArrayIndex` / `arrayIndexToQueryParam` params became `queryParam` / `arrayIndex`, not `canvasNumber`.** Both are called with manifest and page numbers as well as canvas numbers, so naming their params after canvases would have been actively wrong. The new names match the function names.

**The same ambiguity existed pointing the other way.** In `VirtualizedImageViewer.SearchHighlights.tsx`, both a local variable and the `OverlayPositionData` field were called `canvasNumber` but actually hold a **0-based** index — the field is compared against the `FixedSizeList` row index. Both are now `canvasIndex`, with a comment recording which numbering applies. That type is local to the file (legacy has its own copy), so nothing in `legacy/` is touched. Also dropped a redundant `Number()` cast on the already-numeric `findIndex` result there.

### Deliberately out of scope

Three related renames were considered and left, because each reaches beyond `refactored/`:

- `CanvasRotatedImage.canvas` — holds a 1-based number and isn't wire format, but the type is shared, so renaming it means touching three `legacy/` files.
- `canvasIndexById` — maps canvas id to a **1-based** structure position, so "Index" is the wrong word. It's a field on both contexts plus several `legacy/` files.
- `currentCanvasIndex` / `canvasIndex` in the download-tree chain (`ViewerStructures`, `ViewerSidebar`, `work.DownloadItemRenderer`, `WorkDetails.DownloadItem`) — both are 1-based numbers. I checked they're consistent with each other, so this is naming only, not a bug.

The first two get much cheaper once #12990 deletes `legacy/`. These have been written up on #13273.

Also left alone: `pages/works/[workId]/items.tsx` has `canvas` and `currentCanvas` two lines apart, but it's the shared page serving both viewers.

## How to test

This is a rename with no behaviour change, so the check is that nothing moved:

- `yarn tsc` from the repo root — clean.
- From `content/webapp`: `yarn jest "views/pages/works/work/(IIIFViewer|work.helpers)" test/fixtures/iiif hooks/useIIIFProbeService` — 212 passing, identical to the count on `main` before this branch.
- `yarn test:content` — 84 suites, 659 tests passing.

## Have we considered potential risks?

Low risk by construction — every hunk is a name swap, and TypeScript covers the whole surface. `tsc` did catch one genuinely missed site on the first pass (the `OverlayPositionData` field), which is the reassuring part: had any rename been incomplete, the build would have failed rather than shipping a silent mismatch.