### PR TITLE
Declare @prismicio deps where they're used and drop the resolution

### DIFF
--- a/cardigan/package.json
+++ b/cardigan/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.6.0",
+    "@prismicio/client": "^7.22.0",
     "@storybook/addon-a11y": "10.5.5",
     "@storybook/addon-docs": "10.5.5",
     "@storybook/cli": "10.5.5",

--- a/common/package.json
+++ b/common/package.json
@@ -12,7 +12,6 @@
     "@elastic/apm-rum": "^5.17.0",
     "@popperjs/core": "^2.11.8",
     "@prismicio/client": "^7.22.0",
-    "@prismicio/next": "^2.3.0",
     "@prismicio/react": "3.4.0",
     "@testing-library/jest-dom": "^6.9.0",
     "@testing-library/react": "^16.3.0",

--- a/content/webapp/package.json
+++ b/content/webapp/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@iiif/presentation-3": "^2.1.3",
     "@koa/router": "^15.6.0",
+    "@prismicio/client": "^7.22.0",
+    "@prismicio/react": "3.4.0",
     "@vimeo/player": "^2.25.1",
     "@weco/common": "1.0.0",
     "@weco/toggles": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {
-    "@prismicio/client": "7.22.0",
     "@types/react": "19.2.2"
   },
   "private": true,

--- a/prismic-model/package.json
+++ b/prismic-model/package.json
@@ -19,6 +19,7 @@
     "@aws-sdk/client-s3": "^3.1121.0",
     "@aws-sdk/client-secrets-manager": "^3.1121.0",
     "@aws-sdk/client-sts": "^3.1121.0",
+    "@prismicio/client": "^7.22.0",
     "@types/form-data": "^2.5.0",
     "@types/node": "^24.10.0",
     "@types/yargs": "^17.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,7 +2943,14 @@
   dependencies:
     "@prismicio/types-internal" "^3.17.2"
 
-"@prismicio/client@7.17.0", "@prismicio/client@7.22.0", "@prismicio/client@^7.1.0", "@prismicio/client@^7.22.0":
+"@prismicio/client@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-7.17.0.tgz#7b8f12fbc76e02a23fe817a1a0d8410d83fc40f6"
+  integrity sha512-7e1ICYk4IAxKX8zmtCOy9e8rXeeT9A45ZgJY9lNNWqUaL1LW/ilXnh/SsAZG/G5q14JyRJHwBIGIzcKY9hjJhw==
+  dependencies:
+    imgix-url-builder "^0.0.5"
+
+"@prismicio/client@^7.1.0", "@prismicio/client@^7.22.0":
   version "7.22.0"
   resolved "https://registry.yarnpkg.com/@prismicio/client/-/client-7.22.0.tgz#85cc0ebc2f289e19a875e14aef0e9b7a2a8acf82"
   integrity sha512-mWzNx6kLn8cOO9j4Tt92RnVYNHl7xBDAZBUkIwvpUYSW7fzMKCJSYpuYpKpfwt9OCkr/CTRvhlqTzx3f7vU8oA==
@@ -2975,15 +2982,6 @@
     newtype-ts "^0.3.5"
     tslib "^2.8.1"
 
-"@prismicio/next@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@prismicio/next/-/next-2.3.0.tgz#ca47bbc2979c6deddaabcde6f34c3c71f0fcb10f"
-  integrity sha512-Zo6KfE0NitFHagtL1vgvzI/UB1YLlBSFfwH5wqXz49hZgCHbjnKGTsU0uPp62wep05nfzzGH6k7EQCCYAi75lg==
-  dependencies:
-    "@prismicio/simulator" "^0.2.2"
-    imgix-url-builder "^0.0.6"
-    lz-string "^1.5.0"
-
 "@prismicio/react@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@prismicio/react/-/react-3.4.0.tgz#dbbe54630a054e73068f92e5cf1e80e5ed1a1f2c"
@@ -2999,11 +2997,6 @@
     "@prismicio/client" "^7.1.0"
     "@types/statuses" "^2.0.1"
     statuses "^2.0.1"
-
-"@prismicio/simulator@^0.2.2":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@prismicio/simulator/-/simulator-0.2.4.tgz#6b7185b102edd8c8aab1634764364452cea440bb"
-  integrity sha512-dmxqaihyUkuUbbJwe/AJuE40c6jH233plJiGza8sTGmzNKd/V8tsP11+NuBN0vuFSpZ1zBEWYsZFbsCwHuJZyA==
 
 "@prismicio/types-internal@^3.17.2":
   version "3.17.2"
@@ -7126,6 +7119,11 @@ image-size@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-2.0.2.tgz#84a7b43704db5736f364bf0d1b029821299b4bdc"
   integrity sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==
+
+imgix-url-builder@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/imgix-url-builder/-/imgix-url-builder-0.0.5.tgz#641e4af7fc1443d3f9f30f3c1331e4c1a2ad9832"
+  integrity sha512-dCx3UlXghtsjySoqVCcHQHRikqDummwQEfKlxBUK/wrMzd+1ox/XX+zhqVuXKMVuZvCc84pVLEJyntQB0OOi/w==
 
 imgix-url-builder@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
- Suggested follow-up from #13430

> ## What does this change?
>
> Three workspaces import `@prismicio/client` without declaring it as a dependency, and `content/webapp` imports `@prismicio/react` without declaring it either:
>
> | Workspace | Imports | Declared before this PR |
> | --- | --- | --- |
> | `content/webapp` | `@prismicio/client` (80 sites), `@prismicio/react` (9 sites) | neither |
> | `cardigan` | `@prismicio/client` (6 sites, stories + story data) | no |
> | `prismic-model` | `@prismicio/client` (`scripts/migrate.ts`) | no |
>
> These only worked because yarn hoisted `common`'s copy into the root `node_modules`, so the imports resolved by accident rather than by declaration. This PR declares them, using the same range strings `common` already uses (`^7.22.0` and `3.4.0`) so they share a single lockfile entry.
>
> ### Why the resolution can now go
>
> With those declarations in place, the root `resolutions` pin on `@prismicio/client` is no longer doing anything we need.
>
> It was added in #11830, where the stated reason was that "a different version of the package is required for a different dependency (`prismicio/simulator` for `slicemachine`)". That explanation is now out of date: `@prismicio/next` and `@prismicio/react` both declare `@prismicio/client` as a *peer* dependency these days rather than a hard one, and `@prismicio/simulator@0.2.4` has no dependencies at all. The simulator constrains nothing.
>
> What the pin was actually still guarding against is `@slicemachine/manager` and `@slicemachine/plugin-kit` (dev tooling, reached via `slice-machine-ui` and `@slicemachine/adapter-next`), which pin `@prismicio/client` to an exact `7.17.0`. Without the resolution *and* without the declarations above, yarn 1 hoists that `7.17.0` into the root slot and pushes our version down into `common/node_modules`. `content/webapp` and `cardigan` then pick up 7.17.0 while `common` uses 7.22.0, which splits the type identity of `Client` and `PrismicDocument` across the project-reference boundary and produces ~690 `tsc` errors. That is exactly the failure #11830 was reacting to.
>
> Once every consumer declares the dependency, our version has more requesters, wins the root slot, and slicemachine's `7.17.0` nests under the two packages that actually ask for it. That is also more correct than what we had: the resolution was force-upgrading slicemachine's pinned dependency by five minor versions.
>
> Removing the pin closes the maintenance trap it created. The range and the resolution had to be bumped in lockstep, and when #13430 bumped only the range, the upgrade silently didn't happen — yarn kept installing the pinned version while install and CI both stayed green. That needed a follow-up commit to fix, and would have recurred on every future bump.
>
> ### Also in here
>
> - Drops `@prismicio/next` from `common`. It's declared but imported nowhere in the repo. Previews are hand-rolled via `client.enableAutoPreviewsFromReq` (`content/webapp/app.ts`, `content/webapp/services/prismic/fetch/index.ts`), the `withPrismicPreviewStatus` Koa middleware and the `usePrismicPreview` hook, and nothing peer-depends on it. This is the easiest line to revert if anyone has plans for it.
> - The lockfile now reports resolutions accurately, instead of a single entry claiming that `7.17.0`, `^7.1.0` and `^7.22.0` all resolve to the same version.
>
> ## How to test
>
> The meaningful check is a clean install, because this is entirely about how yarn lays out `node_modules`.
>
> ```
> rm -rf node_modules */node_modules */*/node_modules
> yarn install
> find . -type d -name client -path "*@prismicio*" -not -path "*ts-codegen*"
> ```
>
> On this branch you should see our version at the root and slicemachine's nested beneath it:
>
> ```
> ./node_modules/@prismicio/client                         -> 7.22.0
> ./node_modules/@slicemachine/plugin-kit/node_modules/... -> 7.17.0
> ./node_modules/@slicemachine/manager/node_modules/...    -> 7.17.0
> ```
>
> On `main` you get a single copy at 7.22.0 everywhere, because the resolution forces it.
>
> The thing to confirm is that every workspace resolves to the *same* root copy — that shared copy is what keeps the types compatible:
>
> ```
> for w in common content/webapp cardigan prismic-model identity/webapp; do
>   node -e "console.log(require.resolve('@prismicio/client/package.json',{paths:['$PWD/$w']}))"
> done
> ```
>
> All five should print the root path. Then `yarn tsc` should be clean. If it instead reports several hundred errors mentioning `Client` or `PrismicDocument`, hoisting has picked the wrong version for the root slot — see the risk note below.
>
> Also worth exercising, since they're the surfaces that changed: `yarn cardigan` renders stories, `yarn content` serves the site, and `yarn slicemachine` now runs against its own pinned 7.17.0 rather than a forced upgrade.
>
> ### What I ran
>
> All from a clean install with every workspace's `node_modules` deleted:
>
> - `yarn tsc` — 0 errors
> - `yarn test:all:unit` — 1007 tests passing
> - `yarn build` in `content/webapp` — succeeds, including the `/slice-simulator` route, which is the one page that reaches into the slicemachine tooling
> - `yarn lint` — clean
> - `prettier --check` — clean on all five `package.json` files
> - A second `yarn install` produces no further lockfile changes
>
> ## Have we considered potential risks?
>
> The real risk is that dropping the resolution means we rely on yarn 1's hoisting to keep choosing our version for the root slot. It does today, and the declarations added here are what make it do so, but it's an emergent property of how many packages request each version rather than something we assert directly. If a future slicemachine release spread its `7.17.0` pin to more packages, the root slot could flip.
>
> The mitigation is that this fails loudly rather than silently. `.github/workflows/tsc.yml` runs `yarn install && yarn tsc` on every push, so a flip would fail CI on the PR that caused it. It would show up as several hundred type errors about `Client` and `PrismicDocument`, which looks alarming but has a single cause — worth knowing that the fix is to look at hoisting rather than to re-add the resolution reflexively.
>
> A smaller consequence: `node_modules` now carries three copies of `@prismicio/client` instead of one. Two of those are the dev-only slicemachine copies and don't reach any bundle.
>
> Nothing here changes application code or runtime behaviour — the only shipped change is that `@prismicio/client` resolves to the same 7.22.0 it already does on `main`.
>
> - Refs #13430
> - Refs #11830

_Claude_
