### PR TITLE
IVR: Use `hasRealLabel` more

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
@@ -15,6 +15,7 @@ import {
   isChoiceBody,
   isPDFCanvas,
 } from '@weco/content/utils/iiif/v3';
+import { hasRealLabel } from '@weco/content/utils/works';
 
 import IIIFViewerImage from './IIIFViewerImage';
 import Padlock from './Padlock';
@@ -168,7 +169,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
         <div>
           <Space $v={{ size: 'xs', properties: ['margin-bottom'] }}>
             <IIIFViewerThumbNumber>
-              {canvas.label?.trim() !== '-' && 'page'} {canvas.label}
+              {hasRealLabel(canvas.label?.trim()) && 'page'} {canvas.label}
             </IIIFViewerThumbNumber>
           </Space>
           <div>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFItem/index.tsx
@@ -42,7 +42,7 @@ import {
   getLabelString,
 } from '@weco/content/utils/iiif/v3';
 import type { TransformedAuthService } from '@weco/content/utils/iiif/v3';
-import { getFileLabel } from '@weco/content/utils/works';
+import { getFileLabel, hasRealLabel } from '@weco/content/utils/works';
 import AudioPlayer from '@weco/content/views/components/AudioPlayer';
 import BetaMessage from '@weco/content/views/components/BetaMessage';
 import { toWorksItemLink } from '@weco/content/views/components/ItemLink';
@@ -359,7 +359,7 @@ function getItemLabel(
   if ('label' in item) {
     return getLabelString(item.label as InternationalString);
   }
-  return canvas.label?.trim() !== '-' ? canvas.label : undefined;
+  return hasRealLabel(canvas.label?.trim()) ? canvas.label : undefined;
 }
 
 const IIIFItem: FunctionComponent<ItemProps> = ({

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFSearchWithin.tsx
@@ -17,6 +17,7 @@ import {
 } from '@weco/content/services/iiif/types/search/v3';
 import { searchWithinLabel } from '@weco/content/text/aria-labels';
 import { TransformedCanvas } from '@weco/content/types/manifest';
+import { hasRealLabel } from '@weco/content/utils/works';
 import {
   ItemProps,
   toWorksItemLink,
@@ -118,10 +119,9 @@ const Hit: FunctionComponent<HitProps> = ({
   matchingCanvasParam,
   totalCanvases,
 }: HitProps) => {
-  const label =
-    matchingCanvas?.label && matchingCanvas.label.trim() !== '-'
-      ? ` (page ${matchingCanvas?.label})`
-      : '';
+  const label = hasRealLabel(matchingCanvas?.label?.trim())
+    ? ` (page ${matchingCanvas?.label})`
+    : '';
   return (
     <>
       <HitData $v={{ size: 'xs', properties: ['margin-bottom'] }}>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.test.tsx
@@ -102,6 +102,24 @@ describe('ViewerTopBar page-count indicator', () => {
     expect(screen.getByTestId('topbar')).not.toHaveTextContent(/page \d/);
   });
 
+  it('suppresses the page label when the canvas has no label at all', () => {
+    renderTopBar({
+      contextProps: {
+        transformedManifest: createMockManifest({
+          canvases: [
+            createMockCanvas({ label: '1' }),
+            createMockCanvas({ label: undefined }),
+          ],
+        }),
+        hasOnlyRenderableImages: true,
+        query: createMockQuery({ canvas: 2 }),
+      },
+    });
+
+    expect(screen.getByTestId('topbar')).toHaveTextContent('/2');
+    expect(screen.getByTestId('topbar')).not.toHaveTextContent(/page/);
+  });
+
   it('suppresses the page label when the manifest is not renderable-images-only', () => {
     renderTopBar({
       contextProps: {

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -22,7 +22,10 @@ import {
   getVideoAudioDownloadOptions,
   isChoiceBody,
 } from '@weco/content/utils/iiif/v3';
-import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
+import {
+  getDownloadOptionsFromImageUrl,
+  hasRealLabel,
+} from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
 
 import CanvasPositionIndicator from './CanvasPositionIndicator';
@@ -309,7 +312,7 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
           {shouldShowPageIndicator && (
             <>
               <CanvasPositionIndicator positionTestId="active-index" />{' '}
-              {currentPageLabel !== '-' &&
+              {hasRealLabel(currentPageLabel) &&
                 hasOnlyRenderableImages &&
                 `page ${currentPageLabel}`}
             </>


### PR DESCRIPTION
- For #12986 

## What does this change?

`ViewerTopBar.tsx` and `IIIFCanvasThumbnail.tsx` each independently checked `label.trim() !== '-'` to decide whether to show a page label — the same class of magic-string placeholder comparison [step 10](https://github.com/wellcomecollection/wellcomecollection.org/pull/13431) already fixed for file labels via `hasRealLabel`. Reused it in both places instead of reimplementing the check twice.

This also fixes a real, already-tracked bug ([#13273](https://github.com/wellcomecollection/wellcomecollection.org/issues/13273)): `ViewerTopBar`'s version only checked for the literal string `'-'`, not a fully missing label, so a canvas with no label at all rendered the literal text "page undefined". `hasRealLabel` correctly treats a missing label the same as the `'-'` placeholder.

`IIIFCanvasThumbnail.tsx` still has a related quirk we're leaving alone here: even once "page" is correctly suppressed, it still renders a bare `-` character afterward (a separate, untouched line). Noted in #13273 rather than fixed in this PR, to keep scope to the duplicated check itself.

## How to test

- Added a test-first regression test in `ViewerTopBar.test.tsx` for the missing-label case — verified it fails against the old code (renders "page undefined") and passes against the new.
- `IIIFCanvasThumbnail.tsx` has no test coverage today (a known gap, not introduced here) — its fix is covered indirectly by `hasRealLabel`'s existing unit tests in `test/works.test.ts`.
- `yarn tsc`, `yarn eslint` on the changed files, and `yarn jest ViewerTopBar.test.tsx "views/pages/works/work/(IIIFViewer|work.helpers)" test/works.test.ts test/fixtures/iiif hooks/useIIIFProbeService` from `content/webapp` — all green (229 tests).

## Have we considered potential risks?

Low risk. `hasRealLabel` is already shared/tested code from step 10. The only behaviour change is the missing-label case, which was a real bug (visible "page undefined" text), not a regression.
