### PR TITLE
show thumbnails for restricted items to staff

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
@@ -127,7 +127,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
             </>
           )}
 
-          {!isRestricted && (
+          {(!isRestricted || userIsStaffWithRestricted) && (
             <>
               {!hasIconPlaceholder ? (
                 <>

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
@@ -134,7 +134,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
             </>
           )}
 
-          {!isRestricted && (
+          {(!isRestricted || userIsStaffWithRestricted) && (
             <>
               {!shouldShowIconPlaceholder ? (
                 <>


### PR DESCRIPTION
- For #13437

## What does this change?

This PR fixes the thumbnail render condition from !isRestricted to (!isRestricted || userIsStaffWithRestricted), so staff with restricted access actually get to see the thumbnail image for restricted canvases.

Applied to both the legacy/ and refactored/ IIIFCanvasThumbnail.tsx.

## How to test
- log in as staff with restricted access.
- Visit [a restricted items page](https://www-dev.wellcomecollection.org/works/rp9jnamu/items)
- The grid view should show thumbnail images

## Have we considered potential risks?

Small, low-risk permission check with no effect on non-staff users or non-restricted content.