### PR TITLE
Skip the auth0 rolling-session touch on routes that save the session themselves

### DIFF
--- a/identity/webapp/middleware.ts
+++ b/identity/webapp/middleware.ts
@@ -16,8 +16,23 @@ const stripBasePath = (request: NextRequest): string => {
 const isLogoutPath = (request: NextRequest): boolean =>
   stripBasePath(request) === '/api/auth/logout';
 
-const isValidatedPath = (request: NextRequest): boolean =>
-  stripBasePath(request) === '/validated';
+// Routes that save the session themselves, so must not also get
+// auth0.middleware's rolling-session touch:
+//
+//   - /validated refreshes and saves explicitly (see validated.tsx)
+//   - /api/users/* calls getAccessToken, which saves whenever it refreshes
+//     (see pages/api/users/[[...users]].ts)
+//   - /api/auth/me?refetch refreshes and then updates the session (see
+//     pages/api/auth/me.ts); it is ours, not one of the SDK's mounted auth
+//     routes, so skipping the middleware here is safe
+const savesOwnSession = (request: NextRequest): boolean => {
+  const pathname = stripBasePath(request);
+  // Without refetch, /api/auth/me only reads the session, so let it roll.
+  if (pathname === '/api/auth/me') {
+    return request.nextUrl.searchParams.has('refetch');
+  }
+  return pathname === '/validated' || pathname.startsWith('/api/users/');
+};
 
 const isRelative = (returnTo: string): boolean => {
   try {
@@ -70,14 +85,11 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // /validated already does its own explicit session refresh-and-save (see
-  // validated.tsx), so letting auth0.middleware's rolling-session touch run
-  // here too would save the session a second, independent time on the same
-  // request - doubling the Set-Cookie payload and overflowing nginx's
-  // response header buffer (502). Skip it here rather than excluding the
-  // path via the matcher config below, since matcher patterns and basePath
-  // interact in ways that are easy to get wrong silently.
-  if (isValidatedPath(request)) {
+  // Two independent saves on one request double the Set-Cookie payload and
+  // overflow nginx's response header buffer (502). Skipped here rather than
+  // excluded via the matcher config below, since matcher patterns and
+  // basePath interact in ways that are easy to get wrong silently.
+  if (savesOwnSession(request)) {
     return NextResponse.next();
   }
 

--- a/identity/webapp/middleware.ts
+++ b/identity/webapp/middleware.ts
@@ -31,7 +31,11 @@ const savesOwnSession = (request: NextRequest): boolean => {
   if (pathname === '/api/auth/me') {
     return request.nextUrl.searchParams.has('refetch');
   }
-  return pathname === '/validated' || pathname.startsWith('/api/users/');
+  return (
+    pathname === '/validated' ||
+    pathname === '/api/users' ||
+    pathname.startsWith('/api/users/')
+  );
 };
 
 const isRelative = (returnTo: string): boolean => {


### PR DESCRIPTION
## What does this change?

Since the `@auth0/nextjs-auth0` v4 upgrade landed on main on 3 August 2026, nginx has been returning 502s on some identity API routes, with this in the identity nginx logs:

```
upstream sent too big header while reading response header from upstream
```

Confirmed so far on `/account/api/users/me/item-requests` and `/account/api/auth/me?refetch`.

The cause is a double session write. v4's middleware performs a rolling-session touch on every matched request, so any route that also saves the session itself writes it twice on the same response. That doubles the `Set-Cookie` payload, which overflows the 8k `proxy_buffer_size` in the identity nginx config, and nginx answers 502.

This is the same failure that was fixed for `/account/validated` in fa35645177 during the migration. That fix carved out a single path; this generalises it. `isValidatedPath` becomes `savesOwnSession`, which now covers:

- `/validated`, which refreshes and saves explicitly
- `/api/users/*`, the identity API proxy, which calls `getAccessToken` and so saves whenever the token refreshes
- `/api/auth/me`, but only when `refetch` is present, since without it the route just reads the session

`/api/auth/me` is served by `pages/api/auth/me.ts` rather than by the SDK, whose mounted routes are only login, logout and callback, so skipping the middleware for it does not affect the auth routes themselves.

One thing this may not fully fix: `/api/auth/me?refetch` saves the session twice on its own, at `me.ts:25` via `getAccessToken({ refresh: true })` and again at `me.ts:40` via `updateSession`. This change takes that route from three saves to two, and two saves is what overflowed 8k in the first place, so it may keep erroring. Reducing it to a single write needs a change inside that route and is left as a follow-up.

We also considered raising `proxy_buffer_size` from 8k to 16k, and decided against it for now. That config lives in `platform-infrastructure` (`images/dockerfiles/nginx/frontend_identity.nginx.conf`) and changing it means a manual image publish that also republishes the content app's nginx image. The analysis in fa35645177 says two saves *doubled* the payload to exceed 8k, which implies a single save fits comfortably, so the redundant write is the actual defect. Leaving 8k in place also means that if 502s recur we learn about a real second cause rather than masking it.

- Refs #13252

## How to test

The failure needs a logged-in session, since it depends on the session cookie being written.

On PROD, sign in and open the account page. The request to `/account/api/users/me/item-requests` returns 502 and the requested items list fails to render.

On this branch, the same flow returns 200 and the list renders. In devtools, that response should carry at most one set of session `Set-Cookie` chunks rather than two.

Worth checking for regressions, since middleware behaviour changed close to the auth routes:

- login, logout and the Auth0 callback all still work
- the email verification link still lands on `/account/validated` without a 502, which is the path the original fix covered
- changing your email address still works, as that is what calls `/api/auth/me?refetch`

## How can we measure success?

The `upstream sent too big header` error should stop appearing for `/account/api/users/*` in the identity nginx logs in the logging cluster. The 502 rate on the identity target group should drop correspondingly.

If the error persists on `/account/api/auth/me?refetch` specifically, that is the known remaining case described above rather than a failure of this change. If it appears on a route not listed here, that is a fourth instance of the same double-write pattern and wants the same treatment, not a larger buffer.

## Have we considered potential risks?

**The session no longer rolls on these routes.** Requests to the identity API proxy and the refetch call will not extend the 8 hour inactivity window. Page loads still go through the middleware and still roll it, so anyone actively browsing is unaffected, and this is the same tradeoff already accepted for `/validated`. The narrow risk is a user who sits on the account page making only these XHR calls for hours, which I think is unlikely to matter in practice.

**Skipping middleware near the auth routes.** `/api/auth/me` is ours, not SDK-mounted, and the skip is scoped to the `refetch` query so the plain profile fetch that `UserContextProvider` makes across all the webapps is untouched. Login, logout and callback continue through `auth0.middleware`, including the relative `returnTo` handling above the skip.

**Alarms.** This class of bug has now surfaced three times during the v4 migration, counting the `__txn_` cookie pile-up that `enableParallelTransactions: false` addresses and the `/validated` fix. It would be worth confirming whether the identity target group alerts on a 502 rate, since all three were found by reading logs rather than by being paged.
