### PR TITLE
IVR: Extract download options logic from `ViewerTopBar` into `useDownloadOptions`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ All shared code lives in `common/` and is imported using `@weco/` package names,
 Follow these patterns consistently:
 - Component files: PascalCase (`Header.tsx`, `PageLayout.tsx`)
 - Utility files: kebab-case (`undici-agent.ts`, `json-ld.ts`)
-- Test files: same name as source with `.test.ts` / `.test.tsx` suffix (match the source extension, e.g. `Component.tsx` → `Component.test.tsx`)
+- Test files: same name as source with `.test.ts` / `.test.tsx` suffix (match the source extension, e.g. `Component.tsx` → `Component.test.tsx`) - except when the test itself needs JSX (e.g. a context-provider wrapper for a hook test), which takes `.tsx` regardless of the source file's own extension
 - Type declarations: `.d.ts` extension for ambient declarations
 - Service/utility folders: use `index.ts` as the main export point
 

--- a/content/webapp/hooks/useDownloadOptions.test.tsx
+++ b/content/webapp/hooks/useDownloadOptions.test.tsx
@@ -1,0 +1,257 @@
+import { renderHook } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { DigitalLocation } from '@weco/common/model/catalogue';
+import ItemViewerContextRefactored, {
+  defaultItemViewerContext,
+  ItemViewerContextProps,
+} from '@weco/content/contexts/ItemViewerContext/refactored';
+import {
+  createMockCanvas,
+  createMockManifest,
+} from '@weco/content/test/fixtures/iiif/transformed-manifest';
+import { TransformedCanvas } from '@weco/content/types/manifest';
+
+import useDownloadOptions from './useDownloadOptions';
+
+// useDownloadOptions combines every source of downloadable files for the
+// current canvas/manifest into one deduplicated list, extracted from
+// ViewerTopBar.tsx (which still has its own "download button" tests covering
+// the on-screen behaviour - these characterise the hook's own logic directly).
+
+const mockDigitalLocation = (url: string): DigitalLocation => ({
+  locationType: { id: 'iiif-image', label: '', type: 'LocationType' },
+  url,
+  license: { id: 'cc-by', label: '', url: '', type: 'License' },
+  accessConditions: [],
+  type: 'DigitalLocation',
+});
+
+const imageService = (overrides: Record<string, unknown> = {}) => ({
+  '@id': 'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2',
+  '@type': 'ImageService2',
+  width: 1000,
+  height: 1400,
+  ...overrides,
+});
+
+const paintingWithImageService = (
+  overrides: Record<string, unknown> = {}
+): TransformedCanvas['painting'][number] =>
+  ({
+    id: 'https://example.com/image/open',
+    type: 'Image',
+    service: [imageService()],
+    ...overrides,
+  }) as unknown as TransformedCanvas['painting'][number];
+
+// A mutable context value the Wrapper below reads fresh on every render, so
+// tests can vary it across a rerender() call (renderHook's `wrapper` is fixed
+// at setup time and never receives rerender's props directly).
+let mockContextValue: ItemViewerContextProps = defaultItemViewerContext;
+
+const Wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+  <ItemViewerContextRefactored.Provider value={mockContextValue}>
+    {children}
+  </ItemViewerContextRefactored.Provider>
+);
+
+function renderDownloadOptions(
+  contextValue: Partial<ItemViewerContextProps>,
+  iiifImageLocation?: DigitalLocation
+) {
+  mockContextValue = { ...defaultItemViewerContext, ...contextValue };
+  return renderHook(
+    ({ iiifImageLocation }: { iiifImageLocation?: DigitalLocation }) =>
+      useDownloadOptions(iiifImageLocation),
+    { wrapper: Wrapper, initialProps: { iiifImageLocation } }
+  );
+}
+
+describe('useDownloadOptions', () => {
+  it('returns an empty array when there is no canvas or manifest', () => {
+    const { result } = renderDownloadOptions({
+      currentCanvas: undefined,
+      transformedManifest: undefined,
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('includes IIIF image download options when given an iiifImageLocation', () => {
+    const { result } = renderDownloadOptions(
+      { currentCanvas: undefined, transformedManifest: undefined },
+      mockDigitalLocation(
+        'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2'
+      )
+    );
+
+    expect(result.current).toEqual([
+      expect.objectContaining({ label: expect.stringContaining('image') }),
+      expect.objectContaining({ label: expect.stringContaining('image') }),
+    ]);
+  });
+
+  it('includes canvas image downloads from the painting image service', () => {
+    const { result } = renderDownloadOptions({
+      currentCanvas: createMockCanvas({
+        painting: [paintingWithImageService()],
+      }),
+    });
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        id: 'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2/full/full/0/default.jpg',
+      }),
+      expect.objectContaining({
+        id: 'https://iiif.wellcomecollection.org/image/b00000000_0001.jp2/full/760%2C/0/default.jpg',
+      }),
+    ]);
+  });
+
+  it('resolves the image service through a ChoiceBody painting item', () => {
+    const { result } = renderDownloadOptions({
+      currentCanvas: createMockCanvas({
+        painting: [
+          {
+            type: 'Choice',
+            items: [paintingWithImageService()],
+          } as unknown as TransformedCanvas['painting'][number],
+        ],
+      }),
+    });
+
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('includes canvas rendering downloads (e.g. PDFs)', () => {
+    const { result } = renderDownloadOptions({
+      currentCanvas: createMockCanvas({
+        rendering: [
+          {
+            id: 'https://example.com/whole.pdf',
+            type: 'Text',
+            format: 'application/pdf',
+          },
+        ] as unknown as TransformedCanvas['rendering'],
+      }),
+    });
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        id: 'https://example.com/whole.pdf',
+        format: 'application/pdf',
+      }),
+    ]);
+  });
+
+  it('includes manifest-level rendering downloads', () => {
+    const { result } = renderDownloadOptions({
+      transformedManifest: createMockManifest({
+        rendering: [
+          {
+            id: 'https://example.com/manifest-download.pdf',
+            type: 'Text',
+            format: 'application/pdf',
+          },
+        ],
+      }),
+    });
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        id: 'https://example.com/manifest-download.pdf',
+      }),
+    ]);
+  });
+
+  it('includes video/audio downloads from the painting items', () => {
+    const { result } = renderDownloadOptions({
+      currentCanvas: createMockCanvas({
+        painting: [
+          {
+            id: 'https://example.com/video.mp4',
+            type: 'Video',
+            format: 'video/mp4',
+          } as unknown as TransformedCanvas['painting'][number],
+        ],
+      }),
+    });
+
+    expect(result.current).toEqual([
+      expect.objectContaining({
+        id: 'https://example.com/video.mp4',
+        label: 'This video',
+      }),
+    ]);
+  });
+
+  it('deduplicates download options that share the same id across sources', () => {
+    const sharedId = 'https://example.com/duplicated.pdf';
+    const { result } = renderDownloadOptions({
+      currentCanvas: createMockCanvas({
+        rendering: [
+          { id: sharedId, type: 'Text', format: 'application/pdf' },
+        ] as unknown as TransformedCanvas['rendering'],
+      }),
+      transformedManifest: createMockManifest({
+        rendering: [{ id: sharedId, type: 'Text', format: 'application/pdf' }],
+      }),
+    });
+
+    expect(result.current).toHaveLength(1);
+  });
+
+  describe('memoisation', () => {
+    const canvasWithRendering = () =>
+      createMockCanvas({
+        rendering: [
+          {
+            id: 'https://example.com/whole.pdf',
+            type: 'Text',
+            format: 'application/pdf',
+          },
+        ] as unknown as TransformedCanvas['rendering'],
+      });
+
+    it('returns the same array reference across a rerender with unchanged inputs', () => {
+      mockContextValue = {
+        ...defaultItemViewerContext,
+        currentCanvas: canvasWithRendering(),
+      };
+      const { result, rerender } = renderHook(
+        ({ iiifImageLocation }: { iiifImageLocation?: DigitalLocation }) =>
+          useDownloadOptions(iiifImageLocation),
+        { wrapper: Wrapper, initialProps: { iiifImageLocation: undefined } }
+      );
+
+      const firstResult = result.current;
+      rerender({ iiifImageLocation: undefined });
+
+      expect(result.current).toBe(firstResult);
+    });
+
+    it('recalculates when the current canvas changes', () => {
+      mockContextValue = {
+        ...defaultItemViewerContext,
+        currentCanvas: canvasWithRendering(),
+      };
+      const { result, rerender } = renderHook(
+        ({ iiifImageLocation }: { iiifImageLocation?: DigitalLocation }) =>
+          useDownloadOptions(iiifImageLocation),
+        { wrapper: Wrapper, initialProps: { iiifImageLocation: undefined } }
+      );
+
+      const firstResult = result.current;
+
+      mockContextValue = {
+        ...mockContextValue,
+        currentCanvas: createMockCanvas({ rendering: [] }),
+      };
+      rerender({ iiifImageLocation: undefined });
+
+      expect(result.current).not.toBe(firstResult);
+      expect(result.current).toEqual([]);
+    });
+  });
+});

--- a/content/webapp/hooks/useDownloadOptions.ts
+++ b/content/webapp/hooks/useDownloadOptions.ts
@@ -1,0 +1,106 @@
+import { ChoiceBody, ImageService } from '@iiif/presentation-3';
+import { useMemo } from 'react';
+
+import { DigitalLocation } from '@weco/common/model/catalogue';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
+import { DownloadOption } from '@weco/content/types/manifest';
+import {
+  deduplicateDownloadOptions,
+  getDownloadOptionsFromCanvasRenderingAndSupplementing,
+  getDownloadOptionsFromManifestRendering,
+  getImageServiceFromItem,
+  getVideoAudioDownloadOptions,
+  isChoiceBody,
+} from '@weco/content/utils/iiif/v3';
+import { getDownloadOptionsFromImageUrl } from '@weco/content/utils/works';
+
+import useTransformedIIIFImage from './useTransformedIIIFImage';
+
+/**
+ * Works can have a DigitalLocation of type iiif-presentation and/or
+ * iiif-image. For a iiif-presentation DigitalLocation we get the download
+ * options from the manifest to which it points. For a iiif-image
+ * DigitalLocation we create the download options from a combination of the
+ * DigitalLocation and the iiif-image json to which it points - the json
+ * provides the image width and height used in the link text, fetched client
+ * side via useTransformedIIIFImage since it isn't vital to rendering the
+ * links. Sometimes we render images for works that have neither location
+ * type - iiifImageLocation covers that case, passed from the /images.tsx
+ * page's getServerSideProps.
+ */
+export function useDownloadOptions(
+  iiifImageLocation?: DigitalLocation
+): DownloadOption[] {
+  const { work, currentCanvas, transformedManifest } = useItemViewerContext();
+  const transformedIIIFImage = useTransformedIIIFImage(work);
+  const { rendering } = { ...transformedManifest };
+
+  return useMemo(() => {
+    const imageServices = (currentCanvas?.painting
+      .map(p => {
+        if (isChoiceBody(p)) {
+          return p.items.map(item =>
+            getImageServiceFromItem(item as unknown as ChoiceBody)
+          );
+        } else {
+          return getImageServiceFromItem(p);
+        }
+      })
+      .flat()
+      .filter(Boolean) || []) as ImageService[];
+
+    const iiifImageDownloadOptions = iiifImageLocation
+      ? getDownloadOptionsFromImageUrl({
+          url: iiifImageLocation.url,
+          width: transformedIIIFImage.width,
+          height: transformedIIIFImage.height,
+        })
+      : [];
+
+    // We also want to offer download options for each canvas image
+    // in the iiif-presentation manifest when it is being viewed.
+    const canvasImageDownloads = imageServices
+      .map(imageService => {
+        if (imageService['@id']) {
+          return getDownloadOptionsFromImageUrl({
+            url: imageService['@id'],
+            width: imageService.width || undefined,
+            height: imageService.height || undefined,
+          });
+        } else {
+          return [];
+        }
+      })
+      .flat()
+      .filter(Boolean);
+
+    const canvasDownloadOptions = currentCanvas
+      ? getDownloadOptionsFromCanvasRenderingAndSupplementing(currentCanvas)
+      : [];
+
+    const manifestDownloadOptions =
+      getDownloadOptionsFromManifestRendering(rendering);
+
+    const videoAudioDownloadOptions =
+      getVideoAudioDownloadOptions(currentCanvas);
+
+    // We need multiple sources for downloads to cover the different
+    // ways in which a download can be made available in a iiif manifest.
+    // The same file can appear in multiple sources, so we deduplicate by id.
+    return deduplicateDownloadOptions([
+      ...iiifImageDownloadOptions,
+      ...canvasImageDownloads,
+      ...canvasDownloadOptions,
+      ...manifestDownloadOptions,
+      ...videoAudioDownloadOptions,
+    ]);
+  }, [
+    currentCanvas,
+    rendering,
+    iiifImageLocation,
+    transformedIIIFImage.width,
+    transformedIIIFImage.height,
+  ]);
+}
+
+export default useDownloadOptions;

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/ViewerTopBar.tsx
@@ -1,4 +1,3 @@
-import { ChoiceBody, ImageService } from '@iiif/presentation-3';
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
@@ -12,20 +11,9 @@ import { OptionalToUndefined } from '@weco/common/utils/utility-types';
 import Icon from '@weco/common/views/components/Icon';
 import Space from '@weco/common/views/components/styled/Space';
 import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext/refactored';
+import useDownloadOptions from '@weco/content/hooks/useDownloadOptions';
 import useIsFullscreenEnabled from '@weco/content/hooks/useIsFullscreenEnabled';
-import useTransformedIIIFImage from '@weco/content/hooks/useTransformedIIIFImage';
-import {
-  deduplicateDownloadOptions,
-  getDownloadOptionsFromCanvasRenderingAndSupplementing,
-  getDownloadOptionsFromManifestRendering,
-  getImageServiceFromItem,
-  getVideoAudioDownloadOptions,
-  isChoiceBody,
-} from '@weco/content/utils/iiif/v3';
-import {
-  getDownloadOptionsFromImageUrl,
-  hasRealLabel,
-} from '@weco/content/utils/works';
+import { hasRealLabel } from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
 
 import CanvasPositionIndicator from './CanvasPositionIndicator';
@@ -143,96 +131,27 @@ const ViewerTopBar: FunctionComponent<ViewerTopBarProps> = ({
   const {
     gridVisible,
     setGridVisible,
-    work,
     isMobileSidebarActive,
     setIsMobileSidebarActive,
     isDesktopSidebarActive,
     setIsDesktopSidebarActive,
     showZoomed,
     isResizing,
-    transformedManifest,
     showFullscreenControl,
     hasOnlyRenderableImages,
     currentCanvas,
     isCurrentCanvasRestricted,
     hasMultipleCanvases,
   } = useItemViewerContext();
-  const transformedIIIFImage = useTransformedIIIFImage(work);
   const { userIsStaffWithRestricted } = useUserContext();
+  const downloadOptions = useDownloadOptions(iiifImageLocation);
 
-  const { rendering } = { ...transformedManifest };
-  const imageServices = (currentCanvas?.painting
-    .map(p => {
-      if (isChoiceBody(p)) {
-        return p.items.map(item =>
-          getImageServiceFromItem(item as unknown as ChoiceBody)
-        );
-      } else {
-        return getImageServiceFromItem(p);
-      }
-    })
-    .flat()
-    .filter(Boolean) || []) as ImageService[];
   const currentPageLabel = currentCanvas?.label?.trim();
 
   const shouldShowViewToggle =
     !showZoomed && hasMultipleCanvases && isFullSupportBrowser;
   const shouldShowPageIndicator =
     hasMultipleCanvases && !showZoomed && !isResizing;
-
-  // Works can have a DigitalLocation of type iiif-presentation and/or iiif-image.
-  // For a iiif-presentation DigitalLocation we get the download options from the manifest to which it points.
-  // For a iiif-image DigitalLocation we create the download options
-  // from a combination of the DigitalLocation and the iiif-image json to which it points.
-  // The json provides the image width and height used in the link text.
-  // Since this isn't vital to rendering the links, the useTransformedIIIFImage hook
-  // gets this data client side.
-  // Sometimes we render images for works that have neither a iiif-image or a iiif-presentation location type.
-  // In this case we use the iiifImageLocation passed from the serverSideProps of the /images.tsx
-  const iiifImageDownloadOptions = iiifImageLocation
-    ? getDownloadOptionsFromImageUrl({
-        url: iiifImageLocation.url,
-        width: transformedIIIFImage.width,
-        height: transformedIIIFImage.height,
-      })
-    : [];
-
-  // We also want to offer download options for each canvas image
-  // in the iiif-presentation manifest when it is being viewed.
-  const canvasImageDownloads = imageServices
-    .map(imageService => {
-      if (imageService['@id']) {
-        return getDownloadOptionsFromImageUrl({
-          url: imageService['@id'],
-          width: imageService.width || undefined,
-          height: imageService.height || undefined,
-        });
-      } else {
-        return [];
-      }
-    })
-    .flat()
-    .filter(Boolean);
-
-  const canvasDownloadOptions = currentCanvas
-    ? getDownloadOptionsFromCanvasRenderingAndSupplementing(currentCanvas)
-    : [];
-
-  const manifestDownloadOptions =
-    getDownloadOptionsFromManifestRendering(rendering);
-
-  const videoAudioDownloadOptions = getVideoAudioDownloadOptions(currentCanvas);
-
-  // We need multiple sources for downloads to cover the different
-  // ways in which a download can be made available in a iiif manifest.
-  // The same file can appear in multiple sources, so we deduplicate by id.
-  const downloadOptions = deduplicateDownloadOptions([
-    ...iiifImageDownloadOptions,
-    ...canvasImageDownloads,
-    ...canvasDownloadOptions,
-    ...manifestDownloadOptions,
-    ...videoAudioDownloadOptions,
-  ]);
 
   return (
     <TopBar


### PR DESCRIPTION
- For #12987

## What does this change?

Extracts the download-options calculation out of `ViewerTopBar.tsx` into a new `useDownloadOptions` hook (`content/webapp/hooks/useDownloadOptions.ts`), per [RFC 086 Phase 4](https://github.com/wellcomecollection/docs/blob/main/rfcs/086-item-viewer-refactor/10-phase-4-download-logic.md).

`ViewerTopBar.tsx` had ~70 lines of business logic inline: combining IIIF image downloads, canvas image downloads (from image services, including ChoiceBody items), canvas rendering/supplementing downloads (PDFs etc), manifest-level downloads, and video/audio downloads, then deduplicating them by id. None of it was testable without rendering the whole component. It's now a hook with its own direct unit tests, and `ViewerTopBar.tsx` just calls `useDownloadOptions(iiifImageLocation)`.

This is a pure extraction - no behaviour change. The calculation itself is untouched, just moved.

## How to test

Automated:
- `useDownloadOptions.test.tsx` (new) covers each download source directly: empty case, IIIF image downloads, canvas image downloads (including via a ChoiceBody), canvas rendering downloads, manifest rendering downloads, video/audio downloads, deduplication across sources, and memoisation (unchanged inputs return the same array reference; a changed canvas recalculates).
- `ViewerTopBar.test.tsx`'s existing "download button" tests are unchanged and still pass, confirming on-screen behaviour is identical.
- `yarn tsc` and `yarn eslint` clean.

Manual, with the `itemViewerRefactor` toggle on:
- On PROD/www-dev, open a work with downloads available (e.g. [adhnsmj4](https://www-dev.wellcomecollection.org/works/adhnsmj4/items), born-digital with downloads and [a2239muq](https://www-dev.wellcomecollection.org/works/adhnsmj4/items), regular work with downloads) and confirm the download dropdown still lists the same options as before this change.
- Navigate between canvases/pages and confirm the download options update to match.

## Have we considered potential risks?

Low risk - the calculation logic itself wasn't touched, only moved into a hook, and the existing component-level download tests pass unchanged. The main risk would be a dependency missed from the `useMemo` array inside the hook, causing stale download options after navigating - covered by the new memoisation test and the manual canvas-navigation check above. No new alarms needed for this.
