### PR TITLE
Compute GridViewer's current-canvas index once instead of per cell

### DIFF
--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.test.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+
+import { ItemViewerContextProps } from '@weco/content/contexts/ItemViewerContext/refactored';
+import { renderWithContext } from '@weco/content/test/fixtures/iiif/render';
+import {
+  createMockCanvas,
+  createMockManifest,
+  createMockQuery,
+} from '@weco/content/test/fixtures/iiif/transformed-manifest';
+
+import GridViewer from './GridViewer';
+
+// The refactored components read from ItemViewerContextRefactored via the
+// useItemViewerContext hook, which checks the feature flag. Mock it so the
+// hook returns the refactored context values.
+jest.mock('@weco/common/server-data/Context', () => ({
+  ...jest.requireActual('@weco/common/server-data/Context'),
+  useFeatureFlags: () => ({ itemViewerRefactor: true }),
+}));
+
+const renderGrid = (contextProps: Partial<ItemViewerContextProps> = {}) =>
+  renderWithContext(<GridViewer />, {
+    contextProps,
+    useRefactoredContext: true,
+  });
+
+describe('GridViewer', () => {
+  it('marks only the cell for the current canvas as aria-current', () => {
+    renderGrid({
+      transformedManifest: createMockManifest({
+        canvases: [
+          createMockCanvas({ id: 'a' }),
+          createMockCanvas({ id: 'b' }),
+          createMockCanvas({ id: 'c' }),
+        ],
+      }),
+      query: createMockQuery({ canvas: 2 }),
+    });
+
+    const links = screen.getAllByRole('link');
+    const current = links.filter(
+      link => link.getAttribute('aria-current') === 'true'
+    );
+
+    expect(current).toHaveLength(1);
+    expect(current[0]).toHaveAttribute(
+      'href',
+      expect.stringContaining('canvas=2')
+    );
+  });
+});

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/GridViewer.tsx
@@ -41,6 +41,7 @@ type CellProps = GridChildComponentProps<{
   query: ItemViewerQuery;
   workId: string;
   placeholderId?: string;
+  currentCanvasIndex: number;
 }>;
 
 const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
@@ -54,6 +55,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
     query,
     workId,
     placeholderId,
+    currentCanvasIndex,
   } = data;
   const canvasIndex = rowIndex * columnCount + columnIndex;
   const currentCanvas = canvases[canvasIndex];
@@ -85,9 +87,7 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }: CellProps) => {
                   shouldScrollToCanvas: true,
                 },
               })}
-              aria-current={
-                canvasIndex === queryParamToArrayIndex(query.canvas)
-              }
+              aria-current={canvasIndex === currentCanvasIndex}
               onClick={() => {
                 setGridVisible(false);
               }}
@@ -143,13 +143,12 @@ const GridViewer: FunctionComponent = () => {
   const columnCount = Math.max(1, Math.round(mainAreaWidth / itemWidth)); // ensure at least one column is displayed
   const columnWidth = mainAreaWidth / columnCount;
   const canvases = transformedManifest?.canvases;
+  const currentCanvasIndex = queryParamToArrayIndex(query.canvas);
 
   useEffect(() => {
-    const rowIndex = Math.floor(
-      queryParamToArrayIndex(query.canvas) / columnCount
-    );
+    const rowIndex = Math.floor(currentCanvasIndex / columnCount);
     grid.current?.scrollToItem({ align: 'start', rowIndex });
-  }, [query.canvas]);
+  }, [currentCanvasIndex]);
 
   useEffect(() => {
     // required to be set as we are setting the body to overflow hidden to stop multiple scrolls in view bug issue.
@@ -190,6 +189,7 @@ const GridViewer: FunctionComponent = () => {
           query,
           workId: work.id,
           placeholderId: transformedManifest?.placeholderId,
+          currentCanvasIndex,
         }}
         onScroll={({ scrollTop }) => setScrollOffset(scrollTop)}
         ref={grid}


### PR DESCRIPTION
- For #12989

## What does this change?

Ticket #12989 asked us to review the item-viewer refactor for anything that should be centralised in context but isn't, and any remaining duplicate calculations. The RFC's own suggested file/line examples turned out to be stale, but the sweep turned up one real instance: `GridViewer.tsx`'s `Cell` component recomputed `queryParamToArrayIndex(query.canvas)` independently, once per rendered grid cell, to decide its own `aria-current` - duplicating the identical calculation the parent `GridViewer` already does for its scroll-to-item effect.

Computed it once in `GridViewer` and passed it down via `itemData` as `currentCanvasIndex` instead. Pure refactor, no behaviour change.

Everything else the sweep found (a same-named `currentCanvas` local variable in `GridViewer`'s `Cell` and `VirtualizedImageViewer`'s `ItemRenderer`, a first-canvas-specific restriction check, a video-specific fullscreen guard in `IIIFViewer.tsx`) turned out to be legitimately different logic under a coincidentally similar name, not actual duplication - so left alone.

## How to test

- `GridViewer.test.tsx` is new (this component had no tests before) - it characterises the current behaviour (only the cell for the current canvas gets `aria-current`) as a regression net.
- `yarn tsc` and `yarn eslint` clean.
- Manual, with `itemViewerRefactor` on: [open a multi-page work](https://www-dev.wellcomecollection.org/works/a2239muq/items), switch to grid view, confirm the current page's thumbnail is still the one visually/aria marked as current, and that navigating to a different page still scrolls the grid to the right row.

## Have we considered potential risks?

Low risk - this only changes where a value is calculated, not what it calculates. The main risk would be the `itemData` change silently breaking `Cell`'s memoisation (it's wrapped in `React.memo`/`areEqual`), but `currentCanvasIndex` is a plain number alongside the other primitives/objects already passed through `itemData`, so it behaves the same way as `query`/`workId` already did.
