### PR TITLE
Add GA tracking to archive collection contents tree

### DIFF
--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Contents.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Contents.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from '@weco/common/contexts/AppContext';
 import { treeInstructions } from '@weco/common/data/microcopy';
 import { plus } from '@weco/common/icons';
 import { useFeatureFlags, useModes } from '@weco/common/server-data/Context';
+import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import { Work } from '@weco/content/services/wellcome/catalogue/types';
 import {
@@ -182,6 +183,9 @@ const ArchiveCollectionContents: FunctionComponent<{
                         <ShowMoreButton
                           onClick={showMore}
                           disabled={isLoadingMore}
+                          {...dataGtmPropsToAttributes({
+                            trigger: 'show_more_rows_content_tree',
+                          })}
                         >
                           <Icon
                             icon={plus}

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
@@ -104,8 +104,9 @@ const ContentsTreeItemRenderer: FunctionComponent<
                 }}
                 tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
                 {...dataGtmPropsToAttributes({
-                  trigger: 'contents_tree_link',
+                  trigger: 'tree_link',
                   label: `${data.title}${data.referenceNumber ? ` (${data.referenceNumber})` : ''}`,
+                  'data-tree-level': String(level),
                 })}
               >
                 <WorkTitle title={data.title} />


### PR DESCRIPTION
- For #13414

## What does this change?

Two GA tracking additions to the archive collection page's contents tree, both requested in #13414.

The contents tree links now use the same tracking attributes as the existing sidebar ArchiveTree, so clicks on either are captured by the same GTM tag. The trigger becomes `tree_link` rather than `contents_tree_link`, `data-gtm-label` stays as it was, and `data-gtm-data-tree-level` is added (the renderer already receives `level`, so nothing needed plumbing through).

The show more rows button now carries `data-gtm-trigger="show_more_rows_content_tree"`, which it didn't have at all, so clicks on it weren't trackable.

Two things worth confirming on the GTM side:

- [x] ~The `tree_link` trigger needs to match the contents tree markup, not just the sidebar tree. Renaming the trigger here is necessary but may not be sufficient if the container's selector is scoped to the sidebar.~
- [x] `show_more_rows_content_tree` presumably needs a trigger creating (cc @mankeetn).

## How to test

The archive collection page is behind the `archiveCollection` feature flag, and you need a collection with more than 50 rows for the show more button to appear.

On this branch, visit `/works/w8435m6c?toggle=archiveCollection` (Arts for Health archive, 1014 rows) and open the "Collection contents" tab — the tree is fetched client-side when the tab becomes active, so nothing renders until you do.

Inspect a tree link and check it has `data-gtm-trigger="tree_link"`, a populated `data-gtm-label`, and a `data-gtm-data-tree-level` matching its nesting depth. On PROD the same links have `data-gtm-trigger="contents_tree_link"` and no tree level. Or in the console:

```js
const panel = document.getElementById('tabpanel-contents');
[...panel.querySelectorAll('a[data-gtm-trigger]')].slice(0, 5).map(el => ({
  trigger: el.getAttribute('data-gtm-trigger'),
  label: el.getAttribute('data-gtm-label'),
  level: el.getAttribute('data-gtm-data-tree-level'),
}));
```

Then check the show more button has `data-gtm-trigger="show_more_rows_content_tree"` (absent on PROD), click it, and re-run the link check to confirm the newly loaded rows carry the attributes too.

For the end-to-end check, connect Tag Assistant to www-stage once this is merged and confirm the `tree_link` tag fires on a contents tree link with the label and level coming through. Accept analytics cookies first — the consent default is `analytics_storage: denied`, which can stop the GA4 tag sending even when the trigger fires.

I've verified the DOM side locally: all tree links render the three attributes with levels 1-4 matching depth, the button carries its trigger, and after clicking show more all 100 loaded rows still have the full set.

## Have we considered potential risks?

Low risk. These are additive `data-*` attributes plus one renamed attribute value, with no change to markup structure, behaviour or styling.
