### PR TITLE
Archive root page tweaks 2

### DIFF
--- a/common/views/themes/config.ts
+++ b/common/views/themes/config.ts
@@ -312,6 +312,12 @@ const slateTransparentBlack: ButtonColors = {
   text: 'black',
 };
 
+const slateWhiteBlack: ButtonColors = {
+  border: 'neutral.600',
+  background: 'white',
+  text: 'black',
+};
+
 export type Size = keyof typeof sizes;
 
 // Factory functions that create media query helpers with specific sizes
@@ -527,6 +533,7 @@ export const themeValues = {
     whiteWhiteCharcoal,
     silverTransparentBlack,
     slateTransparentBlack,
+    slateWhiteBlack,
     greenGreenWhite,
   },
   spacedTextTopMargin: '1.55em',

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.About.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.About.tsx
@@ -18,15 +18,6 @@ import WorkDetailsText from '@weco/content/views/pages/works/work/WorkDetails/Wo
 const mainSizeMap: SizeMap = { s: [12], m: [12], l: [8], xl: [8] };
 const sideSizeMap: SizeMap = { s: [12], m: [12], l: [4], xl: [4] };
 
-const DesktopOnlyDivider = styled.div`
-  display: none;
-
-  ${props =>
-    props.theme.media('md')(`
-      display: block;
-    `)}
-`;
-
 const SideColumn = styled(GridCell)`
   order: -1;
 
@@ -109,10 +100,6 @@ const ArchiveCollectionAbout: FunctionComponent<{ work: WorkType }> = ({
           />
         </div>
       </WorkDetailsSection>
-
-      <DesktopOnlyDivider>
-        <Divider />
-      </DesktopOnlyDivider>
     </>
   );
 };

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
@@ -2,7 +2,13 @@ import NextLink from 'next/link';
 import { FunctionComponent } from 'react';
 
 import { useAppContext } from '@weco/common/contexts/AppContext';
-import { chevron, closedFolder, file, openFolder } from '@weco/common/icons';
+import {
+  archive,
+  chevron,
+  closedFolder,
+  file,
+  openFolder,
+} from '@weco/common/icons';
 import { dataGtmPropsToAttributes } from '@weco/common/utils/gtm';
 import Icon from '@weco/common/views/components/Icon';
 import { toWorkLink } from '@weco/content/views/components/WorkLink';
@@ -57,11 +63,16 @@ const ContentsTreeItemRenderer: FunctionComponent<
   const indentPx =
     level > 1 ? (level - 1) * compactControlDimensions.controlWidth : 0;
   const rowIndex = rowIndexById?.[data.id];
-  const typeIcon = hasControl
-    ? item.openStatus
-      ? openFolder
-      : closedFolder
-    : file;
+  // The collection root (level 1) represents the archive as a whole, so it
+  // gets the archive icon instead of the folder/file icons used for its contents.
+  const typeIcon =
+    level === 1
+      ? archive
+      : hasControl
+        ? item.openStatus
+          ? openFolder
+          : closedFolder
+        : file;
 
   return (
     <ContentsTable

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Hero.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Hero.tsx
@@ -133,9 +133,7 @@ const ArchiveCollectionHero = ({ work }: { work: WorkType }) => {
                 label="Subjects"
                 value={
                   <WorkDetailsTags
-                    buttonColors={
-                      themeValues.buttonColors.charcoalWhiteCharcoal
-                    }
+                    buttonColors={themeValues.buttonColors.slateWhiteBlack}
                     tags={subjectTags}
                   />
                 }

--- a/content/webapp/views/pages/works/work/NestedList/NestedList.helpers.tsx
+++ b/content/webapp/views/pages/works/work/NestedList/NestedList.helpers.tsx
@@ -96,8 +96,11 @@ export function updateChildren({
 // The API's `type` field for an archive work is either the generic 'Work'
 // (the leaf/item level) or a specific archive level (Collection/Series/
 // Section); this maps it to the label shown/announced for a tree row.
+// 'Series' is shown as 'Section' since, to users, they work the same way.
 export function getWorkLevelLabel(type: TreeDataWork['type']): string {
-  return type === 'Work' ? 'Item' : type;
+  if (type === 'Work') return 'Item';
+  if (type === 'Series') return 'Section';
+  return type;
 }
 
 export function getAriaLabel(item: UiTreeNode) {


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13321

## What does this change?

Some more tweaks to the archive collection work page following QA.

Covers the follwing:

- Can we change the subjects border colour to #6a6a6a (neutral cool 600) so its slightly less heavy and matches tag styling in the headers on concept pages

- Collection contents - first item (collection root) should use the archive box icon instead of folder (apologies I realised the designs only show this on the desktop version)

- Level - this should be Collection, Section or Item. Works currently listed as 'series' should be section as to the user these work in the same way

- Can we remove the bottom line underneath the Permanent link - looking at this now on prod I think it looks a bit odd

## How to test

- View an [archive collection work page](https://www-dev.wellcomecollection.org/works/gttrgcys#contents):
- Check the above

## Have we considered potential risks?

Low risk, presentational tweaks scoped to the archive collection pages
