### PR TITLE
IVR: rename `isPDFCanvas`

### DIFF
--- a/content/webapp/test/utils/iiif.test.ts
+++ b/content/webapp/test/utils/iiif.test.ts
@@ -16,7 +16,7 @@ import {
   getOriginalFiles,
   getTransformedCanvases,
   groupRanges,
-  isPDFCanvas,
+  isPrimaryContentPDF,
 } from '@weco/content/utils/iiif/v3';
 
 const canvases = getTransformedCanvases(manifest as Manifest);
@@ -241,14 +241,14 @@ describe('Determines if a iiif-manifest includes non standard items', () => {
   });
 });
 
-describe('isPDFCanvas', () => {
+describe('isPrimaryContentPDF', () => {
   it('returns false for undefined canvas', () => {
-    expect(isPDFCanvas(undefined)).toBe(false);
+    expect(isPrimaryContentPDF(undefined)).toBe(false);
   });
 
   it('returns false for canvas with no PDF content', () => {
     const canvas = createMockCanvas();
-    expect(isPDFCanvas(canvas)).toBe(false);
+    expect(isPrimaryContentPDF(canvas)).toBe(false);
   });
 
   it('returns true for born digital PDF with application/pdf in original', () => {
@@ -262,7 +262,7 @@ describe('isPDFCanvas', () => {
         },
       ],
     });
-    expect(isPDFCanvas(canvas)).toBe(true);
+    expect(isPrimaryContentPDF(canvas)).toBe(true);
   });
 
   it('returns true for PDF supplement with no paintings', () => {
@@ -276,7 +276,7 @@ describe('isPDFCanvas', () => {
       ],
       painting: [],
     });
-    expect(isPDFCanvas(canvas)).toBe(true);
+    expect(isPrimaryContentPDF(canvas)).toBe(true);
   });
 
   it('returns false for PDF supplement with paintings (e.g., video with PDF transcript)', () => {
@@ -296,7 +296,7 @@ describe('isPDFCanvas', () => {
         },
       ],
     });
-    expect(isPDFCanvas(canvas)).toBe(false);
+    expect(isPrimaryContentPDF(canvas)).toBe(false);
   });
 
   it('returns true for PDF supplement with ChoiceBody containing PDF', () => {
@@ -315,7 +315,7 @@ describe('isPDFCanvas', () => {
       ],
       painting: [],
     });
-    expect(isPDFCanvas(canvas)).toBe(true);
+    expect(isPrimaryContentPDF(canvas)).toBe(true);
   });
 
   it('returns false for ChoiceBody with string items', () => {
@@ -328,7 +328,7 @@ describe('isPDFCanvas', () => {
       ],
       painting: [],
     });
-    expect(isPDFCanvas(canvas)).toBe(false);
+    expect(isPrimaryContentPDF(canvas)).toBe(false);
   });
 
   it('returns false for ChoiceBody with non-PDF items', () => {
@@ -347,7 +347,7 @@ describe('isPDFCanvas', () => {
       ],
       painting: [],
     });
-    expect(isPDFCanvas(canvas)).toBe(false);
+    expect(isPrimaryContentPDF(canvas)).toBe(false);
   });
 
   it('returns true for born digital PDF even with paintings', () => {
@@ -368,7 +368,7 @@ describe('isPDFCanvas', () => {
         },
       ],
     });
-    expect(isPDFCanvas(canvas)).toBe(true);
+    expect(isPrimaryContentPDF(canvas)).toBe(true);
   });
 
   it('returns false for supplement without format property', () => {
@@ -381,7 +381,7 @@ describe('isPDFCanvas', () => {
       ],
       painting: [],
     });
-    expect(isPDFCanvas(canvas)).toBe(false);
+    expect(isPrimaryContentPDF(canvas)).toBe(false);
   });
 });
 

--- a/content/webapp/test/utils/iiif.test.ts
+++ b/content/webapp/test/utils/iiif.test.ts
@@ -16,7 +16,7 @@ import {
   getOriginalFiles,
   getTransformedCanvases,
   groupRanges,
-  isPrimaryContentPDF,
+  shouldTreatAsPDFCanvas,
 } from '@weco/content/utils/iiif/v3';
 
 const canvases = getTransformedCanvases(manifest as Manifest);
@@ -241,14 +241,14 @@ describe('Determines if a iiif-manifest includes non standard items', () => {
   });
 });
 
-describe('isPrimaryContentPDF', () => {
+describe('shouldTreatAsPDFCanvas', () => {
   it('returns false for undefined canvas', () => {
-    expect(isPrimaryContentPDF(undefined)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(undefined)).toBe(false);
   });
 
   it('returns false for canvas with no PDF content', () => {
     const canvas = createMockCanvas();
-    expect(isPrimaryContentPDF(canvas)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(false);
   });
 
   it('returns true for born digital PDF with application/pdf in original', () => {
@@ -262,7 +262,7 @@ describe('isPrimaryContentPDF', () => {
         },
       ],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(true);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(true);
   });
 
   it('returns true for PDF supplement with no paintings', () => {
@@ -276,7 +276,7 @@ describe('isPrimaryContentPDF', () => {
       ],
       painting: [],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(true);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(true);
   });
 
   it('returns false for PDF supplement with paintings (e.g., video with PDF transcript)', () => {
@@ -296,7 +296,7 @@ describe('isPrimaryContentPDF', () => {
         },
       ],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(false);
   });
 
   it('returns true for PDF supplement with ChoiceBody containing PDF', () => {
@@ -315,7 +315,7 @@ describe('isPrimaryContentPDF', () => {
       ],
       painting: [],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(true);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(true);
   });
 
   it('returns false for ChoiceBody with string items', () => {
@@ -328,7 +328,7 @@ describe('isPrimaryContentPDF', () => {
       ],
       painting: [],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(false);
   });
 
   it('returns false for ChoiceBody with non-PDF items', () => {
@@ -347,7 +347,7 @@ describe('isPrimaryContentPDF', () => {
       ],
       painting: [],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(false);
   });
 
   it('returns true for born digital PDF even with paintings', () => {
@@ -368,7 +368,7 @@ describe('isPrimaryContentPDF', () => {
         },
       ],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(true);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(true);
   });
 
   it('returns false for supplement without format property', () => {
@@ -381,7 +381,7 @@ describe('isPrimaryContentPDF', () => {
       ],
       painting: [],
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(false);
   });
 });
 

--- a/content/webapp/utils/iiif/v3/index.test.ts
+++ b/content/webapp/utils/iiif/v3/index.test.ts
@@ -33,7 +33,7 @@ import {
   isChoiceBody,
   isCollection,
   isItemRestricted,
-  isPDFCanvas,
+  isPrimaryContentPDF,
   transformCanvas,
   transformLabel,
 } from '.';
@@ -802,14 +802,14 @@ describe('hasOriginalPdf', () => {
   });
 });
 
-describe('isPDFCanvas', () => {
+describe('isPrimaryContentPDF', () => {
   it('is true for a born-digital PDF (original file)', () => {
     const canvas = createImageCanvas({
       original: [
         { id: 'o', format: 'application/pdf', behavior: 'original' },
       ] as never,
     });
-    expect(isPDFCanvas(canvas)).toBe(true);
+    expect(isPrimaryContentPDF(canvas)).toBe(true);
   });
 
   it('is true for a PDF supplement when there are no paintings', () => {
@@ -819,7 +819,7 @@ describe('isPDFCanvas', () => {
         { id: 's', type: 'Text', format: 'application/pdf' },
       ] as never,
     });
-    expect(isPDFCanvas(canvas)).toBe(true);
+    expect(isPrimaryContentPDF(canvas)).toBe(true);
   });
 
   it('is false for a PDF supplement when paintings are present (e.g. a video)', () => {
@@ -829,11 +829,11 @@ describe('isPDFCanvas', () => {
         { id: 's', type: 'Text', format: 'application/pdf' },
       ] as never,
     });
-    expect(isPDFCanvas(canvas)).toBe(false);
+    expect(isPrimaryContentPDF(canvas)).toBe(false);
   });
 
   it('is false for undefined', () => {
-    expect(isPDFCanvas(undefined)).toBe(false);
+    expect(isPrimaryContentPDF(undefined)).toBe(false);
   });
 });
 
@@ -920,7 +920,7 @@ describe('getFileTypeLabel', () => {
   });
 
   it('labels an empty canvas array as PDF files (vacuous every() quirk)', () => {
-    // With no canvases, `canvases.every(isPDFCanvas)` is vacuously true, so the
+    // With no canvases, `canvases.every(isPrimaryContentPDF)` is vacuously true, so the
     // all-PDFs branch is taken. Documenting current behaviour, not endorsing it.
     expect(getFileTypeLabel(0, 0, false, [])).toBe('0 PDF files');
   });

--- a/content/webapp/utils/iiif/v3/index.test.ts
+++ b/content/webapp/utils/iiif/v3/index.test.ts
@@ -33,7 +33,7 @@ import {
   isChoiceBody,
   isCollection,
   isItemRestricted,
-  isPrimaryContentPDF,
+  shouldTreatAsPDFCanvas,
   transformCanvas,
   transformLabel,
 } from '.';
@@ -802,14 +802,14 @@ describe('hasOriginalPdf', () => {
   });
 });
 
-describe('isPrimaryContentPDF', () => {
+describe('shouldTreatAsPDFCanvas', () => {
   it('is true for a born-digital PDF (original file)', () => {
     const canvas = createImageCanvas({
       original: [
         { id: 'o', format: 'application/pdf', behavior: 'original' },
       ] as never,
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(true);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(true);
   });
 
   it('is true for a PDF supplement when there are no paintings', () => {
@@ -819,7 +819,7 @@ describe('isPrimaryContentPDF', () => {
         { id: 's', type: 'Text', format: 'application/pdf' },
       ] as never,
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(true);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(true);
   });
 
   it('is false for a PDF supplement when paintings are present (e.g. a video)', () => {
@@ -829,11 +829,11 @@ describe('isPrimaryContentPDF', () => {
         { id: 's', type: 'Text', format: 'application/pdf' },
       ] as never,
     });
-    expect(isPrimaryContentPDF(canvas)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(canvas)).toBe(false);
   });
 
   it('is false for undefined', () => {
-    expect(isPrimaryContentPDF(undefined)).toBe(false);
+    expect(shouldTreatAsPDFCanvas(undefined)).toBe(false);
   });
 });
 
@@ -920,7 +920,7 @@ describe('getFileTypeLabel', () => {
   });
 
   it('labels an empty canvas array as PDF files (vacuous every() quirk)', () => {
-    // With no canvases, `canvases.every(isPrimaryContentPDF)` is vacuously true, so the
+    // With no canvases, `canvases.every(shouldTreatAsPDFCanvas)` is vacuously true, so the
     // all-PDFs branch is taken. Documenting current behaviour, not endorsing it.
     expect(getFileTypeLabel(0, 0, false, [])).toBe('0 PDF files');
   });

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -98,7 +98,8 @@ export function getFileTypeLabel(
     return pluralize(collectionManifestsCount, 'volume');
 
   // Check if all items are PDFs
-  const allPdfs = canvases?.every(canvas => isPDFCanvas(canvas)) || false;
+  const allPdfs =
+    canvases?.every(canvas => isPrimaryContentPDF(canvas)) || false;
   if (allPdfs) return pluralize(canvasCount, 'PDF file');
 
   // Non-standard items should be treated as generic files
@@ -108,7 +109,8 @@ export function getFileTypeLabel(
   const hasVideo = hasItemType(canvases, 'Video');
   const hasAudio =
     hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
-  const hasPdfs = canvases?.some(canvas => isPDFCanvas(canvas)) || false;
+  const hasPdfs =
+    canvases?.some(canvas => isPrimaryContentPDF(canvas)) || false;
   const hasImages = hasItemType(canvases, 'Image');
 
   const typeCount = [hasVideo, hasAudio, hasPdfs, hasImages].filter(
@@ -652,7 +654,7 @@ export function hasOriginalPdf(canvases?: TransformedCanvas[]): boolean {
   );
 }
 
-export function isPDFCanvas(canvas?: TransformedCanvas): boolean {
+export function isPrimaryContentPDF(canvas?: TransformedCanvas): boolean {
   if (!canvas) return false;
 
   const hasPDFSupplement = canvas?.supplementing.some(supplement => {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -99,7 +99,7 @@ export function getFileTypeLabel(
 
   // Check if all items are PDFs
   const allPdfs =
-    canvases?.every(canvas => isPrimaryContentPDF(canvas)) || false;
+    canvases?.every(canvas => shouldTreatAsPDFCanvas(canvas)) || false;
   if (allPdfs) return pluralize(canvasCount, 'PDF file');
 
   // Non-standard items should be treated as generic files
@@ -110,7 +110,7 @@ export function getFileTypeLabel(
   const hasAudio =
     hasItemType(canvases, 'Sound') || hasItemType(canvases, 'Audio');
   const hasPdfs =
-    canvases?.some(canvas => isPrimaryContentPDF(canvas)) || false;
+    canvases?.some(canvas => shouldTreatAsPDFCanvas(canvas)) || false;
   const hasImages = hasItemType(canvases, 'Image');
 
   const typeCount = [hasVideo, hasAudio, hasPdfs, hasImages].filter(
@@ -654,7 +654,7 @@ export function hasOriginalPdf(canvases?: TransformedCanvas[]): boolean {
   );
 }
 
-export function isPrimaryContentPDF(canvas?: TransformedCanvas): boolean {
+export function shouldTreatAsPDFCanvas(canvas?: TransformedCanvas): boolean {
   if (!canvas) return false;
 
   const hasPDFSupplement = canvas?.supplementing.some(supplement => {

--- a/content/webapp/utils/iiif/v3/index.ts
+++ b/content/webapp/utils/iiif/v3/index.ts
@@ -654,6 +654,11 @@ export function hasOriginalPdf(canvases?: TransformedCanvas[]): boolean {
   );
 }
 
+/**
+ * Whether a canvas should get PDF treatment in the UI (PDF viewer/download
+ * rather than image/video) - true for a born-digital PDF original (even if
+ * its painting is an Image preview), or a PDF supplement with no paintings.
+ */
 export function shouldTreatAsPDFCanvas(canvas?: TransformedCanvas): boolean {
   if (!canvas) return false;
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
@@ -13,7 +13,7 @@ import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import {
   hasRestrictedItem,
   isChoiceBody,
-  isPDFCanvas,
+  isPrimaryContentPDF,
 } from '@weco/content/utils/iiif/v3';
 
 import IIIFViewerImage from './IIIFViewerImage';
@@ -155,7 +155,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
                             ? audio
                             : itemType === 'Video'
                               ? video
-                              : isPDFCanvas(canvas)
+                              : isPrimaryContentPDF(canvas)
                                 ? pdf
                                 : file
                         }

--- a/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/legacy/IIIFCanvasThumbnail.tsx
@@ -13,7 +13,7 @@ import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import {
   hasRestrictedItem,
   isChoiceBody,
-  isPrimaryContentPDF,
+  shouldTreatAsPDFCanvas,
 } from '@weco/content/utils/iiif/v3';
 
 import IIIFViewerImage from './IIIFViewerImage';
@@ -155,7 +155,7 @@ const IIIFCanvasThumbnail: FunctionComponent<IIIFCanvasThumbnailProps> = ({
                             ? audio
                             : itemType === 'Video'
                               ? video
-                              : isPrimaryContentPDF(canvas)
+                              : shouldTreatAsPDFCanvas(canvas)
                                 ? pdf
                                 : file
                         }

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
@@ -13,7 +13,7 @@ import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import {
   hasRestrictedItem,
   isChoiceBody,
-  isPDFCanvas,
+  isPrimaryContentPDF,
 } from '@weco/content/utils/iiif/v3';
 import { hasRealLabel } from '@weco/content/utils/works';
 
@@ -86,7 +86,7 @@ function getPlaceholderIcon(
 ) {
   if (itemType === 'Sound') return audio;
   if (itemType === 'Video') return video;
-  if (isPDFCanvas(canvas)) return pdf;
+  if (isPrimaryContentPDF(canvas)) return pdf;
   return file;
 }
 

--- a/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
+++ b/content/webapp/views/pages/works/work/IIIFViewer/refactored/IIIFCanvasThumbnail.tsx
@@ -13,7 +13,7 @@ import { IIIFItemProps, TransformedCanvas } from '@weco/content/types/manifest';
 import {
   hasRestrictedItem,
   isChoiceBody,
-  isPrimaryContentPDF,
+  shouldTreatAsPDFCanvas,
 } from '@weco/content/utils/iiif/v3';
 import { hasRealLabel } from '@weco/content/utils/works';
 
@@ -86,7 +86,7 @@ function getPlaceholderIcon(
 ) {
   if (itemType === 'Sound') return audio;
   if (itemType === 'Video') return video;
-  if (isPrimaryContentPDF(canvas)) return pdf;
+  if (shouldTreatAsPDFCanvas(canvas)) return pdf;
   return file;
 }
 

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -24,7 +24,7 @@ import {
   getAuthServices,
   getFileTypeLabel,
   getIframeTokenSrc,
-  isPDFCanvas,
+  isPrimaryContentPDF,
 } from '@weco/content/utils/iiif/v3';
 import { DigitalLocationInfo } from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
@@ -259,7 +259,7 @@ const WorkDetailsAvailableOnline = ({
   const [tabbableId, setTabbableId] = useState<string>();
   const [tree, setTree] = useState<UiTree>([]);
   const allOriginalPdfs =
-    canvases?.every(canvas => isPDFCanvas(canvas)) || false;
+    canvases?.every(canvas => isPrimaryContentPDF(canvas)) || false;
   const clickThroughService = authServices?.active;
 
   // We temporarily want to show the download tree for multiple PDFs

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -24,7 +24,7 @@ import {
   getAuthServices,
   getFileTypeLabel,
   getIframeTokenSrc,
-  isPrimaryContentPDF,
+  shouldTreatAsPDFCanvas,
 } from '@weco/content/utils/iiif/v3';
 import { DigitalLocationInfo } from '@weco/content/utils/works';
 import Download from '@weco/content/views/components/Download';
@@ -259,7 +259,7 @@ const WorkDetailsAvailableOnline = ({
   const [tabbableId, setTabbableId] = useState<string>();
   const [tree, setTree] = useState<UiTree>([]);
   const allOriginalPdfs =
-    canvases?.every(canvas => isPrimaryContentPDF(canvas)) || false;
+    canvases?.every(canvas => shouldTreatAsPDFCanvas(canvas)) || false;
   const clickThroughService = authServices?.active;
 
   // We temporarily want to show the download tree for multiple PDFs

--- a/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
+++ b/content/webapp/views/pages/works/work/WorkDetails/WorkDetails.AvailableOnline.tsx
@@ -258,7 +258,7 @@ const WorkDetailsAvailableOnline = ({
 
   const [tabbableId, setTabbableId] = useState<string>();
   const [tree, setTree] = useState<UiTree>([]);
-  const allOriginalPdfs =
+  const allCanvasesGetPDFTreatment =
     canvases?.every(canvas => shouldTreatAsPDFCanvas(canvas)) || false;
   const clickThroughService = authServices?.active;
 
@@ -266,7 +266,8 @@ const WorkDetailsAvailableOnline = ({
   // See: https://github.com/wellcomecollection/wellcomecollection.org/issues/12089
   const shouldShowDownloadTree =
     hasNonStandardItems &&
-    (!allOriginalPdfs || (allOriginalPdfs && Number(canvases?.length) > 1));
+    (!allCanvasesGetPDFTreatment ||
+      (allCanvasesGetPDFTreatment && Number(canvases?.length) > 1));
 
   useEffect(() => {
     const downloads = createDownloadTree(structures, canvases);
@@ -349,7 +350,7 @@ const WorkDetailsAvailableOnline = ({
           See: https://github.com/wellcomecollection/wellcomecollection.org/issues/12089
         */}
         {(!hasNonStandardItems ||
-          (allOriginalPdfs && canvases?.length === 1)) &&
+          (allCanvasesGetPDFTreatment && canvases?.length === 1)) &&
           shouldShowItemLink && (
             <ItemPageLink
               work={work}


### PR DESCRIPTION
- For #13270

## What does this change?

We'd originally gone for replacing `isPDFCanvas` → `isPrimaryContentPDF` (https://github.com/wellcomecollection/wellcomecollection.org/pull/13249#discussion_r3557815214) as `isPDFCanvas` read as "does this canvas contain a PDF?" but it actually means "should this canvas be treated as a PDF in the UI?". As I went through where it was used and what the function did, though, I went for `shouldTreatAsPDFCanvas`.
It returns `true` in two cases: 
- the canvas's underlying original file is a PDF (true regardless of whether it has paintings - a born-digital PDF's painting is typically an `Image` preview, not a PDF)
- OR is a PDF supplement with no paintings. 

Only the second case actually has PDF as the painted/displayed content, so `isPrimaryContentPDF` overstated what the first branch checks. `shouldTreatAsPDFCanvas` doesn't claim anything about what's actually painted, just that the canvas should be treated as a PDF - accurate for both branches.

- `WorkDetails.AvailableOnline.tsx`'s `allOriginalPdfs` local also claimed "original PDFs" when it's built from the same `shouldTreatAsPDFCanvas` check (true for supplement-only PDFs too) - renamed to `allCanvasesGetPDFTreatment` to match, per review.


Pure rename, no logic change. Touches both `legacy/` and `refactored/` (plus the shared `WorkDetails.AvailableOnline.tsx`) since the function itself is shared, not part of the item-viewer-refactor split.


## How to test

- `yarn tsc` and `yarn eslint` clean on all six changed files.
- `utils/iiif/v3/index.test.ts` and `test/utils/iiif.test.ts` (133 tests between them, both directly exercise this function under its new name) pass unchanged.
- `IIIFCanvasThumbnail.tsx` (legacy + refactored) and `WorkDetails.AvailableOnline.tsx` have no test coverage of their own - their one-line changes (import + call site) are just tsc/eslint-checked.
- Manual: open [jgh7mzns](https://www-dev.wellcomecollection.org/works/jgh7mzns) (a born-digital PDF) and confirm it shows the PDF download/viewer treatment. Couldn't find a live example of the video-with-PDF-supplement negative case (Wellcome's real oral-history-with-transcript works model the PDF as a separate canvas, not a supplement on the video's own canvas) - that branch is covered by the existing unit test instead.


## Have we considered potential risks?

Very low risk - both commits are mechanical renames with no behaviour change, verified by the existing test suite passing unchanged under the new names. No new alarms needed.

_Written by Claude Code._
