### PR TITLE
Archive root page tweaks 3

### DIFF
--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.About.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.About.tsx
@@ -19,11 +19,8 @@ const mainSizeMap: SizeMap = { s: [12], m: [12], l: [8], xl: [8] };
 const sideSizeMap: SizeMap = { s: [12], m: [12], l: [4], xl: [4] };
 
 const SideColumn = styled(GridCell)`
-  order: -1;
-
   ${props =>
     props.theme.media('md')(`
-      order: 0;
       height: calc(100% - ${props.theme.spacingUnits['600']});
       border-left: 1px solid ${props.theme.color('neutral.400')};
       padding-left: ${props.theme.gutter.large};

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Contents.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Contents.tsx
@@ -22,8 +22,8 @@ import NestedList, {
 import ContentsTreeItemRenderer from './ArchiveCollection.ContentsTree.ItemRenderer';
 import {
   ChevronSpacer,
+  ContentsFooterRow,
   ContentsHeaderRow,
-  ContentsRow,
   ContentsRowSummaryCell,
   NameCell,
   ShowMoreButton,
@@ -170,7 +170,7 @@ const ArchiveCollectionContents: FunctionComponent<{
 
         {totalResults !== undefined && (
           <TreeBand>
-            <ContentsRow $indentPx={10}>
+            <ContentsFooterRow>
               <NameCell>
                 <ChevronSpacer />
                 {hasMorePages && (
@@ -190,7 +190,7 @@ const ArchiveCollectionContents: FunctionComponent<{
               <ContentsRowSummaryCell>
                 Showing {works.length} of {totalResults} rows
               </ContentsRowSummaryCell>
-            </ContentsRow>
+            </ContentsFooterRow>
           </TreeBand>
         )}
       </div>

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Contents.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.Contents.tsx
@@ -22,7 +22,9 @@ import NestedList, {
 import ContentsTreeItemRenderer from './ArchiveCollection.ContentsTree.ItemRenderer';
 import {
   ChevronSpacer,
-  ContentsTable,
+  ContentsHeaderRow,
+  ContentsRow,
+  ContentsRowSummaryCell,
   NameCell,
   ShowMoreButton,
   Tree,
@@ -137,15 +139,11 @@ const ArchiveCollectionContents: FunctionComponent<{
     <div style={{ overflowX: 'auto', width: '100%' }}>
       <div style={{ display: 'inline-table', minWidth: '100%' }}>
         <TreeBand aria-hidden="true">
-          <ContentsTable>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Reference</th>
-                <th>Level</th>
-              </tr>
-            </thead>
-          </ContentsTable>
+          <ContentsHeaderRow>
+            <span>Name</span>
+            <span>Reference</span>
+            <span>Level</span>
+          </ContentsHeaderRow>
         </TreeBand>
 
         <Tree $isEnhanced={isEnhanced} $showFirstLevelGuideline $isCompact>
@@ -172,37 +170,27 @@ const ArchiveCollectionContents: FunctionComponent<{
 
         {totalResults !== undefined && (
           <TreeBand>
-            <ContentsTable $indentPx={10}>
-              <tbody>
-                <tr>
-                  <td>
-                    <NameCell>
-                      <ChevronSpacer />
-                      {hasMorePages && (
-                        <ShowMoreButton
-                          onClick={showMore}
-                          disabled={isLoadingMore}
-                        >
-                          <Icon
-                            icon={plus}
-                            matchText
-                            sizeOverride="height: 16px; width: 16px;"
-                          />
-                          {isLoadingMore
-                            ? 'Loading…'
-                            : `Show ${nextBatchSize} more rows`}
-                        </ShowMoreButton>
-                      )}
-                    </NameCell>
-                  </td>
-                  <td colSpan={2}>
-                    <span>
-                      Showing {works.length} of {totalResults} rows
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </ContentsTable>
+            <ContentsRow $indentPx={10}>
+              <NameCell>
+                <ChevronSpacer />
+                {hasMorePages && (
+                  <ShowMoreButton onClick={showMore} disabled={isLoadingMore}>
+                    <Icon
+                      icon={plus}
+                      matchText
+                      sizeOverride="height: 16px; width: 16px;"
+                    />
+                    {isLoadingMore
+                      ? 'Loading…'
+                      : `Show ${nextBatchSize} more rows`}
+                  </ShowMoreButton>
+                )}
+              </NameCell>
+
+              <ContentsRowSummaryCell>
+                Showing {works.length} of {totalResults} rows
+              </ContentsRowSummaryCell>
+            </ContentsRow>
           </TreeBand>
         )}
       </div>

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
@@ -63,12 +63,14 @@ const ContentsTreeItemRenderer: FunctionComponent<
   const indentPx =
     level > 1 ? (level - 1) * compactControlDimensions.controlWidth : 0;
   const rowIndex = rowIndexById?.[data.id];
-  // The collection root (level 1) represents the archive as a whole, so it
-  // gets the archive icon instead of the folder/file icons used for its contents.
+  // The collection root (level 1) represents the archive as a whole,
+  // so it gets the archive icon instead of the folder/file icons
+  // Below that, the icon is driven by data.type
+  // Section/Series/Collection nodes use folder icons, Work nodes use the file icon.
   const typeIcon =
     level === 1
       ? archive
-      : hasControl
+      : data.type !== 'Work'
         ? item.openStatus
           ? openFolder
           : closedFolder

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
@@ -25,7 +25,7 @@ import {
 import {
   ChevronSpacer,
   compactControlDimensions,
-  ContentsTable,
+  ContentsRow,
   LevelCell,
   NameCell,
 } from './ArchiveCollection.ContentsTree.styles';
@@ -75,70 +75,63 @@ const ContentsTreeItemRenderer: FunctionComponent<
         : file;
 
   return (
-    <ContentsTable
+    <ContentsRow
       $isEvenRow={rowIndex !== undefined && rowIndex % 2 === 0}
       $indentPx={indentPx}
       $hasControl={hasControl}
     >
-      <tbody>
-        <tr>
-          <td>
-            <NameCell>
-              {isEnhanced && hasControl ? (
-                <TreeControl
-                  $highlightCondition={highlightCondition}
-                  $isDarkMode={isDarkMode}
-                  $isCompact
-                >
-                  <Icon
-                    rotate={item.openStatus ? undefined : 270}
-                    icon={chevron}
-                    sizeOverride={`height: ${compactControlDimensions.iconSize}px; width: ${compactControlDimensions.iconSize}px;`}
-                  />
-                </TreeControl>
-              ) : (
-                <ChevronSpacer />
-              )}
+      <NameCell>
+        {isEnhanced && hasControl ? (
+          <TreeControl
+            $highlightCondition={highlightCondition}
+            $isDarkMode={isDarkMode}
+            $isCompact
+          >
+            <Icon
+              rotate={item.openStatus ? undefined : 270}
+              icon={chevron}
+              sizeOverride={`height: ${compactControlDimensions.iconSize}px; width: ${compactControlDimensions.iconSize}px;`}
+            />
+          </TreeControl>
+        ) : (
+          <ChevronSpacer />
+        )}
 
-              <Icon
-                icon={typeIcon}
-                iconColor="neutral.600"
-                matchText
-                sizeOverride="height: 16px; width: 16px;"
-              />
+        <Icon
+          icon={typeIcon}
+          iconColor="neutral.600"
+          matchText
+          sizeOverride="height: 16px; width: 16px;"
+        />
 
-              <NextLink
-                {...toWorkLink({ id: data.id, scroll: false })}
-                onClick={event => {
-                  // Don't toggle the branch when the link itself is activated
-                  event.stopPropagation();
-                }}
-                tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
-                {...dataGtmPropsToAttributes({
-                  trigger: 'contents_tree_link',
-                  label: `${data.title}${data.referenceNumber ? ` (${data.referenceNumber})` : ''}`,
-                })}
-              >
-                <WorkTitle title={data.title} />
-              </NextLink>
-            </NameCell>
-          </td>
+        <NextLink
+          {...toWorkLink({ id: data.id, scroll: false })}
+          onClick={event => {
+            // Don't toggle the branch when the link itself is activated
+            event.stopPropagation();
+          }}
+          tabIndex={isEnhanced ? (isSelected ? 0 : -1) : 0}
+          {...dataGtmPropsToAttributes({
+            trigger: 'contents_tree_link',
+            label: `${data.title}${data.referenceNumber ? ` (${data.referenceNumber})` : ''}`,
+          })}
+        >
+          <WorkTitle title={data.title} />
+        </NextLink>
+      </NameCell>
 
-          <td>{data.referenceNumber}</td>
-          <td>
-            <LevelCell>
-              <Icon
-                icon={typeIcon}
-                iconColor="neutral.600"
-                matchText
-                sizeOverride="height: 16px; width: 16px;"
-              />
-              {getWorkLevelLabel(data.type)}
-            </LevelCell>
-          </td>
-        </tr>
-      </tbody>
-    </ContentsTable>
+      <span>{data.referenceNumber}</span>
+
+      <LevelCell>
+        <Icon
+          icon={typeIcon}
+          iconColor="neutral.600"
+          matchText
+          sizeOverride="height: 16px; width: 16px;"
+        />
+        {getWorkLevelLabel(data.type)}
+      </LevelCell>
+    </ContentsRow>
   );
 };
 

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.ItemRenderer.tsx
@@ -67,11 +67,15 @@ const ContentsTreeItemRenderer: FunctionComponent<
   // so it gets the archive icon instead of the folder/file icons
   // Below that, the icon is driven by data.type
   // Section/Series/Collection nodes use folder icons, Work nodes use the file icon.
+  // show the openFolder icon only when children are actually being shown
+  // (matching ListItem's own `item.children && item.openStatus` check
+  // This prevents showing an open folder on the last row before "Show more"), before its expanded to show children.
+  const isVisiblyExpanded = Boolean(item.children && item.openStatus);
   const typeIcon =
     level === 1
       ? archive
       : data.type !== 'Work'
-        ? item.openStatus
+        ? isVisiblyExpanded
           ? openFolder
           : closedFolder
         : file;

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
@@ -16,10 +16,9 @@ export { compactControlDimensions } from '@weco/content/views/pages/works/work/w
 const nameCellTextIndent = (spacingUnit: number) =>
   compactControlDimensions.controlWidth + spacingUnit;
 
-// Visual 3-column (Name/Reference/Level) layout on desktop, but stacks into a single column on mobile. The
-// Below `sm` there's no room for 3 columns, so rows stack into a vertical
-// flex column instead (order below controls the stack order) - the
-// column-grid only applies from `sm` up.
+// Visual 3-column (Name/Reference/Level) layout on desktop, but stacks into a single column on mobile.
+// Below `sm` there's no room for 3 columns, so rows stack into a vertical flex column instead (order below controls the stack order).
+// The column grid only applies from `sm` up.
 const contentsGridColumns = '1fr 160px 110px';
 
 export const ContentsRow = styled.div.attrs({

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
@@ -152,12 +152,78 @@ export const ContentsHeaderRow = styled.div.attrs({
     `)}
 `;
 
-// Merges the "Showing X of Y rows" cell across the Reference/Level
-// columns (the old colSpan={2}) - a no-op below `sm`, where ContentsRow
-// isn't a grid yet and this is just the next stacked block.
-export const ContentsRowSummaryCell = styled.span`
+// The "Show N more rows" control + results summary below the tree. Always
+// 2 cells (unlike ContentsRow's 3 Name/Reference/Level), so it's its own
+// component rather than reusing ContentsRow's nth-child-based rules -
+// those assume a 3-column Name/Reference/Level shape that doesn't apply
+// here. $indentPx is always 10 for this row (matching the other rows'
+// compact tree indentation), so it's hardcoded rather than a prop.
+export const ContentsFooterRow = styled.div.attrs({
+  className: typography('body', 'sm', 'regular'),
+})`
+  display: flex;
+  flex-direction: column-reverse;
+  ${props => props.theme.makeSpacePropertyValues('xs', ['row-gap'])}
+
+  margin-left: -10px;
+  width: calc(100% + 10px);
+
+  > * {
+    padding: 0 10px;
+  }
+
+  /* column-reverse flips what's on screen but not which DOM child
+     :first-/:last-child match, so the visually-first cell (the summary
+     text, last in the DOM) gets the top padding and vice versa - together
+     they read as one padded block rather than adding space between the two. */
+  > *:last-child {
+    ${props => props.theme.makeSpacePropertyValues('sm', ['padding-top'])}
+  }
+
+  > *:first-child {
+    ${props => props.theme.makeSpacePropertyValues('xs', ['padding-bottom'])}
+  }
+
   ${props =>
     props.theme.media('sm')(`
+      display: grid;
+      grid-template-columns: ${contentsGridColumns};
+      column-gap: 10px;
+
+      > * {
+        padding: 0;
+        ${props.theme.makeSpacePropertyValues('xs', [
+          'padding-top',
+          'padding-bottom',
+        ])}
+      }
+
+      > *:first-child {
+        padding-left: 10px;
+      }
+    `)}
+`;
+
+// Merges the "Showing X of Y rows" cell across the Reference/Level
+// columns (the old colSpan={2}) - a no-op below `sm`, where
+// ContentsFooterRow isn't a grid yet and this is just the next stacked
+// block (first in the DOM, but shown above the Show more button via
+// column-reverse). Grey on mobile (secondary info, vs. the actionable
+// Show more button) but dark on desktop, matching how it's inline with
+// the tree rows there rather than sitting below its own button. Padding
+// on mobile lines its text up with the button's, past ChevronSpacer's
+// width - the same offset ContentsRow uses to line Reference/Level up
+// under the title. The right padding at `sm` mirrors ChevronSpacer's
+// width instead, so the gap matches the space to its left on that side.
+export const ContentsRowSummaryCell = styled.span`
+  display: block;
+  color: ${props => props.theme.color('neutral.600')};
+  padding-left: ${props => 10 + nameCellTextIndent(props.theme.spacingUnit)}px;
+
+  ${props =>
+    props.theme.media('sm')(`
+      color: inherit;
+      padding-left: 0;
       grid-column: 2 / span 2;
       display: flex;
       align-items: center;
@@ -237,13 +303,13 @@ export const ShowMoreButton = styled.button.attrs({
 })`
   display: inline-flex;
   align-items: center;
-  color: ${props => props.theme.color('neutral.600')};
+  color: inherit;
   gap: ${props => props.theme.spacingUnit}px;
 
-  ${props =>
-    props.theme.media('sm')(`
-      color: inherit;
-    `)}
+  /* Removes the browser's default button padding, so the icon's left
+     edge lands exactly where ContentsRowSummaryCell's padding-left
+     expects it (nameCellTextIndent, past ChevronSpacer's width). */
+  padding: 0;
 
   &:focus,
   &:hover {

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
@@ -16,23 +16,26 @@ export { compactControlDimensions } from '@weco/content/views/pages/works/work/w
 const nameCellTextIndent = (spacingUnit: number) =>
   compactControlDimensions.controlWidth + spacingUnit;
 
-// Each row's its own <table> (real tables can't nest recursively), so
-// nth-child can't stripe them - $isEvenRow does that instead, from
-// visible-row position (see `rowIndexById`). $indentPx cancels out the
-// ancestor <ul> indentation so the stripe spans full width at any depth,
-// then reapplies it as padding so content doesn't shift.
+// Visual 3-column (Name/Reference/Level) layout only - this isn't real
+// tabular data, so it's plain divs on a grid rather than a <table>. The
+// tree's actual structure/semantics (hierarchy, level, position, name)
+// live on the ARIA tree in NestedList (role="tree"/"treeitem"/"group",
+// aria-level/-posinset/-setsize, aria-label via getAriaLabel) - a <table>
+// nested inside a role="treeitem" isn't a recognised ARIA pattern, and
+// previously each row rendered its own disconnected single-row <table>
+// with no <th> to associate back to the (separate) header table anyway.
 //
-// Below `sm` cells stack into a vertical block instead of 3 columns (no
-// room for those on mobile) - header's hidden too since it stops making
-// sense once things are stacked. `sm` and up restores the normal table.
-export const ContentsTable = styled.table.attrs({
+// Below `sm` there's no room for 3 columns, so rows stack into a vertical
+// flex column instead (order below controls the stack order) - the
+// column-grid only applies from `sm` up.
+const contentsGridColumns = '1fr 160px 110px';
+
+export const ContentsRow = styled.div.attrs({
   className: typography('body', 'sm', 'regular'),
 })<{ $isEvenRow?: boolean; $indentPx?: number; $hasControl?: boolean }>`
-  border-collapse: collapse;
+  display: flex;
+  flex-direction: column;
 
-  /* Needed at every width, not just desktop - with 'auto' layout a long
-     nowrap title just pushes the table wider instead of truncating. */
-  table-layout: fixed;
   margin-left: -${props => props.$indentPx ?? 0}px;
   width: calc(100% + ${props => props.$indentPx ?? 0}px);
 
@@ -46,113 +49,121 @@ export const ContentsTable = styled.table.attrs({
      clickable either. */
   ${props => props.$hasControl && `cursor: pointer;`}
 
-  th,
-  td {
+  > * {
     text-align: left;
-  }
 
-  thead {
-    display: none;
-  }
-
-  tbody tr {
-    display: flex;
-    flex-direction: column;
-  }
-
-  td {
-    display: block;
-
-    /* All cells need this, not just the first - the table's shifted
+    /* All cells need this, not just the first - the row's shifted
        left by $indentPx (see margin-left above), so without it a cell
        would render flush against the page edge. */
     padding: 0 10px 0 ${props => props.$indentPx ?? 0}px;
   }
 
-  td:not(:first-child) {
+  > *:not(:first-child) {
     color: ${props => props.theme.color('neutral.600')};
     padding-left: ${props =>
       (props.$indentPx ?? 0) + nameCellTextIndent(props.theme.spacingUnit)}px;
   }
 
-  ${TreeBand} & td:not(:first-child) {
+  ${TreeBand} & > *:not(:first-child) {
     color: inherit;
   }
 
   /* Vertical padding only goes on the visually first/last cells (Name,
      Reference), so the stack reads as one padded row rather than adding
-     space between every line. Can't put it on ContentsTable/tr instead -
-     browsers ignore padding on table/table-row once border-collapse:
-     collapse is set, and tr's a real table-row again at 'sm' anyway. */
-  td:nth-child(1) {
+     space between every line. */
+  > *:nth-child(1) {
     ${props => props.theme.makeSpacePropertyValues('xs', ['padding-top'])}
   }
 
   /* Mobile order is Name, Level, Reference (matching the design) - 'order'
-     only affects flex items, so it's a no-op once 'sm' switches back to
-     table-cell below and the desktop columns stay Name/Reference/Level. */
-  td:nth-child(2) {
+     only affects flex items, so it's a no-op once 'sm' switches to grid
+     below and the desktop columns stay Name/Reference/Level. */
+  > *:nth-child(2) {
     order: 2;
     ${props => props.theme.makeSpacePropertyValues('xs', ['padding-bottom'])}
   }
 
-  td:nth-child(3) {
+  > *:nth-child(3) {
     order: 1;
   }
 
   ${props =>
     props.theme.media('sm')(`
-      thead {
-        display: table-header-group;
-      }
+      display: grid;
+      grid-template-columns: ${contentsGridColumns};
+      column-gap: 10px;
 
-      tbody tr {
-        display: table-row;
-      }
-
-      td {
-        display: table-cell;
-        padding-right: 10px;
-        padding-left: 0;
+      > * {
+        padding: 0;
         ${props.theme.makeSpacePropertyValues('xs', [
           'padding-top',
           'padding-bottom',
         ])}
       }
 
+      /* Resets the mobile-only reordering above - needs the same
+         nth-child specificity as those rules, a bare '> *' loses to them. */
+      > *:nth-child(2),
+      > *:nth-child(3) {
+        order: initial;
+      }
+
       /* Only the first column needs the tree's indentation here - the
          rest are separate columns starting fresh after it. */
-      td:first-child {
+      > *:first-child {
         padding-left: ${props.$indentPx ?? 0}px;
       }
 
-      /* Undoes the base td:not(:first-child) rule's left padding, which
-         is only for lining cells up under the title on mobile. */
-      td:not(:first-child) {
+      /* Undoes the base rule's left padding above, which is only for
+         lining cells up under the title on mobile. */
+      > *:not(:first-child) {
         color: inherit;
         padding-left: 0;
       }
+    `)}
+`;
 
-      th {
-        padding: 12px 10px 12px 0;
+// The column headings shown above the tree. Purely decorative (the
+// TreeBand wrapping it is aria-hidden) - real column labels are already
+// part of each row's aria-label - so hidden below `sm` entirely rather
+// than stacking, same as the data it's labelling.
+export const ContentsHeaderRow = styled.div.attrs({
+  className: typography('body', 'sm', 'regular'),
+})`
+  display: none;
+
+  ${props =>
+    props.theme.media('sm')(`
+      display: grid;
+      grid-template-columns: ${contentsGridColumns};
+      column-gap: 10px;
+
+      > * {
+        padding: 12px 0;
         font-weight: bold;
+        text-align: left;
       }
 
       /* No ancestor <ul> to line up with here (it's a plain header, not
          part of the tree), so a fixed padding instead of $indentPx. */
-      th:first-child {
+      > *:first-child {
         padding-left: 10px;
       }
+    `)}
+`;
 
-      th:nth-child(2),
-      td:nth-child(2) {
-        width: 160px;
-      }
-
-      th:nth-child(3),
-      td:nth-child(3) {
-        width: 110px;
-      }
+// Merges the "Showing X of Y rows" cell across the Reference/Level
+// columns (the old colSpan={2}) - a no-op below `sm`, where ContentsRow
+// isn't a grid yet and this is just the next stacked block.
+export const ContentsRowSummaryCell = styled.span`
+  ${props =>
+    props.theme.media('sm')(`
+      grid-column: 2 / span 2;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      text-align: right;
+      padding-right: ${compactControlDimensions.controlWidth}px;
     `)}
 `;
 

--- a/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
+++ b/content/webapp/views/pages/works/work/ArchiveCollection/ArchiveCollection.ContentsTree.styles.tsx
@@ -16,15 +16,7 @@ export { compactControlDimensions } from '@weco/content/views/pages/works/work/w
 const nameCellTextIndent = (spacingUnit: number) =>
   compactControlDimensions.controlWidth + spacingUnit;
 
-// Visual 3-column (Name/Reference/Level) layout only - this isn't real
-// tabular data, so it's plain divs on a grid rather than a <table>. The
-// tree's actual structure/semantics (hierarchy, level, position, name)
-// live on the ARIA tree in NestedList (role="tree"/"treeitem"/"group",
-// aria-level/-posinset/-setsize, aria-label via getAriaLabel) - a <table>
-// nested inside a role="treeitem" isn't a recognised ARIA pattern, and
-// previously each row rendered its own disconnected single-row <table>
-// with no <th> to associate back to the (separate) header table anyway.
-//
+// Visual 3-column (Name/Reference/Level) layout on desktop, but stacks into a single column on mobile. The
 // Below `sm` there's no room for 3 columns, so rows stack into a vertical
 // flex column instead (order below controls the stack order) - the
 // column-grid only applies from `sm` up.
@@ -154,10 +146,7 @@ export const ContentsHeaderRow = styled.div.attrs({
 
 // The "Show N more rows" control + results summary below the tree. Always
 // 2 cells (unlike ContentsRow's 3 Name/Reference/Level), so it's its own
-// component rather than reusing ContentsRow's nth-child-based rules -
-// those assume a 3-column Name/Reference/Level shape that doesn't apply
-// here. $indentPx is always 10 for this row (matching the other rows'
-// compact tree indentation), so it's hardcoded rather than a prop.
+// component rather than reusing ContentsRow's nth-child-based rules
 export const ContentsFooterRow = styled.div.attrs({
   className: typography('body', 'sm', 'regular'),
 })`
@@ -204,17 +193,6 @@ export const ContentsFooterRow = styled.div.attrs({
     `)}
 `;
 
-// Merges the "Showing X of Y rows" cell across the Reference/Level
-// columns (the old colSpan={2}) - a no-op below `sm`, where
-// ContentsFooterRow isn't a grid yet and this is just the next stacked
-// block (first in the DOM, but shown above the Show more button via
-// column-reverse). Grey on mobile (secondary info, vs. the actionable
-// Show more button) but dark on desktop, matching how it's inline with
-// the tree rows there rather than sitting below its own button. Padding
-// on mobile lines its text up with the button's, past ChevronSpacer's
-// width - the same offset ContentsRow uses to line Reference/Level up
-// under the title. The right padding at `sm` mirrors ChevronSpacer's
-// width instead, so the gap matches the space to its left on that side.
 export const ContentsRowSummaryCell = styled.span`
   display: block;
   color: ${props => props.theme.color('neutral.600')};


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13321

## What does this change?

Addresses , the following point from QA:

- On mobile "As flagged, the 'Show 50 more rows' and Showing..... copy should be flipped in order and colour so that the interactive element is more prominent [on mobile]"
- On mobile "H2 About this work should be above the Physical description, at the moment its appearing beneath some of the details task options"
- It looks like if a section is the last row to display before the 'Show 50 more rows' CTA, it is displayed the item icon until the next rows are revealed task options
- Also, uses CSS grid for layout rather than table:

The archive collection "Collection contents" tab rendered its Name/Reference/Level tree rows as a `<table>`, but the markup didn't actually behave like one so have replaced with plain `<div>`s laid out on a CSS grid instead.

Why the table wasn't a good fit here:

- **Each row was its own disconnected `<table>`.** Real `<table>`s can't nest recursively, so every tree row rendered a separate single-row `<table>` (`ContentsTreeItemRenderer`). A screen reader's table navigation mode landing on any row saw "table, 1 row, 3 columns" with no way to know what those columns meant.
- **The column headings lived in a completely different `<table>`.** The `<thead>` with Name/Reference/Level was a separate table sitting above the tree, with no `scope`/`headers` link back to any row's cells, so even if a row's mini-table were readable, there was nothing to associate it with.
- **The tree's real structure was already expressed elsewhere.** The actual hierarchy/interaction model is the ARIA tree pattern already on the `<ul>`/`<li>` elements in `NestedList` (`role="tree"/"treeitem"/"group"`, `aria-level`, `aria-posinset`, `aria-setsize`, and a full `aria-label` per row via `getAriaLabel`).
- **It gave up on being a table below `sm` anyway.** `thead{display:none}` and `tbody tr{display:flex; flex-direction:column}` on mobile.
- **It was redundant regardless.** `getAriaLabel` already builds `"{title}, reference number X, {level}"` as the treeitem's accessible name, so all three "columns'" worth of information was already exposed accessibly without the table.

No change to the actual accessible structure. The ARIA tree in `NestedList`/`NestedList.ListItem.tsx` is untouched; this only removes the non-functional table semantics layered on top of it.

## How to test
- visit an [archive collection](https://www-dev.wellcomecollection.org/works/gttrgcys#contents) and go to the "Collection contents" tab.
- Note the Name/Reference/Level column layout on desktop, and how rows stack on mobile.
- Desktop layout should be visually identical to prod (same columns, same widths, same striping)
- Mobile should still stack Name > Level > Reference per row; "Show more"/"Showing X of Y rows" footer should now show "Showing X of Y" above "Show more" ; "Show more" text as the dark/primary one.
- use screen reader and arrow through the tree. It should read as a tree (name, reference, level per item)
- visit [work with section as the last item before show more link](https://www-dev.wellcomecollection.org/works/aegabdcp#contents), icon should be a closed folder
- shrink to mobile screen, everything in about us section should appear below the "About this work" heading

## Have we considered potential risks?

Low risk — this is a markup/CSS-only change scoped to the archive collection contents tree, with no changes to the tree's data, state, or ARIA semantics. The main risk is a subtle visual regression at specific viewport widths