### PR TITLE
Fix browser back button ignoring tab-switch history entries

### DIFF
--- a/content/webapp/views/components/Tabs/Tabs.Switch.test.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.Switch.test.tsx
@@ -11,6 +11,17 @@ import theme from '@weco/common/views/themes/default';
 
 import TabsSwitch from './Tabs.Switch';
 
+// TabsSwitch drives its anchor changes through the router (shallow), rather
+// than a raw history.pushState/replaceState - see Tabs.Switch.tsx for why.
+// This stand-in performs the same real history update the component relies
+// on for its own hashchange listener, without needing a full Next.js router.
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: (url: string) => globalThis.history.pushState({}, '', url),
+    replace: (url: string) => globalThis.history.replaceState({}, '', url),
+  }),
+}));
+
 window.HTMLElement.prototype.scrollIntoView = jest.fn(); // scrollIntoView is not in JSDOM: https://stackoverflow.com/a/60225417
 
 const items = [

--- a/content/webapp/views/components/Tabs/Tabs.Switch.tsx
+++ b/content/webapp/views/components/Tabs/Tabs.Switch.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import {
   Dispatch,
   FunctionComponent,
@@ -70,6 +71,7 @@ const TabsSwitch: FunctionComponent<Props> = ({
   isWhite,
 }: Props) => {
   const { isEnhanced } = useAppContext();
+  const router = useRouter();
   const tabListRef = useRef<HTMLDivElement>(null);
   const hasSyncedFromUrlRef = useRef(false);
 
@@ -111,7 +113,11 @@ const TabsSwitch: FunctionComponent<Props> = ({
       hash === getNoJsAnchorId(selectedItem) &&
       hash !== getJsAnchorId(selectedItem)
     ) {
-      window.history.replaceState(null, '', `#${getJsAnchorId(selectedItem)}`);
+      router.replace(
+        `${window.location.pathname}${window.location.search}#${getJsAnchorId(selectedItem)}`,
+        undefined,
+        { shallow: true, scroll: false }
+      );
     }
     // items is only read above on the initial mount pass (it's static per
     // page load); re-running this for every parent re-render isn't needed.
@@ -138,10 +144,18 @@ const TabsSwitch: FunctionComponent<Props> = ({
 
   // Pushes a new history entry for a user-driven tab switch (click or
   // keyboard), so back/forward can step through previously selected tabs.
+  // Goes through Next's router (shallow, so it doesn't re-run data fetching)
+  // rather than a raw history.pushState - a raw call leaves the entry with
+  // state: null, which Next's own popstate handler doesn't recognise, so it
+  // silently ignores back/forward through it instead of navigating.
   function pushAnchor(item: SwitchSelectableTextLink): void {
     const anchor = `#${getJsAnchorId(item)}`;
     if (window.location.hash !== anchor) {
-      window.history.pushState(null, '', anchor);
+      router.push(
+        `${window.location.pathname}${window.location.search}${anchor}`,
+        undefined,
+        { shallow: true, scroll: false }
+      );
     }
   }
 


### PR DESCRIPTION
- For https://github.com/wellcomecollection/wellcomecollection.org/issues/13321

## What does this change?

Fixes the last QA bug on the above issue:

"If a I click into a work from an item in the tree, then click back in the browser to return, I see the url change but the page content doesn't change. I have to click back multiple times and then eventually get taken to the default collection level page with the 'About this archive...' tab open"

**Repro**: switch tabs on one of these pages (e.g. "Collection contents" on an archive work), click through to another page, then hit Back. The URL in the address bar changes, but the page content doesn't update. Pressing Back repeatedly eventually lands on an unrelated earlier page/state instead of the one you just left.

**Root cause**: `TabsSwitch`'s `pushAnchor` (and a related `replaceState` call) updated the URL anchor via a raw `window.history.pushState(null, '', anchor)` — bypassing Next.js's router entirely. Next's own router tracks a specific `state` shape on every history entry it creates, and its `popstate` handler explicitly checks for that shape. When the browser fires `popstate` for an entry with `state: null` (one `TabsSwitch` created), Next's handler bails out without performing a route change, it just rewrites that entry to match whatever's already on screen. So:

1. Switching tabs pushes a `null`-state entry.
2. Navigating to another page pushes a real, Next-tracked entry.
3. Pressing Back pops back to the `null`-state tab-switch entry. The URL bar updates (native browser behaviour), but Next does nothing, so the content stays put.
4. Each further Back press goes through another untracked tab-switch entry the same way, until the browser finally reaches an entry Next itself created, at which point a real navigation (and any state resets that come with it) finally happens.

**Fix**: route both calls through Next's router (`router.push`/`router.replace` with `shallow: true, scroll: false`) instead of the raw History API, so the resulting entries carry the state shape Next's `popstate` handler expects. Behaviour (hash reflects the selected tab, Back/Forward step through previously selected tabs, no data refetch on a tab switch) is unchanged.

Also updated `Tabs.Switch.test.tsx` with a `next/router` mock (the component now depends on `useRouter()`, following the same mocking pattern already used in `IIIFViewer.test.tsx`).

## How to test

- go to [an archive collection root work page](https://www-dev.wellcomecollection.org/works/aegabdcp), switch to "Collection contents", click into a work from the tree, then press Back.
- You should immediately return you to the collection root with the "Collection contents" tab still selected, and continuing to press Back should step correctly through further history (previous tab selections, then earlier pages).
- Spot-check the same behaviour on another page using tab-switch (e.g. a [What's On month-tabs page](wellcomecollection.org/whats-on)).

## Have we considered potential risks?

Low-medium — `TabsSwitch` is shared across several pages, so this changes real navigation/history behaviour there, not just the archive collection page it was found on. The change itself is narrowly scoped (two `window.history` calls swapped for their `router` equivalents, same shallow/no-scroll semantics), and existing tests cover click, keyboard, hash-sync-on-load, and back-button scenarios.
